### PR TITLE
test(seo): cover canonicalFor and buildGitHubIssueUrl

### DIFF
--- a/src/lib/seo-data.test.ts
+++ b/src/lib/seo-data.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { canonicalFor, SITE_URL } from './seo-data'
+import { buildGitHubIssueUrl, GITHUB_ISSUES_URL } from './constants'
+
+describe('canonicalFor', () => {
+  it('maps the root path to a trailing-slash canonical', () => {
+    expect(canonicalFor('/')).toBe(`${SITE_URL}/`)
+  })
+
+  it('treats the empty string as the root path', () => {
+    expect(canonicalFor('')).toBe(`${SITE_URL}/`)
+  })
+
+  it('appends an absolute path unchanged', () => {
+    expect(canonicalFor('/about')).toBe(`${SITE_URL}/about`)
+  })
+
+  it('normalizes a path missing its leading slash', () => {
+    expect(canonicalFor('about')).toBe(`${SITE_URL}/about`)
+  })
+
+  it('handles nested cert-scoped paths', () => {
+    expect(canonicalFor('/aws/clf-c02/practice-exam')).toBe(
+      `${SITE_URL}/aws/clf-c02/practice-exam`,
+    )
+  })
+})
+
+describe('buildGitHubIssueUrl', () => {
+  it('targets the report-question-error issue form', () => {
+    const url = buildGitHubIssueUrl('clf-q001')
+    expect(url.startsWith(`${GITHUB_ISSUES_URL}/new?`)).toBe(true)
+    expect(new URL(url).searchParams.get('template')).toBe('report-question-error.yml')
+  })
+
+  it('includes the question id in both the id field and the title', () => {
+    const url = buildGitHubIssueUrl('clf-q001')
+    const params = new URL(url).searchParams
+    expect(params.get('question_id')).toBe('clf-q001')
+    expect(params.get('title')).toBe('Question error: clf-q001')
+  })
+
+  it('encodes an id containing a space (no raw space in the query, round-trips on parse)', () => {
+    const url = buildGitHubIssueUrl('clf q001')
+    // URLSearchParams form-encodes spaces as '+', so the raw URL carries no literal space.
+    expect(url).not.toContain(' ')
+    expect(url).toContain('question_id=clf+q001')
+    // Parsing the query back yields the original id, '+' decoded to a space.
+    expect(new URL(url).searchParams.get('question_id')).toBe('clf q001')
+  })
+})


### PR DESCRIPTION
Closes #52

## What

Adds `src/lib/seo-data.test.ts` with pure-function tests for the two untested URL builders flagged in the issue. No production code changes, no new dependencies.

### `canonicalFor` (`src/lib/seo-data.ts`)
- `'/'` and `''` both map to `${SITE_URL}/`
- absolute paths (`/about`) pass through unchanged
- a path missing its leading slash (`about`) is normalized to `${SITE_URL}/about`
- nested cert-scoped paths (`/aws/clf-c02/practice-exam`) are preserved

### `buildGitHubIssueUrl` (`src/lib/constants.ts`)
- targets the `report-question-error.yml` issue form
- the question id appears in both `question_id` and the `title`
- an id containing a space is form-encoded (`+`): the raw URL carries no literal space and the value round-trips back to the original on parse

Assertions read params back via `new URL(url).searchParams` rather than hard-coding the full query string, so they stay robust to param ordering.

## Verification

- `npm run test` -> 196 passed (8 new), `npm run lint` clean.
- ASCII hyphens only, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)