### PR TITLE
docs: remove stale roadmap and test count notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ opening PRs, see `CONTRIBUTING.md`; for a project overview, see `README.md`.
 | `npm run build` | Production build. Runs the prebuild + postbuild guard chains below. |
 | `npm run preview` | Serve the built `dist/`. |
 | `npm run lint` | ESLint over the repo. |
-| `npm run test` | Vitest - 188 unit tests. |
+| `npm run test` | Full Vitest unit suite. |
 | `npm run e2e` | Playwright end-to-end tests. |
 | `npm run validate` | Question-bank validator (also runs in prebuild). |
 | `npm run icons` | Regenerate the favicon / app-icon / maskable set from one source. |
@@ -63,7 +63,7 @@ are no migrations in the repo - and **RLS is the security boundary**, not app co
 
 ## Verify your work before calling it done
 
-- Guards + `npm run lint` + `npm run test` (188) + `npm run e2e` all green.
+- Guards + `npm run lint` + the full `npm run test` suite + `npm run e2e` all green.
 - For UI changes, screenshot the change dark and light, across mobile-to-wide widths,
   and both logged-out and logged-in. Use the Playwright harness with
   `reducedMotion: 'reduce'` (otherwise below-fold reveal animations capture as blank).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Current certifications:
 - AWS Solutions Architect Associate (SAA-C03) — question bank in progress, target Q3 2026
 - AWS Developer Associate (DVA-C02) — planned for late 2026
 - AWS SysOps Administrator Associate (SOA-C02) — planned for 2027
-- Per-cert programmatic SEO landing pages (`/aws/clf-c02/security-questions`, etc.)
 - Per-cert OG share images
 - Community-contributed questions via PR review
 


### PR DESCRIPTION
## Summary
- replace the stale AGENTS.md hardcoded unit-test count with count-free wording
- remove the shipped domain landing pages item from the README roadmap
- remove the stale /aws/clf-c02/security-questions example URL

Fixes #78
Fixes #79

## Validation
- rg stale text check returns no matches for the target AGENTS.md and README.md strings
- npm run lint passes
- npm run test passes, 217 tests
- npm run build passes with local placeholder VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY

Note: npm run build without Supabase env reaches Astro prerendering, then fails with the existing missing VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY environment error.
