### PR TITLE
fix(ux): eliminate cert-hub CLS + FOUC + account/login layout shifts (PR-5)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -413,6 +413,22 @@ header[data-overlay]:not(.hdr-scrolled) {
   -webkit-backdrop-filter: none !important;
   backdrop-filter: none !important;
 }
+/* For authenticated users (cc-authed class on <html>), restore the frosted
+   header state immediately on paint so there is no white-text-on-light-bg
+   flash before the end-of-body script removes [data-overlay]. The JS script
+   still runs and removes the attribute; this CSS merely covers the ~50ms gap.
+   Two rules: light and dark need separate --color-on-header values (the generic
+   overlay rule always sets white, which is invisible on the light frosted bar). */
+html.cc-authed header[data-overlay]:not(.hdr-scrolled) {
+  --color-on-header: 22 25 31;
+  background-color: rgb(var(--color-header-bg) / 0.7) !important;
+  border-color: rgb(var(--color-border) / 0.6) !important;
+  -webkit-backdrop-filter: blur(24px) saturate(150%) !important;
+  backdrop-filter: blur(24px) saturate(150%) !important;
+}
+html.dark.cc-authed header[data-overlay]:not(.hdr-scrolled) {
+  --color-on-header: 244 246 248;
+}
 
 /* Stage grain: subtle film noise so the gradient reads printed, not
    vector-flat. Pure CSS data-URI — zero JS. */

