### PR TITLE
perf(analytics): slim the question_answered payload (cut Umami event-data, keep guest tracking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BlogPosting` image as an `ImageObject` and added `inLanguage`; added
   `BreadcrumbList` JSON-LD to /privacy and /terms; and shortened two over-length
   AIF-C01 domain titles to the SERP budget (keyword-aligned).
+- Slimmed the per-question `question_answered` analytics event to low-cardinality
+  properties (`surface` + `domain_id`, plus `is_correct` in practice), dropping
+  the high-cardinality `question_id` and the positional `question_index`,
+  `question_number`, and `total_questions` fields. Each Umami data property is
+  billed, and those fields were the bulk of analytics data volume while adding
+  little aggregate insight. The event still fires once per answered question, so
+  guest (signed-out) engagement, which is not stored in Supabase, is still
+  tracked.
 
 ### Fixed
 

--- a/src/pages/_DomainPractice.tsx
+++ b/src/pages/_DomainPractice.tsx
@@ -281,12 +281,9 @@ export function DomainPractice() {
     setAnswering(false)
     setShowFeedback(true)
     trackEvent('question_answered', {
+      surface: 'practice',
       domain_id: selectedDomain,
-      question_id: current.id,
       is_correct: correct,
-      mode: 'practice',
-      question_number: currentIndex + 1,
-      total_questions: questions.length
     })
   }
 

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -323,12 +323,11 @@ export function MockExam() {
     const currentState = answers.get(currentIndex) || { userAnswer: null, flagged: false }
 
     // Per-question analytics: fire `question_answered` exactly once per
-    // question, on the transition from "unanswered" to "answered". Subsequent
-    // toggles (multi-answer) or answer changes (single-answer) do not refire,
-    // so event volume scales with question count, not click count. Uses the
-    // same `question_answered` name as DomainPractice to preserve Umami
-    // dashboard continuity (the live baseline event); the `surface: 'exam'`
-    // param distinguishes exam answers from domain-practice answers.
+    // question, on the transition from "unanswered" to "answered" (toggles and
+    // answer changes do not refire). The payload is deliberately low-cardinality
+    // (surface + domain only): every Umami data property is billed, and
+    // per-question detail for signed-in users already lives in Supabase. This is
+    // the guest-inclusive engagement signal; `surface` splits it from practice.
     const wasUnanswered = !isQuestionAnswered(currentState)
 
     if (current.isMultiAnswer) {
@@ -336,24 +335,12 @@ export function MockExam() {
       const newAnswers = toggleMultiAnswer(currentAnswers, answer, MAX_MULTI_ANSWER)
       setAnswers(prev => new Map(prev).set(currentIndex, { ...currentState, userAnswer: newAnswers }))
       if (wasUnanswered && newAnswers.length > 0) {
-        trackEvent('question_answered', {
-          surface: 'exam',
-          question_index: currentIndex,
-          question_id: current.id,
-          domain_id: current.domainId,
-          is_multi_answer: true,
-        })
+        trackEvent('question_answered', { surface: 'exam', domain_id: current.domainId })
       }
     } else {
       setAnswers(prev => new Map(prev).set(currentIndex, { ...currentState, userAnswer: answer }))
       if (wasUnanswered) {
-        trackEvent('question_answered', {
-          surface: 'exam',
-          question_index: currentIndex,
-          question_id: current.id,
-          domain_id: current.domainId,
-          is_multi_answer: false,
-        })
+        trackEvent('question_answered', { surface: 'exam', domain_id: current.domainId })
       }
     }
   }
@@ -369,13 +356,7 @@ export function MockExam() {
     const wasUnanswered = !isQuestionAnswered(currentState)
     setAnswers(prev => new Map(prev).set(currentIndex, { ...currentState, userAnswer: value }))
     if (wasUnanswered && value.length > 0) {
-      trackEvent('question_answered', {
-        surface: 'exam',
-        question_index: currentIndex,
-        question_id: current.id,
-        domain_id: current.domainId,
-        question_type: getQuestionType(current),
-      })
+      trackEvent('question_answered', { surface: 'exam', domain_id: current.domainId })
     }
   }
 


### PR DESCRIPTION
## Why (corrected from the first version of this PR)

The Umami free-tier cap is driven by **event data, not event count** - the usage breakdown was **Event data 78.4k (78%)** vs **Events 22.1k (22%)**. So the fix is to cut the per-event **data properties**, not to remove the event.

`question_answered` fired once per answered question with **5-6 data properties** each, which is essentially the entire 78.4k of event-data. The worst offender is `question_id` (high-cardinality), with `question_index` / `question_number` / `total_questions` adding positional noise of little aggregate value.

Important: this event is **not redundant with Supabase**. Supabase only persists **signed-in** attempts; guests run on localStorage and never hit the DB unless they sign in. So `question_answered` is the only record of **guest** question-level engagement - which is why this PR keeps the event firing and only slims its payload.

## What

Keep `question_answered` firing once per answered question, trimmed to low-cardinality properties:

- **MockExam** (`handleAnswer` x2, `setCurrentAnswer`): `{ surface: 'exam', domain_id }`. (The exam can't know correctness until submit, so no `is_correct` here.)
- **DomainPractice** (`checkAnswer`): `{ surface: 'practice', domain_id, is_correct }`.

Dropped from both: `question_id`, `question_index`, `question_number`, `total_questions`, `is_multi_answer`, `question_type`, `mode`.

`question_answered` stays in the `KNOWN_EVENTS` registry. No change to scoring, the question schema, the Supabase attempt records, or auth.

## Impact

Cuts per-fire data properties from 5-6 down to 2-3, more than halving the event-data volume that drove the cap, while preserving the guest engagement signal (which domains, exam vs practice, practice correctness). Keeps a comfortable margin under Umami Cloud's free 100k, so returning to Cloud after the Jul 1 reset stays viable, and reduces DB growth on the self-hosted box either way.

## Verification

- `npm run test`: 228 passed.
- `npm run build`: green, all guards (citation, internal-graph, person-graph byte-identical, csp:hash, cf:headers).
- `astro check`: 0 errors. `eslint src`: clean.