### PR TITLE
a11y(theme): deepen light --color-danger to meet WCAG AA on tinted surfaces

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -402,7 +402,7 @@ header[data-overlay]:not(.hdr-scrolled) {
   --color-border: 233 235 237;       /* #E9EBED hairline (DSv4) */
   --color-link: 0 115 187;           /* #0073BB AWS link blue, 5.1:1 on white (DSv4) */
   --color-success: 22 101 52;        /* #166534 — 6.1:1 on its bg-success/10 tint, 5.2:1 on /20 (WCAG AA); deepened from #16A34A which read ~2.6:1 on those correct-answer tints */
-  --color-danger: 220 38 38;         /* #DC2626 — passes 4.5:1 on white */
+  --color-danger: 185 28 28;         /* #B91C1C (Tailwind red-700) - 5.0:1 on bg-danger/15 over white, 4.8:1 on /15 over the #F8F9FA page tint (WCAG AA); deepened from #DC2626 which read ~3.8:1 on those tinted surfaces */
   --color-warning: 154 69 9;         /* #9A4509 — 6.5:1 on white, 5.3:1 on its own bg-warning/15 badge tint (WCAG AA) */
   --color-text-primary: 22 25 31;    /* #16191F AWS squid ink (DSv4) */
   --color-text-muted: 84 91 100;     /* #545B64 AWS gray — 6.5:1 on white */


### PR DESCRIPTION
Closes #93.

## Problem
The light-theme `--color-danger` token is `#DC2626` (`220 38 38`), rendered as `text-danger` on a danger tint in two places:
- the Alert component: `src/lib/buttonStyles.ts` (`bg-danger/10 ... text-danger`)
- the review-grid "incorrect" cell: `src/lib/buttonStyles.ts` (`bg-danger/10 ... text-danger`)

On those tinted backgrounds the real contrast falls below the WCAG AA 4.5:1 floor. The old inline comment ("passes 4.5:1 on white") measured against flat white, but the rendered surface is the tint.

## Fix
Deepen the **light-theme** token only to `#B91C1C` (`185 28 28`, Tailwind red-700) and rewrite the inline comment (ASCII punctuation only). The dark-theme token at the `.dark` block is untouched.

## Verification
Computed sRGB relative-luminance contrast of solid `text-danger` against the composited tint (tint = surface blended with N% of the danger color), for both the white card and the `#F8F9FA` page background:

| surface | tint | #DC2626 (before) | #B91C1C (after) |
|---|---|---|---|
| white card | bg-danger/10 | 4.13:1 FAIL | 5.45:1 PASS |
| white card | bg-danger/15 | 3.81:1 FAIL | 5.00:1 PASS |
| page #F8F9FA | bg-danger/10 | 3.94:1 FAIL | 5.20:1 PASS |
| page #F8F9FA | bg-danger/15 | 3.63:1 FAIL | 4.77:1 PASS |

Worst case after the change is 4.77:1, clearing 4.5:1. The dark theme (`#F87171`) is unchanged and still passes.

`npm run lint` and `npm run test` (228 tests) both pass locally.

Note: full WCAG validation also benefits from manual testing with assistive technologies; this change addresses the specific 1.4.3 contrast-ratio criterion called out in the issue.