### PR TITLE
test(formatting): add calendar-boundary tests for formatRelativeDate

### DIFF
--- a/src/lib/formatting.test.ts
+++ b/src/lib/formatting.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { formatRelativeDate } from './formatting'
+
+// `formatRelativeDate` hard-codes the 'en-GB' locale and reads `new Date()` for
+// "now", so tests freeze the clock with fake timers (restored after each test)
+// and assert against en-GB wording. System-time strings use local-time ISO
+// (no trailing 'Z') so the local-midnight calendar-day math is independent of
+// the runner's timezone.
+
+const LOCALE = 'en-GB'
+// Built with the same Intl config as the production fallback so the expected
+// absolute string stays correct under any timezone, rather than hard-coded.
+const absoluteFmt = new Intl.DateTimeFormat(LOCALE, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+/** Freeze "now" at nowISO, then format dateISO. */
+function relativeAt(nowISO: string, dateISO: string): string {
+  vi.setSystemTime(new Date(nowISO))
+  return formatRelativeDate(dateISO)
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe('formatRelativeDate', () => {
+  it('returns "Just now" for under a minute', () => {
+    expect(relativeAt('2026-06-16T09:00:00', '2026-06-16T08:59:30')).toBe('Just now')
+  })
+
+  it('reports minutes within the hour', () => {
+    expect(relativeAt('2026-06-16T10:00:00', '2026-06-16T09:30:00')).toBe('30 minutes ago')
+  })
+
+  it('reports hours within the day', () => {
+    expect(relativeAt('2026-06-16T10:00:00', '2026-06-16T07:00:00')).toBe('3 hours ago')
+  })
+
+  // ACTUAL behaviour of the current implementation: the sub-24h `diffHours`
+  // branch is evaluated BEFORE the calendar-day comparison, so a 23:00 -> 09:00
+  // overnight gap (10 elapsed hours) reads "10 hours ago" and never reaches the
+  // calendar-day "yesterday" branch. NOTE: the function's docstring claims this
+  // case returns "yesterday"; this test pins what the code actually does today.
+  it('uses elapsed hours, not calendar day, for a sub-24h overnight gap', () => {
+    expect(relativeAt('2026-06-16T09:00:00', '2026-06-15T23:00:00')).toBe('10 hours ago')
+  })
+
+  // The calendar-day "yesterday" branch is reached only once >= 24h have
+  // elapsed while the date still falls on the previous local calendar day
+  // (~32.5h here: 00:30 the prior day, read at 09:00).
+  it('returns "yesterday" for the previous calendar day past 24h', () => {
+    expect(relativeAt('2026-06-16T09:00:00', '2026-06-15T00:30:00')).toBe('yesterday')
+  })
+
+  it('reports the day bucket for a few days ago', () => {
+    expect(relativeAt('2026-06-16T09:00:00', '2026-06-13T09:00:00')).toBe('3 days ago')
+  })
+
+  it('reports the week bucket for ~2 weeks ago', () => {
+    expect(relativeAt('2026-06-16T09:00:00', '2026-06-02T09:00:00')).toBe('2 weeks ago')
+  })
+
+  it('reports the month bucket for ~2 months ago', () => {
+    expect(relativeAt('2026-06-16T09:00:00', '2026-04-16T09:00:00')).toBe('2 months ago')
+  })
+
+  it('falls back to an absolute date for dates over a year old', () => {
+    const oldDate = '2024-01-01T09:00:00'
+    expect(relativeAt('2026-06-16T09:00:00', oldDate)).toBe(absoluteFmt.format(new Date(oldDate)))
+  })
+})


### PR DESCRIPTION
Closes #18

## What

Adds `src/lib/formatting.test.ts` — Vitest pure-function tests for `formatRelativeDate` with frozen fake timers. No production code changes, no new dependencies.

Covered buckets (en-GB wording):
- under a minute → `Just now`
- minutes within the hour → `30 minutes ago`
- hours within the day → `3 hours ago`
- calendar-day **yesterday** branch (≥24h elapsed, previous local calendar day) → `yesterday`
- day / week / month buckets → `3 days ago` / `2 weeks ago` / `2 months ago`
- over a year old → absolute date, expected string built from the **same** `Intl.DateTimeFormat` config so it holds under any timezone

Each test sets the clock with `vi.setSystemTime` and restores real timers in `afterEach`, so there's no system-clock flakiness. System-time strings use local-time ISO (no trailing `Z`) so the local-midnight calendar math is timezone-independent.

## ⚠️ One finding worth a maintainer decision

The issue (and the function's docstring) state that a **23:00 → 09:00** overnight gap should read **"yesterday"**. The current implementation does **not** do this: the `if (diffHours < 24)` branch is evaluated *before* the calendar-day comparison, so a 10-hour gap returns **"10 hours ago"** and never reaches the calendar-day branch.

Reproduced:

```
now = 2026-06-16T09:00:00, date = 2026-06-15T23:00:00  →  "10 hours ago"   (docstring claims "yesterday")
now = 2026-06-16T09:00:00, date = 2026-06-15T00:30:00  →  "yesterday"      (≥24h, prev calendar day)
```

Since this issue is explicitly **test-only (no production code changes)**, I pinned the *actual* behaviour (`10 hours ago`) with an explanatory comment and covered the genuine calendar-day "yesterday" branch separately. If the docstring's behaviour is the intended one, the fix is to move the calendar-day comparison ahead of the hours branch — happy to open a follow-up PR for that if you'd like.

## Verification

- `npm run test` → 197 passed (9 new)
- `npm run lint` → clean
- ASCII hyphens only, no new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)