### PR TITLE
a11y(motion): reset animation-delay in reduced-motion block (closes #25)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0ms !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }


### PR DESCRIPTION
## Summary

- Adds `animation-delay: 0ms !important` to the global `prefers-reduced-motion` override block in `src/index.css`

The existing block correctly collapsed `animation-duration` to `0.01ms` and capped `animation-iteration-count` to `1`, but left `animation-delay` untouched. `.stagger` children carry per-child delays of 0/70/140/210/280/350 ms — so reduced-motion users saw `opacity: 0` content for up to 350 ms while waiting for those delayed animations to fire (even though the animations themselves finished in 0.01ms). The fix ensures every delayed animation surfaces immediately.

**Verification of all four surfaces from #25:**
- **Hero stagger** — was the gap: delays of up to 350 ms kept children invisible. Fixed by this PR.
- **Mobile navigation drawer** (`animate-slide-in-right` / `animate-slide-out-right`) — already instant via `animation-duration: 0.01ms`. No change needed.
- **Exam timer pulse** (`animate-pulse`) — global override stops pulsing (iteration count capped to 1); `text-warning` color class is independent and persists. No change needed.
- **DomainPractice `.animate-enter`** — already instant. `[data-reveal]` is also pre-revealed by the inline script in BaseLayout (checks `prefers-reduced-motion` and immediately adds `.is-revealed`). No change needed.

## Test plan

- [ ] Enable "Reduce Motion" in macOS System Settings > Accessibility > Display
- [ ] Load `/` — hero heading and subtext appear immediately, no invisible window
- [ ] Open the mobile nav drawer — slides in/out near-instantly, focus management still works
- [ ] Start a mock exam with < TIMER_PULSE_THRESHOLD seconds — timer shows `text-warning` color, no pulsing
- [ ] Complete a DomainPractice question — feedback alert appears instantly
- [ ] `npm run lint` and `npm run test` both pass