### PR TITLE
fix(exam): harden mock-exam flow - retake modal, timer clamp, save notices (PR-4a)

### DIFF
--- a/e2e/mock-exam-hardening.spec.ts
+++ b/e2e/mock-exam-hardening.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect, type Page } from '@playwright/test'
+import { seedSession } from './seededSession'
+
+/**
+ * PR-4a: mock-exam flow hardening.
+ * Source: EDGE-CASE-FINDINGS-2026-06-28.md surface 1.
+ *
+ * Covers the user-visible flow defects:
+ *  - retake re-opens the stale "Ready to submit?" modal over question 1 (item 1)
+ *  - a signed-in sub-60s submit is silently not saved, with no notice (item 2)
+ *  - a stale "attempt saved" notice bounces a deliberate exam start to /history (item 4)
+ *  - the "Saving your attempt..." loader fires with no save intent (item 4b)
+ *
+ * The pure timing clamp (item 3) is covered by scoring.test.ts (computeExamTiming);
+ * it needs clock control that is cleaner as a node unit test.
+ *
+ * Guest tests need no backend; the signed-in tests use the seeded-session fixture
+ * (no real Supabase / Turnstile).
+ */
+
+test.use({ reducedMotion: 'reduce' })
+
+const EXAM_URL = '/aws/clf-c02/practice-exam'
+const PENDING_KEY = 'cloudcertprep_pending_attempt'
+const INTENT_KEY = 'cloudcertprep_pending_attempt_intent'
+const SAVED_NOTICE_KEY = 'cloudcertprep_pending_attempt_saved'
+
+/** Start the exam and wait until the timed exam screen is active. */
+async function startExam(page: Page) {
+  await page.getByRole('button', { name: 'Start exam', exact: true }).click()
+  await page.waitForFunction(() => document.body.dataset.examActive === 'true', { timeout: 25000 })
+}
+
+/** Submit the active exam through the confirm modal -> results screen. */
+async function submitExam(page: Page) {
+  await page.getByRole('button', { name: 'Submit exam' }).first().click()
+  const dialog = page.getByRole('dialog', { name: 'Ready to submit?' })
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Submit for grading' }).click()
+  await expect(page.getByRole('button', { name: 'Retake exam' })).toBeVisible({ timeout: 15000 })
+}
+
+test('retake does not re-open the "Ready to submit?" modal over question 1', async ({ page }) => {
+  await page.goto(EXAM_URL)
+  await startExam(page)
+  await submitExam(page) // manual submit path leaves showEndModal=true (pre-fix)
+
+  await page.getByRole('button', { name: 'Retake exam' }).click()
+  await startExam(page) // mounts the exam screen again
+
+  // The stale confirm modal must NOT be open on the fresh attempt, and the user
+  // should land on a clean question 1.
+  await expect(page.getByRole('dialog', { name: 'Ready to submit?' })).toHaveCount(0)
+  await expect(page.getByText('Question 1 of', { exact: false })).toBeVisible()
+})
+
+test('signed-in sub-60s submit shows an explicit "not saved" notice', async ({ page }) => {
+  await seedSession(page)
+  await page.goto(EXAM_URL)
+  // Confirm auth has resolved so handleSubmitExam sees a logged-in user.
+  await expect(page.getByRole('button', { name: 'Account menu' }).first()).toBeVisible({ timeout: 15000 })
+
+  await startExam(page)
+  await submitExam(page) // well under 60s -> too short -> not persisted
+
+  await expect(
+    page.getByText('This attempt was too short to be saved to your history.'),
+  ).toBeVisible()
+})
+
+test('a stale "attempt saved" notice does NOT bounce a deliberate exam start to /history', async ({ page }) => {
+  await seedSession(page)
+  // A notice left over from a flush that happened on a non-exam page, older than
+  // the freshness window. Pre-fix this redirects the start screen to /history.
+  await page.addInitScript(
+    ({ key, value }) => sessionStorage.setItem(key, value),
+    { key: SAVED_NOTICE_KEY, value: `clf-c02|${Date.now() - 5 * 60 * 1000}` },
+  )
+
+  await page.goto(EXAM_URL)
+
+  // Stays on the exam start screen instead of bouncing to /history.
+  await expect(page.getByRole('button', { name: 'Start exam', exact: true })).toBeVisible({ timeout: 15000 })
+  await expect(page).toHaveURL(/\/practice-exam$/)
+})
+
+test('no "Saving your attempt..." loader for a pending attempt with no save intent', async ({ page }) => {
+  await seedSession(page)
+  // A pending attempt lingers, but the guest never clicked "Sign in to save" so
+  // there is no intent. PR-3 makes the flush a no-op here; the loader must agree.
+  await page.addInitScript(
+    ({ key, value }) => localStorage.setItem(key, value),
+    {
+      key: PENDING_KEY,
+      value: JSON.stringify({
+        certCode: 'clf-c02',
+        finishedAt: Date.now(),
+        attempt: {
+          score_percent: 80, scaled_score: 800, passed: true, time_taken_seconds: 1200,
+          total_questions: 2, correct_answers: 1, domain_scores: { '1': 100, '2': 0 },
+        },
+        questions: [
+          { question_id: 'q1', user_answer: 'A', correct_answer: 'A', is_correct: true, was_flagged: false, domain_id: 1 },
+        ],
+      }),
+    },
+  )
+
+  await page.goto(EXAM_URL)
+
+  // The loader effect is gated on `user`, so the pre-fix spinner can only appear
+  // AFTER auth resolves. Wait for the signed-in chrome, then let the gated effect
+  // (setTimeout 0) settle - pre-fix this is exactly when "Saving your attempt..."
+  // would replace the start screen for up to 8s.
+  await expect(page.getByRole('button', { name: 'Account menu' }).first()).toBeVisible({ timeout: 15000 })
+  await page.waitForTimeout(500)
+
+  await expect(page.getByText('Saving your attempt...')).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Start exam', exact: true })).toBeVisible()
+  // Sanity: intent really is absent (this is what gates the loader).
+  expect(await page.evaluate((k) => sessionStorage.getItem(k), INTENT_KEY)).toBeNull()
+})

