### PR TITLE
a11y(LoadingSpinner): add aria-label for no-text spinner

### DIFF
--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -17,6 +17,7 @@ export function LoadingSpinner({ size = 'md', text, delayed = false }: LoadingSp
       className={`flex flex-col items-center justify-center gap-4 ${delayed ? 'animate-delayed-fade' : 'animate-fade-in'}`}
       role="status"
       aria-live="polite"
+      aria-label={text ?? "Loading"}
     >
       {/* Monochrome ring (track + single rotating head in the primary text
           colour, theme-aware). The brand orange is reserved for CTAs/active


### PR DESCRIPTION
Adds aria-label={text ?? "Loading"} to the role="status" div so the no-text spinner exposes "Loading" as its accessible name. Verified in the browser accessibility tree: the status region now shows "Loading" as its name when no text prop is passed. Closes #59

## What does this PR do?

Adds aria-label={text ?? "Loading"} to the role="status" div so the no-text spinner has an accessible name

## Why?

When no text prop is passed, screen readers announce an empty status region. This gives them "Loading" to announce instead

Closes #59

## How was this tested?

Verified in the browser accessibility tree that the status region shows "Loading" as its name when no text prop is passed.

## Checklist

- [ ] `npm run build` passes locally
- [ ] `npm run lint` passes locally
- [ ] `npm run test` passes locally
- [ ] `npm run validate` passes locally (only if you touched `src/data/**/*.json`)
- [ ] No new third-party dependencies (or justified above)

## Screenshots (UI changes only)

No visual change