### PR TITLE
fix(seo,a11y): add og:image:alt + twitter:image:alt (closes #80)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -110,6 +110,7 @@ const effectiveRobots = isNoindexPreview ? 'noindex' : robots
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:alt" content={title} />
     <meta property="og:site_name" content="CloudCertPrep" />
     <meta property="og:locale" content="en_GB" />
     <meta property="og:locale:alternate" content="en_US" />
@@ -120,6 +121,7 @@ const effectiveRobots = isNoindexPreview ? 'noindex' : robots
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+    <meta name="twitter:image:alt" content={title} />
 
     <!-- Additional SEO -->
     <meta name="robots" content={effectiveRobots} />


### PR DESCRIPTION
Social/AI share cards now carry alt text (defaults to the page title), flowing to every OG-imaged page from BaseLayout. Improves share-card accessibility; closes the open good-first-issue #80.