--- a/src/lib/pendingAttempt.test.ts
+++ b/src/lib/pendingAttempt.test.ts
@@ -4,6 +4,8 @@ import {
   flushPendingAttempt,
   markPendingAttemptSaveIntent,
   hasPendingAttempt,
+  hasPendingAttemptSaveIntent,
+  consumePendingAttemptSavedNotice,
   type PendingAttempt,
 } from './pendingAttempt'
 
@@ -183,5 +185,54 @@ describe('flushPendingAttempt: save-intent gating', () => {
 
     expect(saved).toBe(false)
     expect(mocks.examInsert).not.toHaveBeenCalled()
+  })
+})
+
+const SAVED_NOTICE_KEY = 'cloudcertprep_pending_attempt_saved'
+
+describe('hasPendingAttemptSaveIntent', () => {
+  it('is false when no intent is set', () => {
+    expect(hasPendingAttemptSaveIntent()).toBe(false)
+  })
+
+  it('is true after the save CTA marks an intent, and does NOT consume it', () => {
+    markPendingAttemptSaveIntent('clf-c02')
+    // Peek-only: reading it must not disarm the real flush, so a second read
+    // still sees it.
+    expect(hasPendingAttemptSaveIntent()).toBe(true)
+    expect(hasPendingAttemptSaveIntent()).toBe(true)
+  })
+})
+
+describe('consumePendingAttemptSavedNotice: freshness window', () => {
+  it('returns the cert code for a fresh notice, then clears it (one-shot)', () => {
+    sessionStorage.setItem(SAVED_NOTICE_KEY, `clf-c02|${Date.now()}`)
+
+    expect(consumePendingAttemptSavedNotice()).toBe('clf-c02')
+    // One-shot: a second read finds nothing.
+    expect(consumePendingAttemptSavedNotice()).toBeNull()
+  })
+
+  it('ignores (and clears) a stale notice set while no exam island was mounted', () => {
+    // > SAVED_NOTICE_TTL_MS (60s) old: the header-sign-in / failed-flush-retry leak.
+    sessionStorage.setItem(SAVED_NOTICE_KEY, `clf-c02|${Date.now() - 5 * 60 * 1000}`)
+
+    expect(consumePendingAttemptSavedNotice()).toBeNull()
+    // Cleared on read so it can't accumulate or misfire later.
+    expect(sessionStorage.getItem(SAVED_NOTICE_KEY)).toBeNull()
+  })
+
+  it('ignores a legacy notice that carries no timestamp', () => {
+    sessionStorage.setItem(SAVED_NOTICE_KEY, 'clf-c02')
+
+    expect(consumePendingAttemptSavedNotice()).toBeNull()
+  })
+
+  it('a successful flush writes a fresh, honored notice', async () => {
+    storePendingAttempt(makePending('clf-c02'))
+    markPendingAttemptSaveIntent('clf-c02')
+
+    expect(await flushPendingAttempt('intended-user-A')).toBe(true)
+    expect(consumePendingAttemptSavedNotice()).toBe('clf-c02')
   })
 })

