### PR TITLE
[codex] add visible FAQ focus rings

### DIFF
--- a/src/components/Faq.astro
+++ b/src/components/Faq.astro
@@ -91,7 +91,7 @@ const chevron = '<polyline points="6 9 12 15 18 9"></polyline>'
     <div class="border-t border-border-hairline">
       {customEntries!.map(entry => (
         <details class="group border-b border-border-hairline" name={headingId}>
-          <summary class="flex items-center justify-between gap-6 py-5 md:py-6 cursor-pointer list-none text-base md:text-lg font-medium text-text-primary/90 hover:text-text-primary transition-colors duration-200 focus-visible:outline-none focus-visible:text-brand">
+          <summary class="flex items-center justify-between gap-6 py-5 md:py-6 cursor-pointer list-none text-base md:text-lg font-medium text-text-primary/90 hover:text-text-primary transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg-dark focus-visible:text-brand">
             <span>{entry.question}</span>
             <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full border border-border-hairline text-text-muted transition-[transform,color,border-color] duration-300 ease-out group-open:rotate-180 group-hover:border-text-muted/60">
               <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" set:html={chevron} />
@@ -113,7 +113,7 @@ const chevron = '<polyline points="6 9 12 15 18 9"></polyline>'
           <div class="border-t border-border-hairline">
             {entries.map(entry => (
               <details class="group border-b border-border-hairline" name={`faq-${category}`}>
-                <summary class="flex items-center justify-between gap-6 py-5 md:py-6 cursor-pointer list-none text-base md:text-lg font-medium text-text-primary/90 hover:text-text-primary transition-colors duration-200 focus-visible:outline-none focus-visible:text-brand">
+                <summary class="flex items-center justify-between gap-6 py-5 md:py-6 cursor-pointer list-none text-base md:text-lg font-medium text-text-primary/90 hover:text-text-primary transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg-dark focus-visible:text-brand">
                   <span>{entry.question}</span>
                   <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full border border-border-hairline text-text-muted transition-[transform,color,border-color] duration-300 ease-out group-open:rotate-180 group-hover:border-text-muted/60">
                     <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" set:html={chevron} />


### PR DESCRIPTION
## What does this PR do?
Adds a clearly visible keyboard focus indicator to both FAQ summary variants using the existing brand ring and theme-aware background offset tokens. The existing focus text color remains unchanged.

## Why?
The summaries removed the native outline and indicated focus only through a text color change. The new ring provides a non-color-only focus cue in light and dark mode.

Closes #74

## How was this tested?
- `npm run lint`
- `npm run test` (228 tests)
- `npm run build` with non-secret placeholder Supabase values
- Keyboard focus verified on grouped and custom FAQ variants
- Responsive visual checks at 1280x720 and 390x844 in light and dark mode

The current prebuild script imports `sharp` without declaring it in the package manifest, so `sharp` was installed locally without saving it to run the existing build pipeline. No dependency files are changed by this PR.

## Checklist
- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [ ] `npm run validate` passes locally (only if you touched `src/data/**/*.json`)
- [x] No new third-party dependencies (or justified above)

## Screenshots (UI changes only)
Verified locally in light and dark mode at desktop and mobile widths.
