### PR TITLE
perf(cwv): lazy-load Supabase off the indexable funnel + gate hero stagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BreadcrumbList` JSON-LD to /privacy and /terms; and shortened two over-length
   AIF-C01 domain titles to the SERP budget (keyword-aligned).
 
+### Performance
+
+- Lazy-load the Supabase client. `@supabase/supabase-js` (~53 KB gzipped) was
+  pulled into every marketing/blog/cert page by the always-mounted header and
+  account-link islands, even for logged-out visitors who never touch auth. It is
+  now imported on demand behind a memoised `getSupabase()`: useAuth loads it only
+  when a session token or an OAuth/recovery `?code=` callback is present, the
+  login page warms it on mount, and app surfaces load it when they query. The
+  library is now a dynamic-import-only chunk, fully off the indexable funnel.
+- Gated the hero entrance stagger behind `html.cc-js` (mirroring `[data-reveal]`)
+  so the LCP H1 on the home and cert landing pages is no longer withheld at
+  `opacity:0` for crawlers, no-JS users, or the pre-hydration window.
+
 ### Fixed
 
 - Domain landing pages now link to the most relevant blog posts. The

--- a/src/components/CertDashboardIsland.tsx
+++ b/src/components/CertDashboardIsland.tsx
@@ -23,7 +23,7 @@ import {
   Target,
 } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { formatRelativeDate } from '../lib/formatting'
 import { formatDuration } from '../lib/scoring'
 import { logError } from '../lib/logger'
@@ -106,34 +106,38 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
 
     let cancelled = false
 
-    Promise.all([
-      supabase
-        .from('domain_progress')
-        .select('*')
-        .eq('user_id', user.id)
-        .eq('cert_code', cert.code),
-      supabase
-        .from('exam_attempts')
-        // Only the columns RecentAttempt renders — keeps the domain_scores
-        // JSONB out of the list-view egress.
-        .select('id, attempted_at, score_percent, scaled_score, passed, time_taken_seconds', { count: 'exact' })
-        .eq('user_id', user.id)
-        .eq('cert_code', cert.code)
-        .order('attempted_at', { ascending: false })
-        .limit(5),
-    ])
-      .then(([progressRes, attemptsRes]) => {
-        if (cancelled) return
-        if (progressRes.error) logError('CertDashboard.loadProgress', progressRes.error)
-        if (attemptsRes.error) logError('CertDashboard.loadAttempts', attemptsRes.error)
-        if (progressRes.data) setDomainProgress(progressRes.data as DomainProgress[])
-        if (attemptsRes.data) setRecentAttempts(attemptsRes.data as RecentAttempt[])
-        if (typeof attemptsRes.count === 'number') setExamCount(attemptsRes.count)
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return
-        logError('CertDashboard.loadDashboardData', error)
-      })
+    void (async () => {
+      const supabase = await getSupabase()
+      if (cancelled) return
+      await Promise.all([
+        supabase
+          .from('domain_progress')
+          .select('*')
+          .eq('user_id', user.id)
+          .eq('cert_code', cert.code),
+        supabase
+          .from('exam_attempts')
+          // Only the columns RecentAttempt renders — keeps the domain_scores
+          // JSONB out of the list-view egress.
+          .select('id, attempted_at, score_percent, scaled_score, passed, time_taken_seconds', { count: 'exact' })
+          .eq('user_id', user.id)
+          .eq('cert_code', cert.code)
+          .order('attempted_at', { ascending: false })
+          .limit(5),
+      ])
+        .then(([progressRes, attemptsRes]) => {
+          if (cancelled) return
+          if (progressRes.error) logError('CertDashboard.loadProgress', progressRes.error)
+          if (attemptsRes.error) logError('CertDashboard.loadAttempts', attemptsRes.error)
+          if (progressRes.data) setDomainProgress(progressRes.data as DomainProgress[])
+          if (attemptsRes.data) setRecentAttempts(attemptsRes.data as RecentAttempt[])
+          if (typeof attemptsRes.count === 'number') setExamCount(attemptsRes.count)
+        })
+        .catch((error: unknown) => {
+          if (cancelled) return
+          logError('CertDashboard.loadDashboardData', error)
+        })
+    })()
 
     return () => {
       cancelled = true

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from 'react'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { logError } from '../lib/logger'
 import { trackEvent } from '../lib/analytics'
 import { maybeNotifyGoogleLink } from '../components/account-link'
@@ -61,86 +61,111 @@ function init() {
     }
   } catch { /* localStorage unavailable */ }
 
-  state = { user: null, loading: hasToken }
+  // An OAuth / magic-link / recovery callback returns as `?code=...` on whatever
+  // page `redirectTo` pointed at. For OAuth that is wherever the user started
+  // (often a marketing page), not only /login or /reset-password. The PKCE
+  // exchange runs when the Supabase client is constructed (detectSessionInUrl),
+  // so we MUST load Supabase to complete sign-in even with no persisted token.
+  const hasAuthCallback = /[?&]code=/.test(window.location.search)
 
-  supabase.auth.getSession()
-    .then(({ data: { session } }) => {
-      // If an onAuthStateChange event already landed, it holds the freshest
-      // state — don't overwrite it with this older getSession snapshot. (M2)
-      if (authEventLanded) return
-      const initialUser = session?.user ?? null
-      prevUser = initialUser
-      setState({ user: initialUser, loading: false })
-      // A guest exam attempt stored before this session resolved (e.g. the
-      // flush failed offline last visit) is retried on any signed-in load.
-      if (initialUser && hasPendingAttempt()) {
-        void flushPendingAttempt(initialUser.id)
-      }
-    })
-    .catch((err: unknown) => {
-      logError('useAuth.getSession', err)
-      if (authEventLanded) return
-      setState({ user: null, loading: false })
-    })
+  // Logged-out with nothing to exchange: paint the logged-out chrome and skip
+  // loading the Supabase client entirely. This is what keeps ~53 KB gz of auth
+  // JS off every marketing/blog/cert page for guests (the CWV win). The site is
+  // an MPA — sign-in is always a full navigation to /login and back — so no
+  // in-place onAuthStateChange is ever needed on a logged-out marketing page.
+  if (!hasToken && !hasAuthCallback) {
+    state = { user: null, loading: false }
+    return
+  }
 
-  supabase.auth.onAuthStateChange((event, session) => {
-    authEventLanded = true
-    const newUser = session?.user ?? null
+  state = { user: null, loading: true }
 
-    // Refuse an OAuth sign-in that returned an unverified email. Google only
-    // federates verified emails, so this is a guard for R5.5 rather than an
-    // expected path. Scope to OAuth providers: email/password users legitimately
-    // have email_verified === false when email confirmation is disabled, and
-    // must not be force-signed-out here. Also covers INITIAL_SESSION so a
-    // persisted unverified OAuth session is caught on reload, not only on the
-    // live SIGNED_IN transition. The signOut() is deferred with setTimeout to
-    // avoid the supabase-js documented deadlock when calling auth methods
-    // synchronously inside the onAuthStateChange callback. (M1)
-    const isOAuth = (newUser?.app_metadata?.provider ?? 'email') !== 'email'
-    if (
-      (event === 'SIGNED_IN' || event === 'INITIAL_SESSION')
-      && newUser
-      && isOAuth
-      && newUser.user_metadata?.email_verified === false
-    ) {
-      setTimeout(() => {
-        supabase.auth.signOut().finally(() => {
-          window.location.assign('/login?error=email_unverified')
-        })
-      }, 0)
-      return
-    }
-
-    // Detect the real "user just signed in" moment. Excludes
-    // TOKEN_REFRESHED, USER_UPDATED, INITIAL_SESSION.
-    if (
-      event === 'SIGNED_IN'
-      && prevUser === null
-      && newUser !== null
-    ) {
-      trackEvent('sign_in', {
-        method: newUser.app_metadata?.provider ?? 'email',
+  void getSupabase().then(supabase => {
+    supabase.auth.getSession()
+      .then(({ data: { session } }) => {
+        // If an onAuthStateChange event already landed, it holds the freshest
+        // state — don't overwrite it with this older getSession snapshot. (M2)
+        if (authEventLanded) return
+        const initialUser = session?.user ?? null
+        prevUser = initialUser
+        setState({ user: initialUser, loading: false })
+        // A guest exam attempt stored before this session resolved (e.g. the
+        // flush failed offline last visit) is retried on any signed-in load.
+        if (initialUser && hasPendingAttempt()) {
+          void flushPendingAttempt(initialUser.id)
+        }
+      })
+      .catch((err: unknown) => {
+        logError('useAuth.getSession', err)
+        if (authEventLanded) return
+        setState({ user: null, loading: false })
       })
 
-      // First-link confirmation (R5.4): when Google was merged into a
-      // pre-existing account (multiple identities incl. google), surface a
-      // one-time notice. The helper self-guards via a localStorage ack flag,
-      // so this is safe to call on every genuine sign-in.
-      maybeNotifyGoogleLink(newUser)
-    }
+    supabase.auth.onAuthStateChange((event, session) => {
+      authEventLanded = true
+      const newUser = session?.user ?? null
 
-    prevUser = newUser
-    setState({ user: newUser, loading: false })
+      // Refuse an OAuth sign-in that returned an unverified email. Google only
+      // federates verified emails, so this is a guard for R5.5 rather than an
+      // expected path. Scope to OAuth providers: email/password users legitimately
+      // have email_verified === false when email confirmation is disabled, and
+      // must not be force-signed-out here. Also covers INITIAL_SESSION so a
+      // persisted unverified OAuth session is caught on reload, not only on the
+      // live SIGNED_IN transition. The signOut() is deferred with setTimeout to
+      // avoid the supabase-js documented deadlock when calling auth methods
+      // synchronously inside the onAuthStateChange callback. (M1)
+      const isOAuth = (newUser?.app_metadata?.provider ?? 'email') !== 'email'
+      if (
+        (event === 'SIGNED_IN' || event === 'INITIAL_SESSION')
+        && newUser
+        && isOAuth
+        && newUser.user_metadata?.email_verified === false
+      ) {
+        setTimeout(() => {
+          supabase.auth.signOut().finally(() => {
+            window.location.assign('/login?error=email_unverified')
+          })
+        }, 0)
+        return
+      }
 
-    // Flush a pending guest exam attempt to the now-signed-in account (the
-    // results-screen "Sign in to save this attempt" path). Deferred out of
-    // the auth callback per the supabase-js deadlock caution; the flush
-    // self-guards against re-entry and missing payloads, so firing on any
-    // signed-in transition (incl. INITIAL_SESSION / TOKEN_REFRESHED) is safe.
-    if (newUser && hasPendingAttempt()) {
-      const userId = newUser.id
-      setTimeout(() => { void flushPendingAttempt(userId) }, 0)
-    }
+      // Detect the real "user just signed in" moment. Excludes
+      // TOKEN_REFRESHED, USER_UPDATED, INITIAL_SESSION.
+      if (
+        event === 'SIGNED_IN'
+        && prevUser === null
+        && newUser !== null
+      ) {
+        trackEvent('sign_in', {
+          method: newUser.app_metadata?.provider ?? 'email',
+        })
+
+        // First-link confirmation (R5.4): when Google was merged into a
+        // pre-existing account (multiple identities incl. google), surface a
+        // one-time notice. The helper self-guards via a localStorage ack flag,
+        // so this is safe to call on every genuine sign-in.
+        maybeNotifyGoogleLink(newUser)
+      }
+
+      prevUser = newUser
+      setState({ user: newUser, loading: false })
+
+      // Flush a pending guest exam attempt to the now-signed-in account (the
+      // results-screen "Sign in to save this attempt" path). Deferred out of
+      // the auth callback per the supabase-js deadlock caution; the flush
+      // self-guards against re-entry and missing payloads, so firing on any
+      // signed-in transition (incl. INITIAL_SESSION / TOKEN_REFRESHED) is safe.
+      if (newUser && hasPendingAttempt()) {
+        const userId = newUser.id
+        setTimeout(() => { void flushPendingAttempt(userId) }, 0)
+      }
+    })
+  }).catch((err: unknown) => {
+    // Supabase chunk failed to load (offline / network). Resolve to logged-out
+    // so the chrome is never stuck on the loading placeholder.
+    logError('useAuth.init', err)
+    if (authEventLanded) return
+    setState({ user: null, loading: false })
   })
 }
 

--- a/src/hooks/useSignOut.ts
+++ b/src/hooks/useSignOut.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { trackEvent } from '../lib/analytics'
 
 /**
@@ -27,6 +27,7 @@ export function useSignOut(): () => Promise<void> {
     // `scope: 'local'` clear (no network call), then a guaranteed sweep of the
     // `sb-*-auth-token` keys the app's pre-paint auth detection looks for. An
     // explicit logout must never leave a credential behind.
+    const supabase = await getSupabase()
     try {
       await supabase.auth.signOut()
     } catch {

--- a/src/hooks/useSpacedRepetition.ts
+++ b/src/hooks/useSpacedRepetition.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { logError } from '../lib/logger'
 import type { Question } from '../types'
 import {
@@ -21,6 +21,7 @@ export function useSpacedRepetition(
     }
 
     try {
+      const supabase = await getSupabase()
       const { data, error: fetchError } = await supabase
         .from('question_mastery')
         .select(

--- a/src/index.css
+++ b/src/index.css
@@ -79,17 +79,20 @@
 /* Hero entrance stagger: direct children fade-and-rise in sequence with a
    small per-child delay, replacing a single slab animation with a settled,
    premium cascade. Capped at 6 children; further children share the last
-   delay. Gated by prefers-reduced-motion via the global block above. (§8 item 2) */
-.stagger > * {
+   delay. Gated by prefers-reduced-motion via the global block above.
+   Gated behind `html.cc-js` (like [data-reveal] below) so the hero H1 — the
+   LCP element on the home + cert landing pages — is never withheld at
+   opacity:0 for crawlers, no-JS users, or the pre-hydration window. (§8 item 2) */
+html.cc-js .stagger > * {
   opacity: 0;
   animation: enter 0.5s var(--ease-out) both;
 }
-.stagger > *:nth-child(1) { animation-delay: 0ms; }
-.stagger > *:nth-child(2) { animation-delay: 70ms; }
-.stagger > *:nth-child(3) { animation-delay: 140ms; }
-.stagger > *:nth-child(4) { animation-delay: 210ms; }
-.stagger > *:nth-child(5) { animation-delay: 280ms; }
-.stagger > *:nth-child(n+6) { animation-delay: 350ms; }
+html.cc-js .stagger > *:nth-child(1) { animation-delay: 0ms; }
+html.cc-js .stagger > *:nth-child(2) { animation-delay: 70ms; }
+html.cc-js .stagger > *:nth-child(3) { animation-delay: 140ms; }
+html.cc-js .stagger > *:nth-child(4) { animation-delay: 210ms; }
+html.cc-js .stagger > *:nth-child(5) { animation-delay: 280ms; }
+html.cc-js .stagger > *:nth-child(n+6) { animation-delay: 350ms; }
 
 /* FAQ open/close polish: animate the panel in when a <details> opens, and
    (where the browser supports interpolate-size) transition the disclosure

--- a/src/lib/pendingAttempt.ts
+++ b/src/lib/pendingAttempt.ts
@@ -18,7 +18,7 @@
  *   silently appear in an account created days later
  * - `attempted_at` is written from the guest finish time, not the flush time
  */
-import { supabase } from './supabase'
+import { getSupabase } from './supabase'
 import { updateDomainProgress } from './supabaseUtils'
 import { logError } from './logger'
 
@@ -125,6 +125,7 @@ export async function flushPendingAttempt(userId: string): Promise<boolean> {
   if (!pending) return false
   flushing = true
   try {
+    const supabase = await getSupabase()
     const { data: attemptData, error: attemptError } = await supabase
       .from('exam_attempts')
       .insert({

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -10,12 +10,31 @@ if (!supabaseUrl || !supabaseAnonKey) {
   )
 }
 
+// Lazy, memoised Supabase client.
+//
+// `@supabase/supabase-js` is ~53 KB gzipped. Importing it eagerly pulled it into
+// every marketing/blog/cert bundle through the always-mounted Header +
+// account-link islands, even for logged-out visitors who never touch auth.
+// Deferring the actual import behind getSupabase() keeps that weight off the
+// indexable funnel: it loads only when a persisted session token or an auth
+// `?code=` callback is present (see useAuth), or when an app/auth surface
+// actually queries. The memoised promise guarantees a single shared instance.
+//
 // flowType: 'pkce' — OAuth + magic-link/recovery return `?code=` (exchanged
 // out-of-band) instead of the implicit-flow `#access_token=...&refresh_token=`
 // in the URL hash. The hash form leaked bearer + refresh tokens into the
 // analytics pageview URL (the tracker captured `href` incl. hash before
 // auth-js could strip it). PKCE removes the token from the URL entirely and
 // auth-js clears the `?code=` via history.replaceState. (security V1)
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: { flowType: 'pkce', detectSessionInUrl: true, persistSession: true },
-})
+let clientPromise: Promise<SupabaseClient> | null = null
+
+export function getSupabase(): Promise<SupabaseClient> {
+  if (!clientPromise) {
+    clientPromise = import('@supabase/supabase-js').then(({ createClient }) =>
+      createClient(supabaseUrl, supabaseAnonKey, {
+        auth: { flowType: 'pkce', detectSessionInUrl: true, persistSession: true },
+      })
+    )
+  }
+  return clientPromise
+}

