### PR TITLE
fix(practice): harden domain-practice leave-guards + start error (PR-4b)

### DIFF
--- a/e2e/domain-practice-hardening.spec.ts
+++ b/e2e/domain-practice-hardening.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * PR-4b: domain-practice flow hardening.
+ * Source: EDGE-CASE-FINDINGS-2026-06-28.md surface 5.
+ *
+ *  - browser/device Back during practice silently discards answers (item 5)
+ *  - the mobile cert-switcher bypasses the "Leave practice?" confirm (item 6)
+ *  - startPractice has no catch, so a failed chunk fetch dead-ends Start (item 7)
+ *
+ * All guest-compatible (domain practice runs without an account).
+ */
+
+test.use({ reducedMotion: 'reduce' })
+
+const PRACTICE_URL = '/aws/clf-c02/domain-practice'
+
+/** From the selection screen: pick the first domain, start, wait until active. */
+async function startFirstDomainSession(page: Page) {
+  await page.getByRole('button', { name: /^Practice .+questions$/ }).first().click()
+  await page.getByRole('button', { name: 'Start practice', exact: true }).click()
+  await page.waitForFunction(() => document.body.dataset.practiceActive === 'true', { timeout: 25000 })
+  // The question screen is up (proves the session mounted).
+  await expect(page.getByText(/Question 1 of \d+/)).toBeVisible()
+}
+
+test('browser Back during practice asks to confirm instead of discarding the session', async ({ page }) => {
+  await page.goto(PRACTICE_URL)
+  await startFirstDomainSession(page)
+
+  // Device/browser Back. Pre-fix this pops ?domain= and silently drops the
+  // session to the selection screen.
+  await page.evaluate(() => window.history.back())
+
+  await expect(page.getByRole('dialog', { name: 'Leave practice?' })).toBeVisible()
+  // The in-progress session is still mounted (not discarded) behind the confirm.
+  await expect(page.getByText(/Question 1 of \d+/)).toBeVisible()
+
+  // "Keep practicing" dismisses and leaves the user mid-session.
+  await page.getByRole('button', { name: 'Keep practicing' }).click()
+  await expect(page.getByRole('dialog', { name: 'Leave practice?' })).toHaveCount(0)
+  await expect(page.getByText(/Question 1 of \d+/)).toBeVisible()
+
+  // A second Back, this time confirmed, discards the session and lands on the
+  // domain-selection screen (no ?domain in the URL).
+  await page.evaluate(() => window.history.back())
+  await expect(page.getByRole('dialog', { name: 'Leave practice?' })).toBeVisible()
+  await page.getByRole('button', { name: 'Leave practice' }).click()
+  await expect(page.getByRole('heading', { name: /Domain Practice/ })).toBeVisible({ timeout: 15000 })
+  await expect(page).toHaveURL(/\/domain-practice$/)
+})
+
+test('mobile cert-switcher routes through the "Leave practice?" confirm', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto(PRACTICE_URL)
+  await startFirstDomainSession(page)
+
+  // Open the drawer and pick the OTHER cert from the mobile cert-switcher. Its
+  // entries are <button>s (not anchors), so the islands' anchor-capture leave
+  // guard never sees them - selectCert must route through guardExamLeave itself.
+  const toggle = page.getByRole('button', { name: 'Toggle menu' })
+  await expect(async () => {
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click()
+    await expect(page.getByRole('dialog', { name: 'Menu' })).toBeVisible({ timeout: 1000 })
+  }).toPass({ timeout: 15000 })
+  const drawer = page.getByRole('dialog', { name: 'Menu' })
+  await drawer.getByRole('button', { name: /AIF-C01/ }).click()
+
+  await expect(page.getByRole('dialog', { name: 'Leave practice?' })).toBeVisible()
+})
+
+test('a failed question-chunk fetch surfaces a retryable error instead of a dead Start button', async ({ page }) => {
+  // Force the domain-1 question chunk to fail (offline / network error).
+  await page.route(/domain1\.[^/]*\.js(\?|$)/, route => route.abort())
+
+  await page.goto(PRACTICE_URL)
+  await page.getByRole('button', { name: /^Practice .+questions$/ }).first().click()
+  await page.getByRole('button', { name: 'Start practice', exact: true }).click()
+
+  // The catch surfaces the error on the config screen, and Start is re-enabled.
+  await expect(page.getByText(/Could not start practice\./)).toBeVisible({ timeout: 15000 })
+  await expect(page.getByRole('button', { name: 'Start practice', exact: true })).toBeEnabled()
+})

