### PR TITLE
fix(crash): guard localStorage in useTheme/useCert; clear stuck dashboard error

### DIFF
--- a/e2e/crash-safety.spec.ts
+++ b/e2e/crash-safety.spec.ts
@@ -58,6 +58,38 @@ test('useTheme: theme toggles without crashing when localStorage is blocked', as
 })
 
 // ---------------------------------------------------------------------------
+// useCert: exam page renders when localStorage.getItem is blocked (surface 7)
+// ---------------------------------------------------------------------------
+
+test('useCert: practice-exam renders without crashing when localStorage.getItem is blocked', async ({ page }) => {
+  // Block localStorage.getItem to simulate a storage-disabled / sandboxed browser.
+  // This is the exact condition that made getStored() throw during render, causing
+  // the AppIsland ErrorBoundary to catch it and show "Something went wrong."
+  await page.addInitScript(() => {
+    const orig = window.localStorage
+    const proxy = new Proxy(orig, {
+      get(target, prop) {
+        if (prop === 'getItem') {
+          return () => { throw new DOMException('SecurityError', 'SecurityError') }
+        }
+        const val = target[prop as keyof Storage]
+        return typeof val === 'function' ? (val as (...args: unknown[]) => unknown).bind(target) : val
+      },
+    })
+    Object.defineProperty(window, 'localStorage', { get: () => proxy, configurable: true })
+  })
+
+  await page.goto('/aws/clf-c02/practice-exam')
+
+  // The ErrorBoundary must NOT fire.
+  await expect(page.getByText(/something went wrong/i)).toHaveCount(0)
+
+  // The exam start screen must render (useCert fell back to DEFAULT_CERT_ID,
+  // not an uncaught SecurityError that crashes the island).
+  await expect(page.getByRole('button', { name: 'Start exam' })).toBeVisible({ timeout: 15000 })
+})
+
+// ---------------------------------------------------------------------------
 // Dashboard: error clears on successful re-fetch (surface 7)
 // ---------------------------------------------------------------------------
 

--- a/e2e/crash-safety.spec.ts
+++ b/e2e/crash-safety.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, type Route } from '@playwright/test'
+import { seedSession } from './seededSession'
+
+/**
+ * PR-2: localStorage crash safety + stuck dashboard error state.
+ * Runs in CI with the seeded-session fixture (no real backend / Turnstile).
+ * Source: EDGE-CASE-FINDINGS-2026-06-28.md, surfaces 3 + 7.
+ */
+
+// ---------------------------------------------------------------------------
+// Storage crash safety: theme toggle with localStorage blocked
+// ---------------------------------------------------------------------------
+
+test('useTheme: theme toggles without crashing when localStorage is blocked', async ({ page }) => {
+  // Proxy localStorage so setItem throws a SecurityError (storage-blocked browser).
+  await page.addInitScript(() => {
+    const orig = window.localStorage
+    const proxy = new Proxy(orig, {
+      get(target, prop) {
+        if (prop === 'setItem') {
+          return () => { throw new DOMException('SecurityError: storage blocked', 'SecurityError') }
+        }
+        const val = target[prop as keyof Storage]
+        return typeof val === 'function' ? (val as (...args: unknown[]) => unknown).bind(target) : val
+      },
+    })
+    Object.defineProperty(window, 'localStorage', { get: () => proxy, configurable: true })
+  })
+
+  await page.goto('/')
+
+  // Theme toggle must be present and interactable
+  const toggle = page.getByRole('button', { name: /toggle.*theme|switch.*theme|dark|light/i }).first()
+  await expect(toggle).toBeVisible({ timeout: 15000 })
+
+  // Click should not crash - if it did, the no-transition class would be stuck
+  // (killing all site transitions) and a second click would fail silently.
+  await toggle.click()
+
+  // Double-rAF takes <50ms; wait a bit then verify no-transition was removed.
+  await page.waitForTimeout(200)
+
+  const hasNoTransition = await page.evaluate(
+    () => document.documentElement.classList.contains('no-transition'),
+  )
+  expect(
+    hasNoTransition,
+    '.no-transition must be removed after toggle even when localStorage throws',
+  ).toBe(false)
+
+  // A second toggle must also work (state is not jammed).
+  await toggle.click()
+  await page.waitForTimeout(200)
+  const stillStuck = await page.evaluate(
+    () => document.documentElement.classList.contains('no-transition'),
+  )
+  expect(stillStuck, 'second toggle must also clean up no-transition').toBe(false)
+})
+
+// ---------------------------------------------------------------------------
+// Dashboard: error clears on successful re-fetch (surface 7)
+// ---------------------------------------------------------------------------
+
+test('CertDashboard: error alert clears when a re-fetch succeeds', async ({ page }) => {
+  // Use a closure flag so the route handler switches from fail -> succeed once
+  // the test is ready to click "Try again".
+  let shouldFail = true
+
+  await seedSession(page, {
+    rest: (route: Route) => {
+      if (shouldFail) {
+        // Abort (network error): caught by the .catch() in CertDashboard, sets dataError=true.
+        return route.abort()
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '[]',
+        headers: { 'Content-Range': '0-0/0' },
+      })
+    },
+  })
+
+  await page.goto('/aws/clf-c02')
+
+  // Wait for auth to resolve and the dashboard kicker to appear (proves
+  // useAuth().user resolved from the seeded token). The middot separator
+  // distinguishes the kicker from the sr-only "Loading your dashboard" status.
+  await expect(page.getByText(/·\s*your dashboard/i)).toBeVisible({ timeout: 15000 })
+
+  // With both REST queries aborted, the dashboard must show the error alert.
+  await expect(
+    page.getByText(/could not load your latest progress/i),
+  ).toBeVisible({ timeout: 10000 })
+
+  // Switch the route handler to succeed, then trigger a re-fetch via "Try again".
+  shouldFail = false
+  await page.getByRole('button', { name: /try again/i }).click()
+
+  // The error alert must disappear (dataError cleared by the success path).
+  await expect(
+    page.getByText(/could not load your latest progress/i),
+  ).toBeHidden({ timeout: 10000 })
+
+  // "Domain mastery" heading is only rendered when !dataError (the section is
+  // conditionally removed, not just hidden), so its presence confirms the error
+  // state was fully resolved, not merely styled away.
+  await expect(
+    page.getByRole('heading', { name: 'Domain mastery', exact: true }),
+  ).toBeVisible({ timeout: 5000 })
+})