--- a/src/lib/supabaseUtils.test.ts
+++ b/src/lib/supabaseUtils.test.ts
@@ -17,7 +17,8 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./supabase', () => ({
-  supabase: {
+  // getSupabase() is the lazy accessor; it resolves to the same mock client.
+  getSupabase: () => Promise.resolve({
     from: (table: string) => {
       if (table === 'attempt_questions') {
         const builder = {
@@ -30,7 +31,7 @@ vi.mock('./supabase', () => ({
       }
       return { upsert: mocks.upsert }
     },
-  },
+  }),
 }))
 
 vi.mock('../data/questions', () => ({

--- a/src/lib/supabaseUtils.ts
+++ b/src/lib/supabaseUtils.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabase'
+import { getSupabase } from './supabase'
 import { logError } from './logger'
 import { calculateDomainMastery } from './domainStats'
 import { DEFAULT_CERT_ID } from '../data/certifications'
@@ -37,6 +37,8 @@ export async function updateDomainProgress(
     logError('supabaseUtils.updateDomainProgress.loadBank', bankError)
     return
   }
+
+  const supabase = await getSupabase()
 
   // Single query - fetch both question_id and is_correct
   const { data: allQuestions, error: selectError } = await supabase

--- a/src/pages/_DomainPractice.tsx
+++ b/src/pages/_DomainPractice.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../hooks/useAuth'
 import { useCert } from '../hooks/useCert'
 import { useCertNavigate } from '../hooks/useCertNavigate'
 import { useSEO } from '../hooks/useSEO'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { logError } from '../lib/logger'
 import { AnswerButton } from '../components/AnswerButton'
 import { OrderingInput } from '../components/OrderingInput'
@@ -306,6 +306,7 @@ export function DomainPractice() {
     // Only save to database if user is logged in
     if (user) {
       try {
+        const supabase = await getSupabase()
         // Save each question result to attempt_questions table (without attempt_id for practice mode)
         const questionRecords = questions.map((q, idx) => {
           const keyMap = optionKeyMaps.get(q.id) || {}

--- a/src/pages/_History.tsx
+++ b/src/pages/_History.tsx
@@ -4,7 +4,7 @@ import { goToLogin } from '../lib/navigation'
 import { useAuth } from '../hooks/useAuth'
 import { useCertNavigate } from '../hooks/useCertNavigate'
 import { useSEO } from '../hooks/useSEO'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { logError } from '../lib/logger'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import type { Question, ExamAttempt } from '../types'
@@ -221,6 +221,7 @@ export function History() {
         return
       }
 
+      const supabase = await getSupabase()
       const { data, error } = await supabase
         .from('exam_attempts')
         .select('*')
@@ -270,6 +271,7 @@ export function History() {
 
     setReviewLoading(attemptId)
     try {
+      const supabase = await getSupabase()
       // Load this cert's question bank if not already cached.
       if (!questionBanks.has(certCode)) {
         const bank = await loadAllQuestions(certCode)
@@ -306,6 +308,7 @@ export function History() {
     if (!user?.id) return
     setResetting(true)
     try {
+      const supabase = await getSupabase()
       const scopedCert = certFilter !== CERT_FILTER_ALL ? certFilter : null
 
       const deleteExamAttempts = supabase

--- a/src/pages/_Login.tsx
+++ b/src/pages/_Login.tsx
@@ -1,6 +1,6 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocation, Link } from 'react-router-dom'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { validatePassword, isPasswordStrongEnough } from '../lib/validation'
 import { trackEvent } from '../lib/analytics'
 import { useSEO } from '../hooks/useSEO'
@@ -61,6 +61,13 @@ export function Login() {
     turnstileRef.current?.reset()
   }
 
+  // Warm the lazy Supabase client on mount. The login page is the one place a
+  // logged-out visitor is about to need auth, so loading the ~53 KB chunk while
+  // they fill the form keeps the first sign-in click instant. (useAuth itself
+  // skips Supabase for logged-out visitors with no `?code=` callback, so this
+  // page is responsible for its own warm-up.)
+  useEffect(() => { void getSupabase() }, [])
+
   const handleEmailAuth = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
@@ -73,6 +80,7 @@ export function Login() {
     setLoading(true)
 
     try {
+      const supabase = await getSupabase()
       if (isSignUp) {
         if (!acceptedTerms) {
           setError('You must accept the Terms of Service and Privacy Policy to sign up.')
@@ -133,6 +141,7 @@ export function Login() {
     setLoading(true)
     try {
       trackEvent('sign_in_initiated', { method: 'github' })
+      const supabase = await getSupabase()
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'github',
         options: { redirectTo: `${window.location.origin}${from}` },
@@ -149,6 +158,7 @@ export function Login() {
     setLoading(true)
     try {
       trackEvent('sign_in_initiated', { method: 'google' })
+      const supabase = await getSupabase()
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: { redirectTo: `${window.location.origin}${from}` },
@@ -173,6 +183,7 @@ export function Login() {
     setLoading(true)
 
     try {
+      const supabase = await getSupabase()
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
         captchaToken: captchaToken ?? undefined,
         redirectTo: `${window.location.origin}/reset-password`,

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -19,7 +19,7 @@ import { LoadingSpinner } from '../components/LoadingSpinner'
 import { QuestionReviewCard } from '../components/QuestionReviewCard'
 import { UnlockCTA } from '../components/landing/UnlockCTA'
 import { selectExamQuestions, calculateScaledScore, isPassed, getDomainScore, formatTime, formatDuration, isAnswerCorrect, correctAnswerFor, getExamDomainTargets } from '../lib/scoring'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { logError } from '../lib/logger'
 import { updateDomainProgress } from '../lib/supabaseUtils'
 import { goToLogin } from '../lib/navigation'
@@ -451,6 +451,7 @@ export function MockExam() {
       // Only save to database if user is logged in AND exam took at least 60 seconds
       if (!isGuest && user && !isTooShort) {
         const userId = user.id
+        const supabase = await getSupabase()
         const { data: attemptData, error: attemptError } = await supabase
           .from('exam_attempts')
           .insert({

--- a/src/pages/_ResetPassword.tsx
+++ b/src/pages/_ResetPassword.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { validatePassword, isPasswordStrongEnough } from '../lib/validation'
 import { useAuth } from '../hooks/useAuth'
 import { useSEO } from '../hooks/useSEO'
@@ -76,6 +76,7 @@ export function ResetPassword() {
     setLoading(true)
 
     try {
+      const supabase = await getSupabase()
       const { error } = await supabase.auth.updateUser({
         password: password,
       })

--- a/src/pages/_Stats.tsx
+++ b/src/pages/_Stats.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import { Card } from '../components/Card'
 import { Alert } from '../components/Alert'
-import { supabase } from '../lib/supabase'
+import { getSupabase } from '../lib/supabase'
 import { formatRelativeDate } from '../lib/formatting'
 import { formatTime } from '../lib/scoring'
 import { CERTIFICATION_LIST, getCertTotalQuestions, getCertDomains } from '../data/certifications'
@@ -50,6 +50,7 @@ export function Stats() {
       setLoading(true)
       setError(null)
 
+      const supabase = await getSupabase()
       // Load platform stats from singleton table
       const { data: statsData, error: statsError } = await supabase
         .from('platform_stats')


### PR DESCRIPTION
## What

Two deferred CWV follow-ups from the technical-SEO audit, both measured-not-blind.

### 1. Lazy-load the Supabase client (the real win)
`@supabase/supabase-js` is **53 KB gzipped** (204 KB raw). It was pulled into every marketing / blog / cert page by the always-mounted header + account-link islands, even for logged-out visitors who never touch auth.

- `supabase.ts` now exports a memoised async `getSupabase()` that dynamic-imports the library on first call (was an eager top-level client).
- `useAuth` loads it only when warranted: a persisted `sb-*-auth-token`, **or** an OAuth/magic-link/recovery `?code=` callback in the URL. (The PKCE exchange runs on client construction via `detectSessionInUrl`, and OAuth's `redirectTo` can be a marketing page, so the callback must still trigger the load.) Logged-out visitors with no callback skip Supabase entirely.
- Every other consumer takes a local `const supabase = await getSupabase()` at the top of its async scope, leaving each query body unchanged.
- The login page warms the client on mount (first sign-in click stays instant); logged-in users are already warmed by `useAuth` on page load.

**Verified in the build:** the library is now a dynamic-import-only chunk. The home page loads 7 JS chunks, **none** of which statically import it; neither home nor the cert landing preloads it.

### 2. Gate the hero entrance stagger behind `html.cc-js`
Mirrors the existing `[data-reveal]` gating so the **LCP H1** on the home + cert landings is not withheld at `opacity:0` for crawlers, no-JS users, or the pre-hydration window. This half is speculative (its LCP effect depends on `cc-js` paint timing) - see QA below.

## Verification
- `check:astro`: 0 errors
- `eslint src`: clean
- `npm run test`: 228 pass (supabaseUtils mock updated to `getSupabase`)
- `npm run build`: all guards green (citation, internal-link graph, person-graph byte-lock, CSP hashing)

## QA needed on the preview (auth can't be tested on localhost - Turnstile)
- [x] **Email** sign-in + sign-up
- [ ] **Google** OAuth (incl. landing back on a marketing page -> still signs in)
- [ ] **GitHub** OAuth
- [x] **Password reset** (request link + set new password)
- [x] **Sign out** clears session
- [x] **Mock exam** save (logged-in) + **guest exam -> sign in -> attempt flushes**
- [x] **/history** loads + reset progress
- [x] **/stats** loads (public)
- [x] **Domain practice** save (logged-in)
- [x] Cert dashboard shows progress when logged in

## PageSpeed before/after
- Marketing pages (home, a cert landing): expect lower TBT/total JS (53 KB gz off the main thread for guests).
- Hero H1: **watch for a flash** (paints, then re-hides). If it flashes or LCP doesn't improve, we drop just the `index.css` stagger gate - the Supabase win stands on its own.