### PR TITLE
fix(readme): bump contrib.rocks cache_bust to refresh contributors image

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ npm run build
 
 CloudCertPrep is maintained by [Alex Santonastaso](https://santonastaso.me) and improved by the contributors below. Every question fix, test, and accessibility tweak helps people study for free.
 
-[![Contributors](https://contrib.rocks/image?repo=nastaso/cloudcertprep&cache_bust=20260618)](https://github.com/nastaso/cloudcertprep/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=nastaso/cloudcertprep&cache_bust=20260621)](https://github.com/nastaso/cloudcertprep/graphs/contributors)
 
 New here? The [good first issues](https://github.com/nastaso/cloudcertprep/labels/good%20first%20issue) are small and welcoming, and even a single-question fix counts. And if CloudCertPrep helps your own studying, a [star](https://github.com/nastaso/cloudcertprep) helps other learners find it.
 


### PR DESCRIPTION
The previous cache_bust=20260618 URL had cached a broken/empty contrib.rocks render (transient glitch when it was bumped), which GitHub Camo then served as a 404 - leaving the contributors wall stale. A fresh token forces a new render (verified: 12 contributors) and a new Camo fetch.

<!--
Thanks for contributing to CloudCertPrep. Small, focused PRs get reviewed faster.
Project conventions (code style, design tokens, commit format) live in CONTRIBUTING.md.
-->

## What does this PR do?

<!-- One or two sentences. -->

## Why?

<!-- Linked issue, user pain point, or design rationale. -->

Closes #

## How was this tested?

<!-- Manual steps, screenshots, or which checks you ran. -->

## Checklist

- [ ] `npm run build` passes locally
- [ ] `npm run lint` passes locally
- [ ] `npm run test` passes locally
- [ ] `npm run validate` passes locally (only if you touched `src/data/**/*.json`)
- [ ] No new third-party dependencies (or justified above)

## Screenshots (UI changes only)

<!-- Drag and drop before/after if any visible UI changed. -->