--- a/src/lib/pendingAttempt.ts
+++ b/src/lib/pendingAttempt.ts
@@ -37,6 +37,14 @@ const SAVED_NOTICE_KEY = 'cloudcertprep_pending_attempt_saved'
 // the same tab, exactly like RESUME_RESULTS_KEY / SAVED_NOTICE_KEY.
 const SAVE_INTENT_KEY = 'cloudcertprep_pending_attempt_intent'
 const PENDING_TTL_MS = 24 * 60 * 60 * 1000
+// Freshness window for the "attempt saved" notice. A successful flush lands a
+// second or two before the exam island remounts (the post-login redirect), so
+// the notice only needs to survive that brief gap. Bounding it stops a notice
+// set while NO exam island was mounted (a header sign-in that lands on home, or
+// a failed-flush retry on a marketing page) from lingering in the tab's
+// sessionStorage and later hijacking a deliberate mock-exam start with a bounce
+// to /history. (EDGE-CASE stale-pending-saved-notice-bounces-to-history)
+const SAVED_NOTICE_TTL_MS = 60 * 1000
 
 /**
  * Fired after a successful flush. The exam island listens for it IN ADDITION
@@ -121,12 +129,25 @@ export function peekPendingAttempt(): PendingAttempt | null {
  * the user is still on /login (the SIGNED_IN event), before the exam island
  * remounts, so a window event would be missed; a sessionStorage flag survives
  * the route change. Returns the cert code once, then clears.
+ *
+ * The notice is stored as `${certCode}|${flushEpochMs}` and only honored within
+ * SAVED_NOTICE_TTL_MS: a notice set while no exam island was mounted (header
+ * sign-in -> home, or a failed-flush retry on a non-exam page) is read-and-
+ * cleared but treated as expired, so it cannot bounce a deliberate later
+ * exam-start to /history. A legacy notice with no timestamp is likewise ignored
+ * (and cleared).
  */
 export function consumePendingAttemptSavedNotice(): string | null {
   try {
     const v = sessionStorage.getItem(SAVED_NOTICE_KEY)
-    if (v) sessionStorage.removeItem(SAVED_NOTICE_KEY)
-    return v
+    if (!v) return null
+    // Always clear on read - the notice is one-shot regardless of freshness.
+    sessionStorage.removeItem(SAVED_NOTICE_KEY)
+    const sep = v.lastIndexOf('|')
+    if (sep === -1) return null
+    const ts = Number(v.slice(sep + 1))
+    if (!Number.isFinite(ts) || Date.now() - ts > SAVED_NOTICE_TTL_MS) return null
+    return v.slice(0, sep)
   } catch {
     return null
   }
@@ -144,6 +165,21 @@ export function markPendingAttemptSaveIntent(certCode: string): void {
     sessionStorage.setItem(SAVE_INTENT_KEY, certCode)
   } catch {
     // sessionStorage unavailable: the attempt just won't auto-save on sign-in.
+  }
+}
+
+/**
+ * True when a save intent is currently set, WITHOUT consuming it. The exam
+ * island reads this to decide whether to show its "Saving your attempt..."
+ * loader: PR-3 gated the actual flush on the intent, so a stale, no-intent
+ * pending attempt no longer saves and must not show a spurious spinner either.
+ * Peek-only so this read never disarms the real flush. (item 4b)
+ */
+export function hasPendingAttemptSaveIntent(): boolean {
+  try {
+    return sessionStorage.getItem(SAVE_INTENT_KEY) !== null
+  } catch {
+    return false
   }
 }
 