--- a/src/pages/_Account.tsx
+++ b/src/pages/_Account.tsx
@@ -108,7 +108,7 @@ export function Account() {
 
   if (authLoading) {
     return (
-      <div className="flex-1 flex items-center justify-center p-8">
+      <div className="p-4 md:p-8 min-h-[320px]">
         <LoadingSpinner text="Loading your account..." />
       </div>
     )

--- a/src/pages/_Login.tsx
+++ b/src/pages/_Login.tsx
@@ -572,12 +572,6 @@ export function Login() {
             </>
           )}
 
-          {error && (
-            <Alert tone="danger" role="alert" className="text-danger">
-              <span id="auth-error">{error}</span>
-            </Alert>
-          )}
-
           {success && (
             <Alert tone="success" role="status">
               {success}
@@ -601,7 +595,7 @@ export function Login() {
               // primary CTA here only made it look broken on load. The submit
               // handlers validate the captcha and show an inline message if the
               // challenge isn't solved. (Sign-up form requirements still gate,
-              // since those have visible inline feedback.)
+              // since those have visible invalid feedback.)
               (isSignUp && !acceptedTerms) ||
               (isSignUp && !isPasswordStrongEnough(password)) ||
               (isSignUp && password !== confirmPassword) ||
@@ -612,6 +606,14 @@ export function Login() {
               ? (resetCooldown > 0 ? `Resend in ${resetCooldown}s` : 'Send reset link')
               : isSignUp ? 'Sign up' : 'Sign in'}
           </Button>
+
+          {/* Error rendered below the submit button so it never shoves the
+              Turnstile + CTA down when it appears (P4 CLS fix). */}
+          {error && (
+            <Alert tone="danger" role="alert" className="text-danger">
+              <span id="auth-error">{error}</span>
+            </Alert>
+          )}
         </form>
 
         <div className="mt-6 text-center">

--- a/src/pages/aws/[cert].astro
+++ b/src/pages/aws/[cert].astro
@@ -236,8 +236,11 @@ const latestPosts = (taggedPosts.length > 0 ? taggedPosts : allPosts).slice(0, 2
   <Breadcrumb items={breadcrumbItems} visuallyHidden />
 
   {/* Static GUEST view (stage hero + content sheet) — visible to crawlers and
-      logged-out users. CertDashboardIsland hides this for authenticated users. */}
-  <div id="cert-guest-view">
+      logged-out users. For active certs, cc-auth-out hides this pre-paint the
+      instant BaseLayout adds cc-authed to <html>, before CertDashboardIsland
+      hydrates (mirrors how #home-guest-hero works). Coming-soon certs omit the
+      class: a signed-in visitor still sees the coming-soon page. */}
+  <div id="cert-guest-view" class:list={[isActive && 'cc-auth-out']}>
     {/* ---- Stage hero, glow in the cert's official LEVEL color ---- */}
     <section class="stage relative overflow-hidden -mt-[calc(3rem+1px)] md:-mt-[calc(3.5rem+1px)]" style={`--stage-glow: ${levelGlow}`}>
       <div class="relative max-w-6xl mx-auto px-4 md:px-8 pt-28 md:pt-36 pb-16 md:pb-24">
@@ -384,8 +387,14 @@ const latestPosts = (taggedPosts.length > 0 ? taggedPosts : allPosts).slice(0, 2
       no question bank, so a logged-in visitor must keep seeing the coming-soon
       guest view (Watch on GitHub) rather than a practice dashboard whose CTAs
       lead to non-existent exam routes. */}
+  {/* cc-auth-in: guests see display:none (no visual gap, Lighthouse-neutral).
+      min-h reserves the above-fold dashboard height so the footer never rises
+      into view while the island resolves, matching the domain page pattern at
+      [domain].astro:368. Sized to push the footer below the fold on every
+      device: viewport height minus the sticky header (3rem mobile / 3.5rem
+      desktop per h-12 md:h-14 in Header.astro). */}
   {isActive && (
-    <div class="px-4 md:px-8">
+    <div class="cc-auth-in px-4 md:px-8 min-h-[calc(100vh-3rem)] md:min-h-[calc(100vh-3.5rem)]">
       <CertDashboardIsland cert={certForIsland} client:only="react" />
     </div>
   )}


### PR DESCRIPTION
## Summary

Four runtime layout-shift / FOUC fixes from Section 10 of MERGE-READINESS-AUDIT-2026-06-28.md. Pure CSS + minimal JSX moves; no new dependencies, no auth/scoring changes.

- **P1 (cert-hub CLS 0.31 desktop / 0.66 mobile)** - wrap `CertDashboardIsland` in `cc-auth-in min-h-[calc(100vh-3rem)] md:min-h-[calc(100vh-3.5rem)]`. Guests see `display:none` (no SEO impact, Lighthouse-neutral). Authed users get a reserved above-fold height so the footer never rises while the island resolves. Mirrors the domain page `[domain].astro:368` pattern exactly. (`aws/[cert].astro`)
- **P2 (guest-hero + overlay-header FOUC ~50-80ms)** - add `cc-auth-out` to `#cert-guest-view` on active certs so the pre-paint CSS rule hides it the instant `BaseLayout` sets `cc-authed`, before any JS runs. Add a CSS override that restores the frosted header state for authed users so the transparent white-text overlay never paints over the light background. Coming-soon certs omit the class. (`aws/[cert].astro`, `index.css`)
- **P3 (account spinner CLS 0.037/0.053)** - remove vertical centering from the loading branch and match the settled state's `p-4 md:p-8` wrapper, ending the centered-to-top reflow on resolve. (`_Account.tsx`)
- **P4 (sign-up error-alert reflow ~100px)** - move the error `Alert` below the submit button so inserting it never shoves the Turnstile + CTA downward. (`_Login.tsx`)

## Files changed

- `src/pages/aws/[cert].astro` - P1 island wrapper + P2 guest-view class
- `src/index.css` - P2 authed header overlay override (light + dark)
- `src/pages/_Account.tsx` - P3 loading state alignment
- `src/pages/_Login.tsx` - P4 error alert position

## Verification

- `npm run lint` - pre-existing 2 issues, none from this PR (confirmed against main)
- `npm run test` - 248 / 248 passed
- `npm run build` + full guard chain - all green (validate-questions, generate-seo-assets, validate-blog-frontmatter, validate-internal-links, check:citation, check:graph, check:person-graph byte-identical, csp:hash)
- Build artifacts restored after build

## Owner action needed

- Preview QA: hard-load a signed-in cert hub on desktop + mobile and confirm no footer flash (before/after CLS should drop from 0.31/0.66 to ~0). Observer harness at `.kiro/ux/uiux-audit-2026-06-28/` to re-run if desired.
- Confirm the sign-up error position (below submit button) reads naturally.

Refs: MERGE-READINESS-AUDIT-2026-06-28.md Section 10 items 1-4, all marked `[DONE PR-5 fix/uiux-runtime-cls]`.