### PR TITLE
fix(auth): bind guest pending-attempt flush to an explicit save intent (PR-3)

### DIFF
--- a/e2e/pending-attempt-owner-binding.spec.ts
+++ b/e2e/pending-attempt-owner-binding.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect, type Route } from '@playwright/test'
+import { seedSession } from './seededSession'
+
+/**
+ * PR-3: guest pending exam attempt must bind to the account that explicitly
+ * asked to save it, never to whatever account next signs in on the device.
+ * Source: EDGE-CASE-FINDINGS-2026-06-28.md surfaces 1 + 4
+ * (pending-attempt-cross-account-contamination /
+ * rls-pending-attempt-cross-account-misattribution).
+ *
+ * Runs in CI with the seeded-session fixture (no real backend / Turnstile). A
+ * seeded session resolves through useAuth's INITIAL_SESSION path - exactly the
+ * passive transition a different person's restored session takes - so it is the
+ * right shape to prove the negative case. The positive case approximates the
+ * save-CTA flow by pre-setting the same save-intent the results-screen CTA sets.
+ * The live SIGNED_IN save flow itself is real-creds only (Turnstile-gated).
+ */
+
+const PENDING_KEY = 'cloudcertprep_pending_attempt'
+const INTENT_KEY = 'cloudcertprep_pending_attempt_intent'
+const CERT = 'clf-c02'
+
+/** A well-shaped, in-TTL guest snapshot, as storePendingAttempt would write it. */
+function pendingPayload(finishedAt: number): string {
+  return JSON.stringify({
+    certCode: CERT,
+    finishedAt,
+    attempt: {
+      score_percent: 80,
+      scaled_score: 800,
+      passed: true,
+      time_taken_seconds: 1200,
+      total_questions: 2,
+      correct_answers: 1,
+      domain_scores: { '1': 100, '2': 0 },
+    },
+    questions: [
+      { question_id: 'q1', user_answer: 'A', correct_answer: 'A', is_correct: true, was_flagged: false, domain_id: 1 },
+      { question_id: 'q2', user_answer: 'B', correct_answer: 'C', is_correct: false, was_flagged: false, domain_id: 2 },
+    ],
+  })
+}
+
+/** Record every REST request so we can assert an attempt write did / didn't fire. */
+function makeRestRecorder() {
+  const calls: { method: string; url: string }[] = []
+  const handler = (route: Route) => {
+    const req = route.request()
+    calls.push({ method: req.method(), url: req.url() })
+    // exam_attempts insert chains .select().single(), which expects ONE object.
+    if (req.method() === 'POST' && req.url().includes('/exam_attempts')) {
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 'seed-attempt-1' }) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  }
+  const attemptWrites = () =>
+    calls.filter(c => c.method === 'POST' && /\/(exam_attempts|attempt_questions)\b/.test(c.url))
+  return { handler, attemptWrites }
+}
+
+test('passive sign-in with a pending guest attempt but NO save intent never writes it to the account', async ({ page }) => {
+  const rec = makeRestRecorder()
+
+  // A DIFFERENT person's session restores (INITIAL_SESSION) on a shared device.
+  await seedSession(page, {
+    user: { id: 'innocent-user-b', email: 'b@example.com' },
+    rest: rec.handler,
+  })
+  // A guest left a finished attempt in localStorage but did NOT click "Sign in
+  // to save this attempt", so there is no save intent.
+  await page.addInitScript(
+    ({ key, value }) => localStorage.setItem(key, value),
+    { key: PENDING_KEY, value: pendingPayload(Date.now()) },
+  )
+
+  await page.goto('/')
+
+  // Wait until auth has fully resolved (signed-in chrome): useAuth has run and
+  // the INITIAL_SESSION event has been delivered, so the flush decision is made.
+  await expect(page.getByRole('button', { name: 'Account menu' }).first()).toBeVisible({ timeout: 15000 })
+  // Settle past the deferred (setTimeout 0) flush attempt, had one been made.
+  await page.waitForTimeout(1500)
+
+  expect(
+    rec.attemptWrites(),
+    'no exam_attempts / attempt_questions write may fire for an account that did not ask to save the attempt',
+  ).toEqual([])
+})
+
+test('the save-CTA intent flushes the pending attempt to the intended account', async ({ page }) => {
+  const rec = makeRestRecorder()
+  const now = Date.now()
+
+  await seedSession(page, {
+    user: { id: 'intended-user-a', email: 'a@example.com' },
+    rest: rec.handler,
+  })
+  // The guest clicked "Sign in to save this attempt" (sets the matching intent)
+  // and the intended account is now signing in.
+  await page.addInitScript(
+    ({ pendingKey, pendingValue, intentKey, intentValue }) => {
+      localStorage.setItem(pendingKey, pendingValue)
+      sessionStorage.setItem(intentKey, intentValue)
+    },
+    { pendingKey: PENDING_KEY, pendingValue: pendingPayload(now), intentKey: INTENT_KEY, intentValue: CERT },
+  )
+
+  await page.goto('/')
+
+  await expect(page.getByRole('button', { name: 'Account menu' }).first()).toBeVisible({ timeout: 15000 })
+
+  // The flush must write the attempt for the intended account (proves both the
+  // capture harness and the legitimate save path are reachable - so the negative
+  // test above is not vacuous).
+  await expect
+    .poll(() => rec.attemptWrites().length, { timeout: 10000 })
+    .toBeGreaterThan(0)
+  expect(rec.attemptWrites().some(c => c.url.includes('/exam_attempts'))).toBe(true)
+})

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -89,11 +89,11 @@ function init() {
         const initialUser = session?.user ?? null
         prevUser = initialUser
         setState({ user: initialUser, loading: false })
-        // A guest exam attempt stored before this session resolved (e.g. the
-        // flush failed offline last visit) is retried on any signed-in load.
-        if (initialUser && hasPendingAttempt()) {
-          void flushPendingAttempt(initialUser.id)
-        }
+        // No pending-attempt flush here: a persisted session resolving on load
+        // is a PASSIVE transition (it may be a different person on a shared
+        // device), so it must not adopt a stored guest attempt. The flush is
+        // wired into onAuthStateChange below and gated on an explicit save
+        // intent; INITIAL_SESSION delivers the same session through that path.
       })
       .catch((err: unknown) => {
         logError('useAuth.getSession', err)
@@ -152,10 +152,17 @@ function init() {
 
       // Flush a pending guest exam attempt to the now-signed-in account (the
       // results-screen "Sign in to save this attempt" path). Deferred out of
-      // the auth callback per the supabase-js deadlock caution; the flush
-      // self-guards against re-entry and missing payloads, so firing on any
-      // signed-in transition (incl. INITIAL_SESSION / TOKEN_REFRESHED) is safe.
-      if (newUser && hasPendingAttempt()) {
+      // the auth callback per the supabase-js deadlock caution. flushPendingAttempt
+      // is the real guard: it writes ONLY when the guest set a matching save
+      // intent, so a passive or unrelated sign-in adopts nothing. We additionally
+      // skip bare TOKEN_REFRESHED / USER_UPDATED here so they never even attempt
+      // it; SIGNED_IN is the genuine save flow and INITIAL_SESSION carries the
+      // same intent-gated session for the in-tab return from /login. (P2 data-bleed)
+      if (
+        (event === 'SIGNED_IN' || event === 'INITIAL_SESSION')
+        && newUser
+        && hasPendingAttempt()
+      ) {
         const userId = newUser.id
         setTimeout(() => { void flushPendingAttempt(userId) }, 0)
       }

--- a/src/lib/pendingAttempt.test.ts
+++ b/src/lib/pendingAttempt.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  storePendingAttempt,
+  flushPendingAttempt,
+  markPendingAttemptSaveIntent,
+  hasPendingAttempt,
+  type PendingAttempt,
+} from './pendingAttempt'
+
+/**
+ * Regression guard for the guest -> wrong-account contamination bug
+ * (EDGE-CASE-FINDINGS-2026-06-28: pending-attempt-cross-account-contamination /
+ * rls-pending-attempt-cross-account-misattribution).
+ *
+ * flushPendingAttempt() used to write the stored guest attempt into WHATEVER
+ * userId it was handed, so any sign-in on a shared device (incl. a different
+ * person's passive INITIAL_SESSION) adopted the snapshot. The fix binds the
+ * flush to an explicit, single-use "save this attempt" intent that only the
+ * guest's results-screen CTA sets. These tests stub the Supabase client and the
+ * storage globals (Vitest runs in node, so neither exists by default) and assert
+ * the exam_attempts insert IS / IS NOT attempted.
+ */
+
+const mocks = vi.hoisted(() => ({
+  examInsert: vi.fn(),
+  questionsInsert: vi.fn(),
+  examDelete: vi.fn(),
+  updateDomainProgress: vi.fn(),
+  logError: vi.fn(),
+  // Tunable responses so a test can force the questions insert to fail, etc.
+  attemptResult: { data: { id: 'attempt-1' } as { id: string } | null, error: null as unknown },
+  questionsResult: { error: null as unknown },
+}))
+
+vi.mock('./supabase', () => ({
+  getSupabase: () => Promise.resolve({
+    from: (table: string) => {
+      if (table === 'exam_attempts') {
+        return {
+          insert: (payload: unknown) => {
+            mocks.examInsert(payload)
+            return { select: () => ({ single: () => Promise.resolve(mocks.attemptResult) }) }
+          },
+          delete: () => ({
+            eq: (...args: unknown[]) => { mocks.examDelete(...args); return Promise.resolve({ error: null }) },
+          }),
+        }
+      }
+      if (table === 'attempt_questions') {
+        return {
+          insert: (rows: unknown) => { mocks.questionsInsert(rows); return Promise.resolve(mocks.questionsResult) },
+        }
+      }
+      throw new Error(`unexpected table: ${table}`)
+    },
+  }),
+}))
+
+vi.mock('./supabaseUtils', () => ({ updateDomainProgress: mocks.updateDomainProgress }))
+vi.mock('./logger', () => ({ logError: mocks.logError }))
+
+// --- storage + window stubs (node has none) -------------------------------
+
+function memStorage(): Storage {
+  const m = new Map<string, string>()
+  return {
+    get length() { return m.size },
+    clear: () => m.clear(),
+    getItem: (k: string) => (m.has(k) ? m.get(k)! : null),
+    key: (i: number) => Array.from(m.keys())[i] ?? null,
+    removeItem: (k: string) => { m.delete(k) },
+    setItem: (k: string, v: string) => { m.set(k, String(v)) },
+  } as Storage
+}
+
+function defineGlobal(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, { value, writable: true, configurable: true })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.attemptResult = { data: { id: 'attempt-1' }, error: null }
+  mocks.questionsResult = { error: null }
+  defineGlobal('localStorage', memStorage())
+  defineGlobal('sessionStorage', memStorage())
+  // flushPendingAttempt dispatches a window Event on success.
+  if (typeof (globalThis as { Event?: unknown }).Event === 'undefined') {
+    defineGlobal('Event', class { constructor(public type: string) {} })
+  }
+  defineGlobal('window', { dispatchEvent: vi.fn() })
+})
+
+afterEach(() => {
+  defineGlobal('localStorage', undefined)
+  defineGlobal('sessionStorage', undefined)
+  defineGlobal('window', undefined)
+})
+
+function makePending(certCode = 'clf-c02'): PendingAttempt {
+  return {
+    certCode,
+    finishedAt: Date.now(),
+    attempt: {
+      score_percent: 80,
+      scaled_score: 800,
+      passed: true,
+      time_taken_seconds: 1200,
+      total_questions: 5,
+      correct_answers: 4,
+      domain_scores: { '1': 80, '2': 80 },
+    },
+    questions: [
+      { question_id: 'q1', user_answer: 'A', correct_answer: 'A', is_correct: true, was_flagged: false, domain_id: 1 },
+      { question_id: 'q2', user_answer: 'B', correct_answer: 'C', is_correct: false, was_flagged: true, domain_id: 2 },
+    ],
+  }
+}
+
+describe('flushPendingAttempt: save-intent gating', () => {
+  it('does NOT flush a stored attempt when no save intent is set (passive / unrelated sign-in)', async () => {
+    storePendingAttempt(makePending())
+
+    const saved = await flushPendingAttempt('innocent-user-B')
+
+    expect(saved).toBe(false)
+    expect(mocks.examInsert).not.toHaveBeenCalled()
+    expect(mocks.questionsInsert).not.toHaveBeenCalled()
+    expect(mocks.updateDomainProgress).not.toHaveBeenCalled()
+    // The snapshot must be LEFT intact so a later legitimate save flow can still
+    // flush it; a no-intent sign-in must neither adopt nor destroy it.
+    expect(hasPendingAttempt()).toBe(true)
+  })
+
+  it('flushes exactly once, for the intended user, when a matching save intent is set', async () => {
+    storePendingAttempt(makePending('clf-c02'))
+    markPendingAttemptSaveIntent('clf-c02')
+
+    const saved = await flushPendingAttempt('intended-user-A')
+
+    expect(saved).toBe(true)
+    expect(mocks.examInsert).toHaveBeenCalledTimes(1)
+    expect(mocks.examInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'intended-user-A', cert_code: 'clf-c02' }),
+    )
+    // Every attempt_questions row is stamped with the SAME intended user.
+    const rows = mocks.questionsInsert.mock.calls[0][0] as Array<{ user_id: string }>
+    expect(rows.every(r => r.user_id === 'intended-user-A')).toBe(true)
+    // Consumed on success: nothing left to re-flush into a second account.
+    expect(hasPendingAttempt()).toBe(false)
+  })
+
+  it('does NOT flush when the save intent names a different cert than the snapshot', async () => {
+    storePendingAttempt(makePending('clf-c02'))
+    markPendingAttemptSaveIntent('aif-c01')
+
+    const saved = await flushPendingAttempt('intended-user-A')
+
+    expect(saved).toBe(false)
+    expect(mocks.examInsert).not.toHaveBeenCalled()
+  })
+
+  it('intent is single-use: it cannot be replayed into a second account', async () => {
+    storePendingAttempt(makePending('clf-c02'))
+    markPendingAttemptSaveIntent('clf-c02')
+
+    // First (legitimate) sign-in consumes the intent and the snapshot.
+    expect(await flushPendingAttempt('intended-user-A')).toBe(true)
+    expect(mocks.examInsert).toHaveBeenCalledTimes(1)
+
+    // A second person re-stores a snapshot (or the same one lingers) and signs
+    // in: with the intent already consumed, no flush is attempted for them.
+    storePendingAttempt(makePending('clf-c02'))
+    const second = await flushPendingAttempt('innocent-user-B')
+
+    expect(second).toBe(false)
+    expect(mocks.examInsert).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a no-op (no crash) when an intent is set but no snapshot exists', async () => {
+    markPendingAttemptSaveIntent('clf-c02')
+
+    const saved = await flushPendingAttempt('intended-user-A')
+
+    expect(saved).toBe(false)
+    expect(mocks.examInsert).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/pendingAttempt.ts
+++ b/src/lib/pendingAttempt.ts
@@ -17,6 +17,10 @@
  * - pending attempts expire after 24 hours, so a stale guest score does not
  *   silently appear in an account created days later
  * - `attempted_at` is written from the guest finish time, not the flush time
+ * - OWNER BINDING: the flush writes to an account ONLY when the guest set an
+ *   explicit, matching "save this attempt" intent (the results-screen CTA). A
+ *   passive or unrelated sign-in on a shared device never adopts the snapshot,
+ *   so a stranger's account is never polluted with someone else's attempt.
  */
 import { getSupabase } from './supabase'
 import { updateDomainProgress } from './supabaseUtils'
@@ -24,6 +28,14 @@ import { logError } from './logger'
 
 const PENDING_KEY = 'cloudcertprep_pending_attempt'
 const SAVED_NOTICE_KEY = 'cloudcertprep_pending_attempt_saved'
+// Explicit "save this attempt" intent, set ONLY when the guest clicks the
+// results-screen save CTA (markPendingAttemptSaveIntent). flushPendingAttempt
+// refuses to write to any account without a matching intent, so a passive or
+// unrelated sign-in on a shared device never adopts the snapshot. sessionStorage
+// (per-tab, not localStorage) so the intent cannot leak into a different
+// person's later session; it still survives the /login (and OAuth) round-trip in
+// the same tab, exactly like RESUME_RESULTS_KEY / SAVED_NOTICE_KEY.
+const SAVE_INTENT_KEY = 'cloudcertprep_pending_attempt_intent'
 const PENDING_TTL_MS = 24 * 60 * 60 * 1000
 
 /**
@@ -120,19 +132,57 @@ export function consumePendingAttemptSavedNotice(): string | null {
   }
 }
 
+/**
+ * Record that the guest explicitly asked to save THIS attempt, by clicking the
+ * results-screen "Sign in to save this attempt" CTA. flushPendingAttempt only
+ * writes the snapshot to an account when this intent is present AND names the
+ * same cert, so a passive INITIAL_SESSION / TOKEN_REFRESHED or an unrelated
+ * person's sign-in on a shared device can never adopt it.
+ */
+export function markPendingAttemptSaveIntent(certCode: string): void {
+  try {
+    sessionStorage.setItem(SAVE_INTENT_KEY, certCode)
+  } catch {
+    // sessionStorage unavailable: the attempt just won't auto-save on sign-in.
+  }
+}
+
+/**
+ * Read-and-clear the save intent. Single-use by construction: consumed before
+ * the flush writes anything, so the same intent can never be replayed into a
+ * second account (and a concurrent flush call finds nothing to act on).
+ */
+function consumeSaveIntent(): string | null {
+  try {
+    const v = sessionStorage.getItem(SAVE_INTENT_KEY)
+    if (v) sessionStorage.removeItem(SAVE_INTENT_KEY)
+    return v
+  } catch {
+    return null
+  }
+}
+
 let flushing = false
 
 /**
  * Write the pending attempt to Supabase for `userId`. Self-guards against
- * concurrent calls and missing/expired payloads, so it is safe to call from
- * every auth transition. On a partial write the attempt row is deleted and
- * the pending copy is KEPT for a later retry. Returns true when a pending
- * attempt was fully saved.
+ * concurrent calls, missing/expired payloads, AND the absence of an explicit,
+ * matching save intent, so it is safe to call from every auth transition: a
+ * passive or unrelated sign-in (no save CTA click) leaves the snapshot
+ * untouched. On a partial write the attempt row is deleted and the pending copy
+ * is KEPT (but the single-use intent is already gone). Returns true when a
+ * pending attempt was fully saved.
  */
 export async function flushPendingAttempt(userId: string): Promise<boolean> {
   if (flushing) return false
   const pending = readPendingAttempt()
   if (!pending) return false
+  // Owner binding: only flush when the guest explicitly asked to save THIS
+  // attempt (the results-screen CTA set a matching intent). Consumed up front so
+  // it is strictly single-use - it can never be replayed into a second account,
+  // and only the account that completes the save flow adopts the snapshot.
+  const intent = consumeSaveIntent()
+  if (intent !== pending.certCode) return false
   flushing = true
   try {
     const supabase = await getSupabase()

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -31,7 +31,7 @@ import { KOFI_URL } from '../lib/constants'
 import { MIN_VALID_EXAM_SECONDS, MAX_MULTI_ANSWER, TIMER_PULSE_THRESHOLD } from '../lib/constants'
 import { registerExamLeaveHandler, confirmExamLeave, isIntentionalLeave, SIGN_OUT_SENTINEL, markIntentionalLeave } from '../lib/examGuard'
 import { useSignOut } from '../hooks/useSignOut'
-import { storePendingAttempt, consumePendingAttemptSavedNotice, PENDING_ATTEMPT_SAVED_EVENT, peekPendingAttempt, type PendingAttempt } from '../lib/pendingAttempt'
+import { storePendingAttempt, consumePendingAttemptSavedNotice, markPendingAttemptSaveIntent, PENDING_ATTEMPT_SAVED_EVENT, peekPendingAttempt, type PendingAttempt } from '../lib/pendingAttempt'
 import { getProviderLabel } from '../data/certifications'
 
 type ExamScreen = 'start' | 'exam' | 'results' | 'review'
@@ -818,6 +818,10 @@ export function MockExam() {
           {!user && (
             <UnlockCTA
               onSignIn={() => {
+                // Bind the stored snapshot to THIS save action: flushPendingAttempt
+                // only writes it to the account that completes this sign-in, so a
+                // passive/unrelated sign-in on a shared device never adopts it.
+                markPendingAttemptSaveIntent(cert.code)
                 // Remember to re-show this result if the guest returns via
                 // "Continue as guest" instead of signing in (P1-6).
                 try { sessionStorage.setItem(RESUME_RESULTS_KEY, cert.code) } catch { /* ignore */ }


### PR DESCRIPTION
## The bug (P2, privacy / data-integrity)

A logged-out guest who finishes a mock exam (>=60s) gets the attempt snapshotted to
`localStorage`. `flushPendingAttempt(userId)` then wrote that snapshot (the `exam_attempts`
row, every `attempt_questions` row, and recomputed `domain_progress`/mastery) into **whatever
`userId` the next signed-in transition supplied**, with no check that the signer created the
snapshot. On a shared device (library / kiosk / family) a **different** person signing into
**their own** account within the 24h TTL got the guest's attempt + per-domain mastery written
into their account: a phantom exam in their history and permanently polluted mastery feeding
spaced repetition. RLS does not protect (rows are written under the signer's own id). The flush
also fired on every passive transition (`INITIAL_SESSION` / `TOKEN_REFRESHED` / getSession-restore).

Source: `.kiro/ux/EDGE-CASE-FINDINGS-2026-06-28.md` -
`pending-attempt-cross-account-contamination` (surface 1) +
`rls-pending-attempt-cross-account-misattribution` (surface 4, same bug).

## The fix

Bind the snapshot to an explicit, single-use **save intent**:

- **`pendingAttempt.ts`** - new `markPendingAttemptSaveIntent(certCode)` (sessionStorage, per-tab).
  `flushPendingAttempt` now refuses to write unless a save intent is present **and names the same
  cert**, and consumes it **before** any write, so it is strictly single-use (never replayable into
  a second account). A passive or unrelated sign-in leaves the snapshot untouched (it expires via TTL).
- **`_MockExam.tsx`** - the results-screen "Sign in to save this attempt" CTA sets the intent. The
  generic start-screen nudge does not (there is no finished attempt yet).
- **`useAuth.ts`** - dropped the passive getSession-restore flush; the remaining flush skips bare
  `TOKEN_REFRESHED` / `USER_UPDATED`. `SIGNED_IN` is the genuine save flow and `INITIAL_SESSION`
  carries the same intent-gated session for the in-tab return from `/login` (which is how the legit
  save flow's flush actually fires - the post-login redirect is a full navigation).

The intent gate is the real boundary; the event filter is defense-in-depth. Scoring, the save
schema, and the Supabase auth flow are untouched.

### Residual (accepted, plan-noted)
A guest who clicks save then **abandons**, and a **different** person who reuses **that exact tab**
to sign in, still flushes. Narrowed to same-tab + lingering intent + 24h TTL (vs. the old "any
account, any sign-in, even a fresh-tab reload"). Per the audit fix direction, the alternative is to
let the TTL expire it.

## Conversion funnel: intact
The legitimate path still works: guest clicks "Sign in to save this attempt" -> signs into the
intended account -> attempt saved -> `?saved=1` history redirect. Validated by the seeded **positive**
e2e (INITIAL_SESSION + intent => write) and the existing P1-6 rehydrate e2e.

## Tests (test-first)
- **Unit** `src/lib/pendingAttempt.test.ts` (5): no-intent flush is a no-op (no insert, snapshot left
  intact); matching intent flushes exactly once for the intended user; wrong-cert intent no-op;
  intent single-use / no replay into a second account; intent-without-snapshot no-op.
- **e2e** `e2e/pending-attempt-owner-binding.spec.ts` (seeded harness, CI): **negative** - a passive
  seeded session + pending attempt + no intent fires NO `exam_attempts`/`attempt_questions` write;
  **positive** - with the intent set, the write fires (proves the capture works, so the negative is
  not vacuous). The live `SIGNED_IN` save flow is real-creds only (Turnstile-gated).

## Verification
- `npm run lint` (touched files clean), `npm run test` (230 passed, +5), `npm run build`
  (prebuild/postbuild guards green), `npm run e2e` (97 passed / 9 real-creds skipped, incl. the 2 new
  specs and all guest-funnel/rehydrate specs).
- Build-regenerated artifacts (`public/llms.txt`, `public/sitemap.xml`, `functions/_csp.generated.js`)
  restored, not committed.

## Merge
Do **not** merge without an explicit owner go (live site). No DB / schema / RLS / scoring changes;
rollback = revert.