--- a/src/components/CertSwitcher.tsx
+++ b/src/components/CertSwitcher.tsx
@@ -2,6 +2,7 @@ import { useSyncExternalStore } from 'react'
 import { Check } from 'lucide-react'
 import { setActiveCert } from '../hooks/useCert'
 import { useExamActive } from '../hooks/useExamActive'
+import { guardExamLeave } from '../lib/examGuard'
 import { subscribeLocationChange } from '../lib/locationChange'
 import { getSortedCerts, getProviderLabel, getCertByPath, CERTIFICATIONS, DEFAULT_CERT_ID } from '../data/certifications'
 import type { Certification } from '../data/certifications'
@@ -147,13 +148,26 @@ export function CertSwitcher({ variant, onSelect, initialPathname }: CertSwitche
       onSelect?.()
       return
     }
+    const url = certTargetPath(target, pathname)
+    // During an active exam OR practice session, route the cert switch through
+    // the leave-confirm broker (the session island owns the navigation on
+    // confirm) instead of silently discarding the in-progress session. This is
+    // what the mobile switcher buttons need: unlike the desktop anchors, a
+    // <button> is not caught by the islands' anchor-capture leave guard. Matches
+    // the header Sign in / Sign out buttons. When guarded we must NOT also
+    // navigate here, and the active cert is persisted by useCert on the target
+    // page after the confirmed reload, so skip setActiveCert too.
+    if (guardExamLeave(url)) {
+      onSelect?.()
+      return
+    }
     setActiveCert(target.code)
     onSelect?.()
     // Real document navigation: each cert page is a separate Astro document,
     // so we must trigger a full browser navigation rather than a client-side
     // react-router push (which would only change the URL without loading the
     // new prerendered Astro page).
-    window.location.assign(certTargetPath(target, pathname))
+    window.location.assign(url)
   }
 
   // Build the grouped menu list shared between desktop and mobile variants.

--- a/src/pages/_DomainPractice.tsx
+++ b/src/pages/_DomainPractice.tsx
@@ -85,6 +85,10 @@ export function DomainPractice() {
   const [selectedQuestionIndex, setSelectedQuestionIndex] = useState(0)
   const [optionKeyMaps, setOptionKeyMaps] = useState<Map<string, OptionKeyMap>>(new Map())
   const [loading, setLoading] = useState(false)
+  // Surfaced on the config screen when the question-chunk fetch fails, so a
+  // failed start is a visible, retryable error instead of a dead Start button
+  // (mirrors the mock exam's loadError). (item 7)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [answering, setAnswering] = useState(false)
   const [pendingLeaveUrl, setPendingLeaveUrl] = useState<string | null>(null)
   // "End session early" confirm. Distinct from the leave guard: ending the
@@ -218,6 +222,35 @@ export function DomainPractice() {
     return () => { delete document.body.dataset.practiceActive; cleanup() }
   }, [effectiveScreen, questions.length])
 
