### PR TITLE
fix(faq): FAQ answer links no longer break on trailing punctuation

### DIFF
--- a/src/components/Faq.astro
+++ b/src/components/Faq.astro
@@ -18,6 +18,7 @@
  */
 import { FAQ_ENTRIES, FAQ_CATEGORY_LABEL, FAQ_CATEGORY_ORDER } from '../lib/seo-data'
 import { serializeJsonLd } from '../lib/jsonld'
+import { splitLinks } from '../lib/faqLinks'
 
 interface SimpleEntry {
   question: string
@@ -69,14 +70,6 @@ const faqJsonLd = serializeJsonLd({
     acceptedAnswer: { '@type': 'Answer', text: entry.answer },
   })),
 })
-
-// Split bare URLs in an answer into linkable fragments.
-function splitLinks(text: string): Array<{ text: string; isLink: boolean }> {
-  return text.split(/(https?:\/\/[^\s)]+)/g).filter(Boolean).map(part => ({
-    text: part,
-    isLink: part.startsWith('http://') || part.startsWith('https://'),
-  }))
-}
 
 const chevron = '<polyline points="6 9 12 15 18 9"></polyline>'
 ---

--- a/src/data/aif-c01/domain2.json
+++ b/src/data/aif-c01/domain2.json
@@ -1402,6 +1402,10 @@
     "isMultiAnswer": false,
     "taskStatement": "2.3",
     "lastVerified": "2026-06-13",
-    "services": []
+    "services": [
+      "Amazon Bedrock",
+      "Amazon SageMaker JumpStart",
+      "Amazon Q Business"
+    ]
   }
 ]

--- a/src/data/aif-c01/domain4.json
+++ b/src/data/aif-c01/domain4.json
@@ -962,6 +962,11 @@
     "isMultiAnswer": false,
     "taskStatement": "4.1",
     "lastVerified": "2026-06-13",
-    "services": []
+    "services": [
+      "Amazon SageMaker Clarify",
+      "Amazon SageMaker Model Monitor",
+      "Amazon Augmented AI (Amazon A2I)",
+      "Amazon SageMaker Model Cards"
+    ]
   }
 ]

--- a/src/data/aif-c01/domain5.json
+++ b/src/data/aif-c01/domain5.json
@@ -931,6 +931,11 @@
     "isMultiAnswer": false,
     "taskStatement": "5.1",
     "lastVerified": "2026-06-13",
-    "services": []
+    "services": [
+      "AWS IAM",
+      "AWS KMS",
+      "Amazon Macie",
+      "AWS CloudTrail"
+    ]
   }
 ]

--- a/src/lib/faqLinks.test.ts
+++ b/src/lib/faqLinks.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { splitLinks } from './faqLinks'
+
+const joined = (frags: { text: string }[]) => frags.map(f => f.text).join('')
+const linkOf = (frags: { text: string; isLink: boolean }[]) => frags.find(f => f.isLink)?.text
+
+describe('splitLinks', () => {
+  it('returns a single plain fragment when there is no URL', () => {
+    expect(splitLinks('no links here')).toEqual([{ text: 'no links here', isLink: false }])
+  })
+
+  it('links a bare URL surrounded by prose', () => {
+    const frags = splitLinks('see https://example.com/x for more')
+    expect(linkOf(frags)).toBe('https://example.com/x')
+    expect(frags.filter(f => f.isLink)).toHaveLength(1)
+  })
+
+  it('peels a trailing period off the URL (the reported FAQ 404 bug)', () => {
+    const frags = splitLinks('fork it at https://github.com/nastaso/cloudcertprep.')
+    expect(linkOf(frags)).toBe('https://github.com/nastaso/cloudcertprep')
+  })
+
+  it('peels a trailing comma off the URL', () => {
+    const frags = splitLinks('guide at https://docs.aws.amazon.com/x.html, kept updated')
+    expect(linkOf(frags)).toBe('https://docs.aws.amazon.com/x.html')
+  })
+
+  it('keeps internal dots, the path .yml, and query strings inside the URL', () => {
+    expect(linkOf(splitLinks('watch https://www.youtube.com/watch?v=NhDYbskXRgc.')))
+      .toBe('https://www.youtube.com/watch?v=NhDYbskXRgc')
+    expect(linkOf(splitLinks('open https://github.com/x/issues/new?template=report-question-error.yml.')))
+      .toBe('https://github.com/x/issues/new?template=report-question-error.yml')
+  })
+
+  it('does not absorb a closing paren into the URL', () => {
+    expect(linkOf(splitLinks('(see https://example.com/x)'))).toBe('https://example.com/x')
+  })
+
+  it('never drops or adds characters (round-trip)', () => {
+    for (const input of [
+      'no links here',
+      'fork it at https://github.com/nastaso/cloudcertprep. Thanks',
+      'a https://a.com/1, b https://b.com/2.',
+      '(see https://example.com/x) and more',
+    ]) {
+      expect(joined(splitLinks(input))).toBe(input)
+    }
+  })
+})

--- a/src/lib/faqLinks.ts
+++ b/src/lib/faqLinks.ts
@@ -1,0 +1,30 @@
+/**
+ * Split FAQ answer text into linkable fragments for rendering. Bare http(s)
+ * URLs become links; the surrounding prose stays plain text.
+ *
+ * Trailing sentence punctuation (. , ; : ! ?) is peeled off the matched URL
+ * and emitted as text, so a URL that ends a sentence does not link to a 404.
+ * For example "...github.com/nastaso/cloudcertprep." links to
+ * ".../cloudcertprep" with the period rendered after it, not as part of the
+ * href. Used by Faq.astro (registry render mode).
+ */
+export interface LinkFragment {
+  text: string
+  isLink: boolean
+}
+
+export function splitLinks(text: string): LinkFragment[] {
+  return text
+    .split(/(https?:\/\/[^\s)]+)/g)
+    .filter(Boolean)
+    .flatMap(part => {
+      if (!/^https?:\/\//.test(part)) return [{ text: part, isLink: false }]
+      const trailing = part.match(/[.,;:!?]+$/)
+      if (!trailing) return [{ text: part, isLink: true }]
+      const url = part.slice(0, part.length - trailing[0].length)
+      return [
+        { text: url, isLink: true },
+        { text: trailing[0], isLink: false },
+      ]
+    })
+}


### PR DESCRIPTION
## What

Two small, verified changes. **No blog post is published** (the held AIF draft is untouched).

### 1. Fix broken FAQ links (the bug)
Bare URLs that end an FAQ answer were being linked with the trailing `.` or `,` included (e.g. linking to `https://github.com/nastaso/cloudcertprep.`), so the link 404'd. Affected the home page and both cert landing pages.

- Extracted `splitLinks` into `src/lib/faqLinks.ts` and made it peel trailing sentence punctuation (`.,;:!?`) off the matched URL, emitting it as text.
- Added `src/lib/faqLinks.test.ts` (7 tests, incl. the reported 404 case + a round-trip 'no characters lost' check).
- `Faq.astro` now imports the helper. **Rendering-only** - the FAQPage JSON-LD is built from the raw answer text and is byte-identical (verified by `check:person-graph`).

### 2. Tag services on 3 AIF matching questions
`aif-q460` / `q464` / `q466` are match-the-service questions whose options are AWS services; tagged the services they cover to complete the AIF services convention (the only genuine omissions). PartyRock omitted (not in vocab). Metadata only.

## Verification
- `npm run build` green (citation / internal-graph / person-graph guards all pass)
- `npm run validate` clean · 212 unit tests pass · changed source files lint clean