### PR TITLE
docs: fix question ID issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-question-error.yml
+++ b/.github/ISSUE_TEMPLATE/report-question-error.yml
@@ -7,8 +7,8 @@ body:
     id: question_id
     attributes:
       label: Question ID
-      description: The ID shown in the bottom-left of the question card (e.g. CLF-D3-0142). The "Report on GitHub" link from inside the app pre-fills this.
-      placeholder: CLF-D3-0142
+      description: The ID shown in the bottom-left of the question card (e.g. q142 or aif-q457). The "Report on GitHub" link from inside the app pre-fills this.
+      placeholder: q142 or aif-q457
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
﻿## Summary
- Update the Question ID field copy to use real CloudCertPrep question ID formats.
- Replace the stale `CLF-D3-0142` placeholder with `q142 or aif-q457`.

## Verification
- YAML parse check passed.
- `git diff --check`
- `npm run validate`

Closes #26