--- a/src/components/CertDashboardIsland.tsx
+++ b/src/components/CertDashboardIsland.tsx
@@ -163,7 +163,13 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
           if (typeof attemptsRes.count === 'number') setExamCount(attemptsRes.count)
           // Surface an error only when BOTH queries failed; a partial failure
           // still has useful data to show. Either way the skeleton resolves.
-          if (progressRes.error && attemptsRes.error) setDataError(true)
+          if (progressRes.error && attemptsRes.error) {
+            setDataError(true)
+          } else {
+            // Clear any prior error (e.g. from a TOKEN_REFRESHED re-fetch after
+            // a transient failure) so the dashboard is not stuck on the error alert.
+            setDataError(false)
+          }
           setDataLoading(false)
         })
         .catch((error: unknown) => {

--- a/src/hooks/useCert.ts
+++ b/src/hooks/useCert.ts
@@ -1,6 +1,7 @@
 import { useEffect, useSyncExternalStore } from 'react'
 import { CERTIFICATIONS, DEFAULT_CERT_ID, getCertByPath } from '../data/certifications'
 import { subscribeLocationChange } from '../lib/locationChange'
+import { storageGet, storageSet } from '../lib/storage'
 import type { Certification } from '../data/certifications'
 
 /**
@@ -17,6 +18,11 @@ const STORAGE_KEY = 'activeCert'
 
 const pathListeners = new Set<() => void>()
 const storeListeners = new Set<() => void>()
+
+// In-memory fallback for storage-blocked browsers (private mode / cookies
+// disabled). Keeps cert navigation functional for the current session even
+// when localStorage is inaccessible.
+let inMemoryCert: string | null = null
 
 let pathInitialised = false
 function initPath() {
@@ -46,8 +52,7 @@ function subscribeStore(cb: () => void) {
   return () => storeListeners.delete(cb)
 }
 function getStored(): string {
-  if (typeof localStorage === 'undefined') return DEFAULT_CERT_ID
-  return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_CERT_ID
+  return storageGet(STORAGE_KEY, inMemoryCert ?? DEFAULT_CERT_ID)
 }
 function getServerStored(): string { return DEFAULT_CERT_ID }
 
@@ -81,8 +86,9 @@ export function useCert(): Certification {
 
 export function setActiveCert(certCode: string): boolean {
   if (!CERTIFICATIONS[certCode]) return false
-  if (typeof localStorage === 'undefined') return false
-  localStorage.setItem(STORAGE_KEY, certCode)
+  // Always update in-memory first so storage-blocked browsers still navigate correctly.
+  inMemoryCert = certCode
+  storageSet(STORAGE_KEY, certCode)
   storeListeners.forEach(cb => cb())
   return true
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -8,6 +8,7 @@
  */
 
 import { useCallback, useSyncExternalStore } from 'react'
+import { storageSet } from '../lib/storage'
 
 type Theme = 'light' | 'dark'
 
@@ -49,7 +50,9 @@ export function useTheme() {
     root.classList.add('no-transition')
     const next: Theme = t === 'dark' ? 'light' : 'dark'
     root.classList.toggle('dark', next === 'dark')
-    localStorage.setItem(THEME_KEY, next)
+    // storageSet catches SecurityError in private/cookies-disabled browsers;
+    // execution continues so theme and no-transition are always resolved.
+    storageSet(THEME_KEY, next)
     theme = next
     notify()
     requestAnimationFrame(() => {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { storageGet, storageSet } from './storage'
+
+function stubStorage(impl: Partial<Storage>): void {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: impl,
+    writable: true,
+    configurable: true,
+  })
+}
+
+function removeStorage(): void {
+  // Restore undefined (node default - no localStorage)
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  })
+}
+
+afterEach(removeStorage)
+
+describe('storageGet', () => {
+  it('returns fallback when localStorage is undefined (node / no-storage env)', () => {
+    expect(storageGet('k', 'fb')).toBe('fb')
+  })
+
+  it('returns stored value when localStorage is accessible', () => {
+    stubStorage({ getItem: () => 'stored' })
+    expect(storageGet('k', 'fb')).toBe('stored')
+  })
+
+  it('returns fallback when getItem returns null (key absent)', () => {
+    stubStorage({ getItem: () => null })
+    expect(storageGet('k', 'fb')).toBe('fb')
+  })
+
+  it('returns fallback when localStorage.getItem throws (storage blocked)', () => {
+    stubStorage({ getItem: () => { throw new Error('SecurityError: blocked') } })
+    expect(() => storageGet('k', 'fb')).not.toThrow()
+    expect(storageGet('k', 'fb')).toBe('fb')
+  })
+})
+
+describe('storageSet', () => {
+  it('returns false when localStorage is undefined', () => {
+    expect(storageSet('k', 'v')).toBe(false)
+  })
+
+  it('returns true and calls setItem when localStorage is accessible', () => {
+    const calls: Array<[string, string]> = []
+    stubStorage({ setItem: (k: string, v: string) => { calls.push([k, v]) } })
+    expect(storageSet('k', 'v')).toBe(true)
+    expect(calls).toEqual([['k', 'v']])
+  })
+
+  it('returns false when localStorage.setItem throws (storage blocked)', () => {
+    stubStorage({ setItem: () => { throw new Error('SecurityError: blocked') } })
+    expect(() => storageSet('k', 'v')).not.toThrow()
+    expect(storageSet('k', 'v')).toBe(false)
+  })
+})

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,24 @@
+/**
+ * Safe localStorage wrappers. In private/cookies-disabled browsers, accessing
+ * localStorage.getItem or .setItem throws a SecurityError. These helpers catch
+ * that and degrade gracefully instead of crashing the calling hook or render.
+ */
+
+export function storageGet(key: string, fallback: string): string {
+  try {
+    if (typeof localStorage === 'undefined') return fallback
+    return localStorage.getItem(key) ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function storageSet(key: string, value: string): boolean {
+  try {
+    if (typeof localStorage === 'undefined') return false
+    localStorage.setItem(key, value)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- **`src/lib/storage.ts`** (new) - thin `storageGet`/`storageSet` helpers that wrap `localStorage` in `try/catch`, degrading gracefully on `SecurityError` (private mode, cookies disabled, sandboxed iframes)
- **`useTheme.ts`** - replace bare `localStorage.setItem` with `storageSet`; execution now continues past a storage failure so `.no-transition` is always removed and theme state stays in sync
- **`useCert.ts`** - replace bare `localStorage.getItem/setItem` with `storageGet/storageSet`; add in-memory fallback so cert navigation stays functional for the current session even when storage is blocked
- **`CertDashboardIsland.tsx`** - add `setDataError(false)` in the success branch of the fetch effect; fixes the bug where a TOKEN_REFRESHED re-fetch that succeeded left the dashboard stuck on the error alert

## Tests

- **7 Vitest unit tests** (`src/lib/storage.test.ts`) - stub `localStorage` to throw and assert graceful fallback for both reads and writes
- **2 Playwright e2e tests** (`e2e/crash-safety.spec.ts`):
  - `useTheme`: proxy `localStorage.setItem` to throw, click the theme toggle, assert `.no-transition` is removed (transitions not stuck)
  - `CertDashboard`: route REST to abort (both queries fail), wait for error alert, switch route to succeed, click "Try again", assert error alert hides and "Domain mastery" section renders

## Verification

- `npm run lint` - no new errors (2 pre-existing: `.kiro` file + `_Stats.tsx` hook warning)
- `npm run test` - 232 passed (225 pre-existing + 7 new storage tests)
- `npm run build` + guard chain - all green; artifacts restored
- `npm run e2e` - 96 passed / 9 skipped / 1 pre-existing flake (`github_click` conversion event, retries green)

## Source

`EDGE-CASE-FINDINGS-2026-06-28.md`:
- Surface 3 (useTheme) - lines 26-27: `.no-transition` stuck on storage throw
- Surface 7 (useCert) - line 38: `getStored` throws during render in storage-blocked browser
- Top-bugs list - line 20: `CertDashboard` `dataError` never cleared on successful re-fetch

PR-2 of the post-#114 stabilization sprint (see `.kiro/ux/impl-2026-06-28/00-START-HERE.md`).