@@ -225,7 +261,9 @@ export async function flushPendingAttempt(userId: string): Promise<boolean> {
     }
 
     localStorage.removeItem(PENDING_KEY)
-    try { sessionStorage.setItem(SAVED_NOTICE_KEY, pending.certCode) } catch { /* ignore */ }
+    // Stamp the notice with the flush time so a stale one (set on a non-exam
+    // page) cannot bounce a deliberate later exam start to /history. (item 4)
+    try { sessionStorage.setItem(SAVED_NOTICE_KEY, `${pending.certCode}|${Date.now()}`) } catch { /* ignore */ }
     window.dispatchEvent(new Event(PENDING_ATTEMPT_SAVED_EVENT))
     return true
   } catch (error: unknown) {

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -8,7 +8,9 @@ import {
   isAnswerCorrect,
   correctAnswerFor,
   getExamDomainTargets,
+  computeExamTiming,
 } from './scoring'
+import { MIN_VALID_EXAM_SECONDS } from './constants'
 import type { Certification } from '../data/certifications'
 import type { Question } from '../types'
 
@@ -223,5 +225,53 @@ describe('correctAnswerFor', () => {
   it('returns sorted K:T tokens for matching questions', () => {
     expect(correctAnswerFor({ ...base, type: 'matching', correctMatches: { B: '2', A: '3', C: '1' } }))
       .toEqual(['A:3', 'B:2', 'C:1'])
+  })
+})
+
+describe('computeExamTiming', () => {
+  // 90-minute exam, like CLF-C02.
+  const EXAM_SECONDS = 90 * 60
+
+  it('reports the real elapsed time for a normal full-length attempt', () => {
+    const start = 1_000_000
+    const now = start + 45 * 60 * 1000 // 45 minutes later
+    expect(computeExamTiming(start, now, EXAM_SECONDS)).toEqual({
+      timeTaken: 45 * 60,
+      isTooShort: false,
+    })
+  })
+
+  it('flags a genuine sub-minute attempt as too short', () => {
+    const start = 1_000_000
+    const now = start + 30 * 1000 // 30 seconds
+    const { timeTaken, isTooShort } = computeExamTiming(start, now, EXAM_SECONDS)
+    expect(timeTaken).toBe(30)
+    expect(timeTaken).toBeLessThan(MIN_VALID_EXAM_SECONDS)
+    expect(isTooShort).toBe(true)
+  })
+
+  it('treats exactly MIN_VALID_EXAM_SECONDS as long enough (boundary)', () => {
+    const start = 1_000_000
+    const now = start + MIN_VALID_EXAM_SECONDS * 1000
+    expect(computeExamTiming(start, now, EXAM_SECONDS).isTooShort).toBe(false)
+  })
+
+  it('clamps a forward clock jump / device sleep to the exam length (no inflated time)', () => {
+    // Laptop slept for ~3.5h mid-exam, then woke past the deadline.
+    const start = 1_000_000
+    const now = start + 3.5 * 60 * 60 * 1000
+    const { timeTaken, isTooShort } = computeExamTiming(start, now, EXAM_SECONDS)
+    expect(timeTaken).toBe(EXAM_SECONDS) // capped, not 3h30m
+    expect(isTooShort).toBe(false)
+  })
+
+  it('does NOT discard a completed attempt when the clock jumps backward (negative elapsed)', () => {
+    // NTP / manual correction moved the wall clock back during the exam.
+    const start = 1_000_000
+    const now = start - 5 * 60 * 1000 // "now" is before start
+    const { timeTaken, isTooShort } = computeExamTiming(start, now, EXAM_SECONDS)
+    expect(timeTaken).toBe(0) // floored, never negative
+    // The completed attempt must NOT be classified as a sub-minute throwaway.
+    expect(isTooShort).toBe(false)
   })
 })

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -1,6 +1,7 @@
 import type { Question, QuestionType } from '../types'
 import type { Certification } from '../data/certifications'
 import { fisherYatesShuffle, getQuestionType, matchesToTokens } from './utils'
+import { MIN_VALID_EXAM_SECONDS } from './constants'
 
 /**
  * Calculate AWS scaled score (100-1000 range)
@@ -157,4 +158,30 @@ export function formatTotalTime(minutes: number): string {
   const hours = Math.floor(minutes / 60)
   const mins = minutes % 60
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
+}
+
+/**
+ * Derive the persisted/displayed exam duration and the "too short to save" flag
+ * from wall-clock timestamps, defended against a non-monotonic `Date.now()`
+ * (device sleep/suspend, NTP or manual clock jumps) corrupting the result.
+ *
+ * - `timeTaken` is clamped to `[0, examTimeSeconds]`, so a FORWARD jump (waking a
+ *   suspended laptop) can no longer inflate the saved/shown time past the exam
+ *   length, and a BACKWARD jump can no longer go negative.
+ * - `isTooShort` is true only for a genuine sub-minute run (raw elapsed in
+ *   `[0, MIN_VALID_EXAM_SECONDS)`). A NEGATIVE raw elapsed signals the clock
+ *   moved backward on an otherwise-complete attempt, so it is NOT classified as
+ *   too short - the attempt is still saved rather than silently discarded.
+ *
+ * See EDGE-CASE-FINDINGS-2026-06-28: exam-timer-wallclock-sleep-clockjump.
+ */
+export function computeExamTiming(
+  startTimeMs: number,
+  nowMs: number,
+  examTimeSeconds: number,
+): { timeTaken: number; isTooShort: boolean } {
+  const rawElapsed = Math.floor((nowMs - startTimeMs) / 1000)
+  const timeTaken = Math.min(Math.max(0, rawElapsed), examTimeSeconds)
+  const isTooShort = rawElapsed >= 0 && rawElapsed < MIN_VALID_EXAM_SECONDS
+  return { timeTaken, isTooShort }
 }

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -18,7 +18,7 @@ import { PassFailBanner } from '../components/PassFailBanner'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import { QuestionReviewCard } from '../components/QuestionReviewCard'
 import { UnlockCTA } from '../components/landing/UnlockCTA'
-import { selectExamQuestions, calculateScaledScore, isPassed, getDomainScore, formatTime, formatTotalTime, isAnswerCorrect, correctAnswerFor, getExamDomainTargets } from '../lib/scoring'
+import { selectExamQuestions, calculateScaledScore, isPassed, getDomainScore, formatTime, formatTotalTime, isAnswerCorrect, correctAnswerFor, getExamDomainTargets, computeExamTiming } from '../lib/scoring'
 import { getSupabase } from '../lib/supabase'
 import { logError } from '../lib/logger'
 import { updateDomainProgress } from '../lib/supabaseUtils'
@@ -28,10 +28,10 @@ import { loadAllQuestions } from '../data/questions'
 import { shuffleAndMapQuestions, toggleMultiAnswer, getQuestionType, encodeAnswerForDb, type OptionKeyMap } from '../lib/utils'
 import { trackEvent, trackPageView } from '../lib/analytics'
 import { KOFI_URL } from '../lib/constants'
-import { MIN_VALID_EXAM_SECONDS, MAX_MULTI_ANSWER, TIMER_PULSE_THRESHOLD } from '../lib/constants'
+import { MAX_MULTI_ANSWER, TIMER_PULSE_THRESHOLD } from '../lib/constants'
 import { registerExamLeaveHandler, confirmExamLeave, isIntentionalLeave, SIGN_OUT_SENTINEL, markIntentionalLeave } from '../lib/examGuard'
 import { useSignOut } from '../hooks/useSignOut'
-import { storePendingAttempt, consumePendingAttemptSavedNotice, markPendingAttemptSaveIntent, PENDING_ATTEMPT_SAVED_EVENT, peekPendingAttempt, type PendingAttempt } from '../lib/pendingAttempt'
+import { storePendingAttempt, consumePendingAttemptSavedNotice, markPendingAttemptSaveIntent, PENDING_ATTEMPT_SAVED_EVENT, peekPendingAttempt, hasPendingAttemptSaveIntent, type PendingAttempt } from '../lib/pendingAttempt'
 import { getProviderLabel } from '../data/certifications'
 
 type ExamScreen = 'start' | 'exam' | 'results' | 'review'
@@ -177,6 +177,10 @@ export function MockExam() {
   // flips synchronously, so the save body runs at most once per attempt.
   const submittingRef = useRef(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  // Set when a SIGNED-IN submit is skipped as too short (or a backward clock jump
+  // makes a completed attempt look sub-minute): the results screen renders a full
+  // score, so without this the not-saved state would be silent. (item 2)
+  const [tooShortNotSaved, setTooShortNotSaved] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [startTime, setStartTime] = useState<number>(0)
   const [reviewFilter, setReviewFilter] = useState<'all' | 'incorrect' | 'flagged'>('all')
@@ -320,7 +324,13 @@ export function MockExam() {
   // loader instead of the start screen so they don't see the intro flash.
   useEffect(() => {
     if (!user || screen !== 'start') return
-    const t = window.setTimeout(() => { if (peekPendingAttempt()) setSavingToHistory(true) }, 0)
+    // Only show the loader when a flush is genuinely coming: a pending snapshot
+    // AND a live save intent. PR-3 gated the flush itself on the intent, so a
+    // signed-in user with a stale, no-intent pending attempt would otherwise see
+    // the spinner for up to 8s while nothing actually saves. (item 4b)
+    const t = window.setTimeout(() => {
+      if (peekPendingAttempt() && hasPendingAttemptSaveIntent()) setSavingToHistory(true)
+    }, 0)
     return () => window.clearTimeout(t)
   }, [user, screen])
   // Fallback: if the flush never completes (e.g. it failed), drop the loader
@@ -378,6 +388,16 @@ export function MockExam() {
       setOptionKeyMaps(keyMaps)
       setAnswers(new Map())
       setCurrentIndex(0)
+      // Reset transient modal / notice flags so a retake starts clean. A manual
+      // submit leaves showEndModal=true; without this the "Ready to submit?"
+      // modal re-opens over question 1 of the retake (and a reflex "Submit for
+      // grading" instantly grades the fresh exam 0/total). (item 1)
+      setShowEndModal(false)
+      setShowQuestionNav(false)
+      setPendingLeaveUrl(null)
+      setPendingExternalUrl(null)
+      setSubmitError(null)
+      setTooShortNotSaved(false)
       submittingRef.current = false // re-arm the dup-submit guard for this fresh attempt
       setScreen('exam')
       setStartTime(Date.now())
@@ -474,12 +494,15 @@ export function MockExam() {
     // Clear any stale submit error from a previous attempt so a later
     // successful save doesn't keep showing "could not be saved". (M0b)
     setSubmitError(null)
+    setTooShortNotSaved(false)
     timer.pause()
 
-    const timeTaken = Math.floor((Date.now() - startTime) / 1000)
+    // Clamp the duration and the too-short test against a non-monotonic clock
+    // (device sleep, NTP / manual jumps), so a forward jump can't inflate the
+    // saved time and a backward jump can't discard a completed attempt. (item 3)
+    const { timeTaken, isTooShort } = computeExamTiming(startTime, Date.now(), cert.examTimeSeconds)
     const isGuest = !user
-    const isTooShort = timeTaken < MIN_VALID_EXAM_SECONDS
-    
+
     const results = questions.map((q, idx) => {
       const state = answers.get(idx)
       const type = getQuestionType(q)
@@ -597,6 +620,12 @@ export function MockExam() {
             domain_id: r.domainId,
           })),
         })
+      } else if (!isGuest && isTooShort) {
+        // Signed in, but the run was too short to count as a real attempt, so
+        // nothing is persisted. The results screen still renders a full score, so
+        // surface an explicit "not saved" notice rather than dropping it silently
+        // (the guest path at least has its own sign-in CTA). (item 2)
+        setTooShortNotSaved(true)
       }
     } catch (error: unknown) {
       logError('MockExam.submitExam', error)
@@ -768,6 +797,11 @@ export function MockExam() {
           {submitError && (
             <Alert tone="warning">
               {submitError}
+            </Alert>
+          )}
+          {tooShortNotSaved && (
+            <Alert tone="warning">
+              This attempt was too short to be saved to your history.
             </Alert>
           )}
 


### PR DESCRIPTION
## What & why

PR-4a of the PR-4 split (mock-exam half; the domain-practice half is PR-4b). Hardens the
mock-exam flow against five confirmed P2 edge cases from
`.kiro/ux/EDGE-CASE-FINDINGS-2026-06-28.md` (surface 1). No scoring math or save-schema
changes.

| # | Bug | Fix |
|---|-----|-----|
| 1 | Manual submit leaves the "Ready to submit?" modal open, so a **retake** mounts with it open over question 1 (a reflex "Submit for grading" grades the fresh exam 0/total) | `startExam()` resets the transient modal/notice flags (`showEndModal`, `showQuestionNav`, `pendingLeaveUrl`, `pendingExternalUrl`, `submitError`, `tooShortNotSaved`) |
| 2 | Signed-in **sub-60s submit** is silently not saved, with no notice | results screen shows an explicit "This attempt was too short to be saved to your history." Alert |
| 3 | Wall-clock **timer**: forward jump/device-sleep inflates `time_taken`; backward jump discards a completed attempt | pure `computeExamTiming()` helper clamps `timeTaken` to `[0, examTimeSeconds]` and makes `isTooShort` false for negative raw elapsed |
| 4 | Stale "attempt saved" notice **bounces a fresh exam start to /history** | notice is timestamped (`certCode\|ms`) and only honored within a 60s freshness window |
| 4b | Follow-on to #117: "Saving your attempt..." **spinner fires with no real save** | loader gated on `hasPendingAttemptSaveIntent()` too |

The timer countdown is intentionally left wall-clock (auto-submit-after-sleep is defensible);
only the persisted/displayed values are hardened, per the finding's scope note.

## Finding refs
- `_MockExam.tsx:146` (retake modal), `:480-481` (sub-60s), `useTimer.ts:41` / `_MockExam.tsx:479` (timer), `pendingAttempt.ts:113` (stale notice), follow-on from PR-3 (#117) for the spinner.

## Tests
- **Unit (Vitest, node):** `scoring.test.ts` -> `computeExamTiming` (forward-clamp, backward-no-discard, boundary, normal); `pendingAttempt.test.ts` -> notice freshness TTL + `hasPendingAttemptSaveIntent` peek.
- **e2e (Playwright):** `mock-exam-hardening.spec.ts` -> 4 flows (retake-no-modal, seeded sub-60s notice, stale-notice no-bounce, no-spurious-spinner). **Verified non-vacuous**: all 4 fail against the pre-fix build, pass after.

## Verification
- `npm run build` (prebuild + postbuild guards) green; build-regenerated artifacts restored.
- `npm run test` -> 248 unit tests green. `scoring.test.ts` + `examGuard.test.ts` pass (no scoring/guard regression).
- `npm run lint` clean for all changed files (2 repo-wide reports are pre-existing/local-only: a gitignored `.kiro` archive file and an existing `_Stats.tsx` warning).
- Related e2e specs (pending-attempt-owner-binding, conversion-events, practice-menu, flows, seeded) pass (one `github_click` failure is a known parallel-load flake; passes in isolation).

## Not merging
Per the #114 lesson (live site), holding for an owner go + a manual sanity pass on the exam happy path (normal full-length submit still saves).
