### PR TITLE
fix(saa-c03): split first explanation paragraph

### DIFF
--- a/src/data/saa-c03/domain1.json
+++ b/src/data/saa-c03/domain1.json
@@ -9,7 +9,7 @@
       "D": "Client-side encryption"
     },
     "answer": "A",
-    "explanation": "SSE-S3 uses Amazon S3 managed keys (AES-256) with no customer involvement, no per-key policies, and no KMS audit trail. SSE-KMS uses AWS KMS keys (AWS-managed or customer-managed) and adds KMS access policies and CloudTrail integration, which is more than the requirement asks for. SSE-C requires the customer to provide and manage their own keys on every request. Client-side encryption happens before upload and is fully customer-managed.",
+    "explanation": "SSE-S3 uses Amazon S3 managed keys (AES-256) with no customer involvement, no per-key policies, and no KMS audit trail.\nSSE-KMS uses AWS KMS keys (AWS-managed or customer-managed) and adds KMS access policies and CloudTrail integration, which is more than the requirement asks for. SSE-C requires the customer to provide and manage their own keys on every request. Client-side encryption happens before upload and is fully customer-managed.",
     "isMultiAnswer": false
   },
   {


### PR DESCRIPTION
## What does this PR do?
Splits the `saa-d1-001` explanation into the two-paragraph format expected by the question validator.

## Why?
`npm run validate` reported this as the first SAA-C03 explanation paragraph warning because the explanation did not contain exactly one `\n`.

## How was this tested?
- `npm run validate`
- `npm run lint`
- `npm run test`

`npm run build` was attempted, but it stops on `scripts/generate-og-images.mjs` because `sharp` is imported by the existing script and is not present in the locked dependencies.

## Checklist
- [ ] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [x] `npm run validate` passes locally (only if you touched `src/data/**/*.json`)
- [x] No new third-party dependencies (or justified above)

## Screenshots (UI changes only)
N/A
