### PR TITLE
fix(a11y-alert): Added role for Alert component in reset-password and stats error component

### DIFF
--- a/src/pages/_ResetPassword.tsx
+++ b/src/pages/_ResetPassword.tsx
@@ -146,7 +146,7 @@ export function ResetPassword() {
           )}
 
           {error && (
-            <Alert tone="danger" className="text-danger">
+            <Alert tone="danger" role="alert" className="text-danger">
               {error}
             </Alert>
           )}

--- a/src/pages/_Stats.tsx
+++ b/src/pages/_Stats.tsx
@@ -125,7 +125,7 @@ export function Stats() {
           </header>
 
           {error && (
-            <Alert tone="danger" className="text-danger">
+            <Alert tone="danger" role="alert" className="text-danger">
               <p className="text-danger text-sm">{error}</p>
             </Alert>
           )}


### PR DESCRIPTION
## What does this PR do?

This PR contains changes to pass role in `Alert` component from following components:
* `_ResetPassword`
* `_Stats`

## Why?
This change fixes https://github.com/nastaso/cloudcertprep/issues/53

Closes #
https://github.com/nastaso/cloudcertprep/issues/53

## How was this tested?

This was tested via test cases and also verified from UI that div is getting rendered with role property 

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [ ] `npm run validate` passes locally (only if you touched `src/data/**/*.json`)
- [x] No new third-party dependencies (or justified above)

## Screenshots (UI changes only)
N/A

<!-- Drag and drop before/after if any visible UI changed. -->
