### PR TITLE
a11y(MockExam): add an h1 to the active exam screen so headings start at h1

### DIFF
--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -740,6 +740,10 @@ export function MockExam() {
   if (screen === 'exam' && currentQuestion) {
     return (
       <div className="bg-bg-dark">
+        {/* Visually-hidden page heading so the active exam's outline starts at
+            h1 (the exam) -> h2 (the question) instead of opening on an orphan h2.
+            Screen-reader only; no visual change. */}
+        <h1 className="sr-only">{cert.shortName} Practice Exam</h1>
         {/* In-page exam toolbar: slim, neutral (NOT a second orange gradient),
             so it reads as a subordinate toolbar under the site header rather
             than a second heavy header bar. Sticks to the top while scrolling.


### PR DESCRIPTION
Closes #105

## Problem
On the active mock-exam screen (`screen === 'exam'`), the first heading is the question text rendered as an `<h2>` (`_MockExam.tsx:809`). The exam branch (line 740) has no `<h1>` before it, so a screen-reader user taking the exam lands on an orphan `h2` with nothing above it. Heading levels should start at `<h1>` and not skip (WCAG 1.3.1), since screen-reader users navigate by the heading outline.

## Change
Add a visually-hidden `<h1>` as the first child of the exam branch, reusing the start screen's wording:

```tsx
<h1 className="sr-only">{cert.shortName} Practice Exam</h1>
```

The outline now reads h1 (the exam) -> h2 (the question). `sr-only` is the project's existing visually-hidden utility (used in `OrderingInput.tsx` and `BaseLayout.astro`), so it stays in the accessibility tree and DOM while being hidden visually. `cert` is already in scope via `useCert()` at line 103, matching the visible start-screen h1 at line 555.

## Scope respected
- Only the `screen === 'exam'` branch is touched; `start` / `results` / `review` are unchanged.
- The question stays an `<h2>` with its original classes.
- Timer, scoring, and navigation are untouched.
- No new dependencies; no em/en dashes.

## Validation
- `npm run lint` passes.
- `npm run test` passes (228 tests, 17 files).

## Acceptance criteria
- [x] Active exam outline starts at `<h1>` (h1 -> h2), no skipped top-level heading.
- [x] No visual change (new heading is `sr-only`).
- [x] Scoring, timer, and question flow unchanged.
- [x] `npm run lint` and `npm run test` pass.