+  // Guard browser/device Back during an active practice session. The session
+  // lives only in this island's memory (persisted at finishPractice), and Back
+  // drops the ?domain= param, so effectiveScreen would silently fall to
+  // 'selection' and discard the answers. The anchor-capture + beforeunload
+  // guards don't see a same-document history pop, and re-pinning via react-router
+  // loses to its own popstate handling, so instead push a DUPLICATE history entry
+  // on top of the practice URL: a Back pops onto this identical URL, react-router's
+  // location is unchanged, the session stays mounted, and we route the Back through
+  // the same "Leave practice?" confirm as every other leave. The selection screen
+  // (domainPracticePath, no ?domain) is the target the confirm honors.
+  useEffect(() => {
+    if (effectiveScreen !== 'practice' || questions.length === 0) return
+    const practiceUrl = location.pathname + location.search
+    window.history.pushState(null, '', practiceUrl)
+    function onPopState() {
+      window.history.pushState(null, '', practiceUrl) // re-arm for the next Back
+      window.dispatchEvent(new Event('cc:close-drawer'))
+      setPendingLeaveUrl(domainPracticePath)
+    }
+    window.addEventListener('popstate', onPopState)
+    return () => {
+      window.removeEventListener('popstate', onPopState)
+      // Pop the guard entry we added so a normal finish -> results -> Back needs no
+      // extra "dead" Back press. The guard shares the practice URL, so this pop
+      // changes no route (react-router reads the same location).
+      window.history.back()
+    }
+  }, [effectiveScreen, questions.length, location.pathname, location.search, domainPracticePath])
+
   function confirmPracticeLeave() {
     if (!pendingLeaveUrl) return
     if (pendingLeaveUrl === SIGN_OUT_SENTINEL) {
@@ -254,6 +287,7 @@ export function DomainPractice() {
 
   async function startPractice() {
     setLoading(true)
+    setLoadError(null)
     try {
       // Re-fetch mastery data so back-to-back sessions use fresh weights
       await refreshMastery()
@@ -280,6 +314,13 @@ export function DomainPractice() {
       // Keep the visitor "online" in Umami during the practice session by
       // emitting a virtual page view (see MockExam, task 13.10). (R15.5)
       trackPageView(`/${cert.provider}/${cert.code}/domain-practice/active`)
+    } catch (err: unknown) {
+      // A failed chunk fetch (offline / network) used to dead-end the Start
+      // button silently because there was no catch. Surface a retryable error
+      // instead, matching the mock exam's startExam. (item 7)
+      const msg = err instanceof Error ? err.message : 'Failed to load questions'
+      setLoadError(`Could not start practice. ${msg}. Please check your connection and try again.`)
+      logError('DomainPractice.startPractice', err)
     } finally {
       setLoading(false)
     }
@@ -539,6 +580,12 @@ export function DomainPractice() {
                 </p>
               )}
             </div>
+
+            {loadError && (
+              <Alert tone="danger" role="alert" className="mb-4 md:mb-6 text-sm">
+                {loadError}
+              </Alert>
+            )}
 
             <div className="flex gap-4">
               <Button


### PR DESCRIPTION
## What & why

PR-4b of the PR-4 split (domain-practice half; the mock-exam half is PR-4a / #118).
Hardens domain-practice leave-guards and start-error handling against three confirmed P2
edge cases from `.kiro/ux/EDGE-CASE-FINDINGS-2026-06-28.md` (surface 5). No scoring or
save-schema changes.

| # | Bug | Fix |
|---|-----|-----|
| 5 | **Browser/device Back** during practice silently discards the answers (drops `?domain=`, falls to the selection screen) | the island pushes a **duplicate history entry** on top of the practice URL while a session is active, so Back pops onto an identical URL (react-router location unchanged, session stays mounted) and routes through the same "Leave practice?" confirm; the guard entry is popped on cleanup so finish -> results -> Back needs no extra press |
| 6 | **Mobile cert-switcher** buttons bypass "Leave practice?" (the buttons aren't anchors, so the anchor-capture guard never sees them) | `selectCert` routes through `guardExamLeave` (like the header Sign in / Sign out buttons) |
| 7 | `startPractice` has **no catch**, so a failed chunk fetch dead-ends the Start button | added a catch that surfaces a retryable error on the config screen + re-enables Start (mirrors `startExam`) |

### Why the duplicate-history-entry for #5
The practice screen derives `selectedDomain` from react-router's `useLocation()`. On Back,
react-router processes the popstate first and re-pinning via `navigate()` synchronously inside
the handler is lost (verified empirically: URL drops `?domain=`, `practiceActive` clears). Pushing
a duplicate entry means the guarded Back never changes react-router's location at all.

## Finding refs
- `_DomainPractice.tsx:62` (Back), `CertSwitcher.tsx:122` (mobile switch), `_DomainPractice.tsx:255` (no catch).

## Tests
- **e2e (Playwright, guest):** `domain-practice-hardening.spec.ts` -> (1) Back -> confirm, "Keep practicing" keeps the session, a second confirmed Back discards to selection; (2) mobile drawer cert-switch -> "Leave practice?"; (3) aborted domain chunk -> retryable error + enabled Start. **Verified non-vacuous**: all 3 fail against the pre-fix build, pass after.
- Manually verified finish -> results -> Back lands on selection in one press (cleanup-pop works).

## Verification
- `npm run build` (prebuild + postbuild guards) green; build-regenerated artifacts restored.
- `npm run test` -> 237 unit tests green; `examGuard.test.ts` unchanged and passing.
- Lint clean for all changed files.
- Related e2e specs (practice-menu, flows, seeded, conversion-events) pass - no nav regression from the history guard or the cert-switcher change.

## Out of scope (noted in the finding)
The optional follow-on - `finishPractice` silently discarding a signed-in user's results on a
mid-session session-drop (`practice-finish-session-drop-silent-discard`) - is left for a later
pass to keep this PR surgical.

## Not merging
Holding for an owner go + a manual sanity pass on the practice happy path.
