### PR TITLE
test: extract and unit test spaced repetition selection

### DIFF
--- a/src/hooks/useSpacedRepetition.ts
+++ b/src/hooks/useSpacedRepetition.ts
@@ -2,40 +2,10 @@ import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '../lib/supabase'
 import { logError } from '../lib/logger'
 import type { Question } from '../types'
-import { fisherYatesShuffle } from '../lib/utils'
-
-const UNSEEN_QUOTA = 0.2 // Reserve 20% of each session for unseen questions (if available)
-
-interface MasteryRow {
-  question_id: string
-  correct_streak: number
-  last_was_wrong: boolean
-  last_seen_at: string
-  is_mastered: boolean
-  in_exclusion_window: boolean
-  weight: number | null
-}
-
-function weightedDraw(pool: Array<{ question: Question; weight: number }>, count: number): Question[] {
-  const results: Question[] = []
-  const remaining = [...pool]
-
-  while (results.length < count && remaining.length > 0) {
-    const totalWeight = remaining.reduce((sum, item) => sum + item.weight, 0)
-    let rand = Math.random() * totalWeight
-
-    for (let i = 0; i < remaining.length; i++) {
-      rand -= remaining[i].weight
-      if (rand <= 0) {
-        results.push(remaining[i].question)
-        remaining.splice(i, 1)
-        break
-      }
-    }
-  }
-
-  return results
-}
+import {
+  selectQuestions as selectQuestionsCore,
+  type MasteryRow,
+} from '../lib/spacedRepetition'
 
 export function useSpacedRepetition(
   userId: string | null,
@@ -53,19 +23,25 @@ export function useSpacedRepetition(
     try {
       const { data, error: fetchError } = await supabase
         .from('question_mastery')
-        .select('question_id, correct_streak, last_was_wrong, last_seen_at, is_mastered, in_exclusion_window, weight')
+        .select(
+          'question_id, correct_streak, last_was_wrong, last_seen_at, is_mastered, in_exclusion_window, weight'
+        )
         .eq('user_id', userId)
         .eq('domain_id', domainId)
         .eq('cert_code', certCode)
 
-      if (fetchError) throw fetchError
+      if (fetchError) {
+        throw fetchError
+      }
 
       const map = new Map<string, MasteryRow>()
+
       if (data) {
         for (const row of data as MasteryRow[]) {
           map.set(row.question_id, row)
         }
       }
+
       setMasteryMap(map)
     } catch (err: unknown) {
       logError('useSpacedRepetition.loadMastery', err)
@@ -80,67 +56,19 @@ export function useSpacedRepetition(
     refreshMastery()
   }, [refreshMastery])
 
-  function selectQuestions(allDomainQuestions: Question[], count: number): Question[] {
-    // Guest: random shuffle
-    if (!userId) {
-      return fisherYatesShuffle(allDomainQuestions).slice(0, count)
-    }
-
-    const unseenPool: Question[] = []
-    const activePool: Array<{ question: Question; weight: number }> = []
-    const backfillPool: Array<{ question: Question; lastSeenAt: string }> = []
-
-    for (const question of allDomainQuestions) {
-      const row = masteryMap.get(question.id)
-
-      if (!row) {
-        // Never seen, separate pool for quota guarantee
-        unseenPool.push(question)
-        continue
-      }
-
-      if (row.weight === null) {
-        // Excluded (mastered + in exclusion window), goes to backfill
-        backfillPool.push({ question, lastSeenAt: row.last_seen_at })
-        continue
-      }
-
-      activePool.push({ question, weight: row.weight })
-    }
-
-    // Reserve 20% of session for unseen questions (if available)
-    const unseenQuota = Math.min(
-      Math.ceil(count * UNSEEN_QUOTA),
-      unseenPool.length
+  const selectQuestions = (
+    allDomainQuestions: Question[],
+    count: number,
+  ) =>
+    selectQuestionsCore(
+      allDomainQuestions,
+      count,
+      masteryMap,
+      userId,
     )
-    const guaranteedUnseen = fisherYatesShuffle(unseenPool).slice(0, unseenQuota)
-    const remainingUnseen = unseenPool.filter(q => !guaranteedUnseen.includes(q))
 
-    // Add remaining unseen back to active pool with weight 5
-    for (const question of remainingUnseen) {
-      activePool.push({ question, weight: 5 })
-    }
-
-    // Weighted draw from active pool for remaining slots
-    const remainingSlots = count - guaranteedUnseen.length
-    let selected = weightedDraw(activePool, remainingSlots)
-
-    // Combine guaranteed unseen + weighted draw
-    selected = [...guaranteedUnseen, ...selected]
-
-    // Backfill if not enough
-    if (selected.length < count) {
-      const sortedBackfill = backfillPool.sort(
-        (a, b) => new Date(a.lastSeenAt).getTime() - new Date(b.lastSeenAt).getTime()
-      )
-      const needed = count - selected.length
-      const backfillQuestions = sortedBackfill.slice(0, needed).map(b => b.question)
-      selected = [...selected, ...backfillQuestions]
-    }
-
-    // Final shuffle so unseen/backfill questions aren't always first/last
-    return fisherYatesShuffle(selected)
+  return {
+    selectQuestions,
+    refreshMastery,
   }
-
-  return { selectQuestions, refreshMastery }
 }

--- a/src/lib/spacedRepetition.test.ts
+++ b/src/lib/spacedRepetition.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import {
+  selectQuestions,
+  type MasteryRow,
+} from './spacedRepetition'
+import type { Question } from '../types'
+
+const makeQuestion = (id: string): Question => ({
+  id,
+  domainId: 1,
+  question: `Question ${id}`,
+  options: {
+    A: 'Option A',
+    B: 'Option B',
+    C: 'Option C',
+    D: 'Option D',
+    E: '',
+  },
+  answer: 'A',
+  explanation: '',
+  isMultiAnswer: false,
+})
+
+const makeMasteryRow = (
+  questionId: string,
+  weight: number | null,
+  lastSeenAt = '2026-01-01T00:00:00Z',
+): MasteryRow => ({
+  question_id: questionId,
+  correct_streak: 0,
+  last_was_wrong: false,
+  last_seen_at: lastSeenAt,
+  is_mastered: false,
+  in_exclusion_window: false,
+  weight,
+})
+
+describe('selectQuestions', () => {
+  it('returns a subset of the input for guest users', () => {
+    const questions = [
+      makeQuestion('q1'),
+      makeQuestion('q2'),
+      makeQuestion('q3'),
+      makeQuestion('q4'),
+    ]
+
+    const result = selectQuestions(
+      questions,
+      2,
+      new Map(),
+      null,
+    )
+
+    expect(result).toHaveLength(2)
+
+    for (const question of result) {
+      expect(
+        questions.some(q => q.id === question.id),
+      ).toBe(true)
+    }
+  })
+
+  it('reserves unseen questions when available', () => {
+    const questions = [
+      makeQuestion('q1'),
+      makeQuestion('q2'),
+      makeQuestion('q3'),
+      makeQuestion('q4'),
+      makeQuestion('q5'),
+    ]
+
+    const masteryMap = new Map<string, MasteryRow>([
+      ['q1', makeMasteryRow('q1', 1)],
+      ['q2', makeMasteryRow('q2', 1)],
+      ['q3', makeMasteryRow('q3', 1)],
+    ])
+
+    const result = selectQuestions(
+      questions,
+      5,
+      masteryMap,
+      'user-1',
+    )
+
+    const unseenCount = result.filter(
+      question => !masteryMap.has(question.id),
+    ).length
+
+    // ceil(5 * 0.2) = 1
+    expect(unseenCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('uses excluded questions as backfill when active questions are insufficient', () => {
+    const questions = [
+      makeQuestion('q1'),
+      makeQuestion('q2'),
+      makeQuestion('q3'),
+      makeQuestion('q4'),
+    ]
+
+    const masteryMap = new Map<string, MasteryRow>([
+      ['q1', makeMasteryRow('q1', 1)],
+      ['q2', makeMasteryRow('q2', 1)],
+      ['q3', makeMasteryRow('q3', null, '2025-01-01T00:00:00Z')],
+      ['q4', makeMasteryRow('q4', null, '2025-01-02T00:00:00Z')],
+    ])
+
+    const result = selectQuestions(
+      questions,
+      4,
+      masteryMap,
+      'user-1',
+    )
+
+    const ids = result.map(question => question.id)
+
+    expect(ids).toContain('q3')
+    expect(ids).toContain('q4')
+    expect(result).toHaveLength(4)
+  })
+
+  it('never returns duplicate questions', () => {
+    const questions = [
+      makeQuestion('q1'),
+      makeQuestion('q2'),
+      makeQuestion('q3'),
+      makeQuestion('q4'),
+      makeQuestion('q5'),
+    ]
+
+    const masteryMap = new Map<string, MasteryRow>([
+      ['q1', makeMasteryRow('q1', 1)],
+      ['q2', makeMasteryRow('q2', 2)],
+      ['q3', makeMasteryRow('q3', 3)],
+    ])
+
+    const result = selectQuestions(
+      questions,
+      5,
+      masteryMap,
+      'user-1',
+    )
+
+    const ids = result.map(question => question.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/src/lib/spacedRepetition.ts
+++ b/src/lib/spacedRepetition.ts
@@ -1,0 +1,137 @@
+import type { Question } from '../types'
+import { fisherYatesShuffle } from './utils'
+
+export const UNSEEN_QUOTA = 0.2
+
+export interface MasteryRow {
+  question_id: string
+  correct_streak: number
+  last_was_wrong: boolean
+  last_seen_at: string
+  is_mastered: boolean
+  in_exclusion_window: boolean
+  weight: number | null
+}
+
+function weightedDraw(
+  pool: Array<{ question: Question; weight: number }>,
+  count: number
+): Question[] {
+  const results: Question[] = []
+  const remaining = [...pool]
+
+  while (results.length < count && remaining.length > 0) {
+    const totalWeight = remaining.reduce(
+      (sum, item) => sum + item.weight,
+      0
+    )
+
+    let rand = Math.random() * totalWeight
+
+    for (let i = 0; i < remaining.length; i++) {
+      rand -= remaining[i].weight
+
+      if (rand <= 0) {
+        results.push(remaining[i].question)
+        remaining.splice(i, 1)
+        break
+      }
+    }
+  }
+
+  return results
+}
+
+export function selectQuestions(
+  allDomainQuestions: Question[],
+  count: number,
+  masteryMap: Map<string, MasteryRow>,
+  userId: string | null
+): Question[] {
+  if (!userId) {
+    return fisherYatesShuffle(allDomainQuestions).slice(0, count)
+  }
+
+  const unseenPool: Question[] = []
+  const activePool: Array<{ question: Question; weight: number }> = []
+  const backfillPool: Array<{ question: Question; lastSeenAt: string }> = []
+
+  for (const question of allDomainQuestions) {
+    const row = masteryMap.get(question.id)
+
+    if (!row) {
+      unseenPool.push(question)
+      continue
+    }
+
+    if (row.weight === null) {
+      backfillPool.push({
+        question,
+        lastSeenAt: row.last_seen_at,
+      })
+      continue
+    }
+
+    activePool.push({
+      question,
+      weight: row.weight,
+    })
+  }
+
+  const unseenQuota = Math.min(
+    Math.ceil(count * UNSEEN_QUOTA),
+    unseenPool.length
+  )
+
+  const guaranteedUnseen =
+    fisherYatesShuffle(unseenPool).slice(
+      0,
+      unseenQuota
+    )
+
+  const remainingUnseen = unseenPool.filter(
+    q => !guaranteedUnseen.includes(q)
+  )
+
+  for (const question of remainingUnseen) {
+    activePool.push({
+      question,
+      weight: 5,
+    })
+  }
+
+  const remainingSlots =
+    count - guaranteedUnseen.length
+
+  let selected = weightedDraw(
+    activePool,
+    remainingSlots
+  )
+
+  selected = [
+    ...guaranteedUnseen,
+    ...selected,
+  ]
+
+  if (selected.length < count) {
+    const sortedBackfill = backfillPool.sort(
+      (a, b) =>
+        new Date(a.lastSeenAt).getTime() -
+        new Date(b.lastSeenAt).getTime()
+    )
+
+    const needed = count - selected.length
+
+    const backfillQuestions =
+      sortedBackfill
+        .slice(0, needed)
+        .map(b => b.question)
+
+    selected = [
+      ...selected,
+      ...backfillQuestions,
+    ]
+  }
+
+  return fisherYatesShuffle(selected)
+}


### PR DESCRIPTION
## What does this PR do?

Extracts the spaced repetition question selection logic from
`useSpacedRepetition.ts` into a pure utility module and adds unit tests for the
selection behavior.

## Why?

The selection logic is the core of the adaptive practice experience but was
previously embedded inside the React hook, making it difficult to unit test.

This change keeps the behavior unchanged while making the logic directly
testable.

## Changes

- Extracted `selectQuestions` into `src/lib/spacedRepetition.ts`
- Moved `weightedDraw` and `MasteryRow` alongside the selection logic
- Updated `useSpacedRepetition.ts` to delegate to the extracted function
- Added tests covering:
  - guest selection path
  - unseen quota reservation
  - excluded-question backfill behavior
  - no-duplicates guarantee

## Validation

- [x] npm run test
- [x] npm run lint

Closes #30