### PR TITLE
a11y(useFocusTrap): restore focus only when previous element is still in the DOM

### DIFF
--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -88,7 +88,16 @@ export function useFocusTrap(
       if (lockBodyScroll) {
         document.body.style.overflow = previousOverflowRef.current
       }
-      previouslyFocusedRef.current?.focus()
+      // Only restore focus if the previously focused element is still in the
+      // document. If it was removed while the trap was open (the trigger
+      // unmounted, or a navigation replaced the content underneath), calling
+      // `.focus()` on the detached node is a no-op and focus silently falls
+      // back to `<body>`, losing a keyboard or screen-reader user's place
+      // (WCAG 2.4.3 Focus Order).
+      const previous = previouslyFocusedRef.current
+      if (previous?.isConnected) {
+        previous.focus()
+      }
     }
   }, [active, containerRef, lockBodyScroll])
 }


### PR DESCRIPTION
## What

Fixes #102. `useFocusTrap` restored focus to the previously focused element on close unconditionally:

```ts
previouslyFocusedRef.current?.focus()
```

If that element was removed from the DOM while the trap was open (the trigger unmounted, or a navigation replaced the content underneath the modal), `.focus()` on the detached node is a no-op and focus silently falls back to `<body>`. A keyboard or screen-reader user then loses their place. This is a WCAG 2.4.3 (Focus Order) gap.

## Change

Guard the restore with `Node.isConnected` so focus is only returned when the saved element is still in the document:

```ts
const previous = previouslyFocusedRef.current
if (previous?.isConnected) {
  previous.focus()
}
```

- Behaviour is unchanged in the normal case (the trigger is still on the page); this only avoids the broken restore when the element has been removed.
- The trap / Tab-cycling logic and the hook signature are untouched.
- The hook is shared by `Modal` (centred dialog) and `Header` (mobile drawer), so both surfaces benefit.

## Acceptance criteria

- [x] Focus is restored on close only when the previously-focused element is still in the DOM; otherwise `.focus()` is not called.
- [x] Opening/closing the Modal and the mobile nav drawer still return focus to the trigger as before (unchanged code path).
- [x] `npm run lint` and `npm run test` pass.

## On the optional test

The issue lists a `renderHook` test as an optional bonus. It would need `@testing-library/react` + a DOM environment (jsdom), but the repo has a hard "no new npm dependencies" rule and the Vitest `environment` is `node` with no DOM, so I left it out rather than pull in new deps for a one-line guard. Happy to add it if you'd prefer to flip the test env / add the dep.

## Validation

- `npm run lint` clean.
- `npm run test` green (228 tests, 17 files).