### PR TITLE
fix(polish): C1-C4 inconsistencies + a11y/locale/comment nits (PR-6)

### DIFF
--- a/src/components/AccountLinkNotice.tsx
+++ b/src/components/AccountLinkNotice.tsx
@@ -38,10 +38,10 @@ export function AccountLinkNotice() {
         <button
           type="button"
           onClick={() => setVisible(false)}
-          className="absolute top-0.5 right-0.5 w-11 h-11 inline-flex items-center justify-center text-success hover:text-success/70 transition-colors rounded-md"
+          className="absolute top-0.5 right-0.5 w-11 h-11 inline-flex items-center justify-center text-success hover:text-success/70 transition-colors rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
           aria-label="Dismiss"
         >
-          <X className="w-4 h-4" />
+          <X className="w-4 h-4" aria-hidden="true" />
         </button>
       </Alert>
     </div>

--- a/src/components/AnswerButton.tsx
+++ b/src/components/AnswerButton.tsx
@@ -60,8 +60,8 @@ export function AnswerButton({ label, text, state, onClick, disabled, compact }:
           className={`flex-shrink-0 ${compact ? 'pt-0.5' : 'pt-0.5 md:pt-1'} ${state === 'correct' ? 'text-success' : 'text-danger'}`}
         >
           {state === 'correct'
-            ? <Check className={compact ? 'w-4 h-4' : 'w-4 h-4 md:w-5 md:h-5'} aria-label="Correct answer" />
-            : <X className={compact ? 'w-4 h-4' : 'w-4 h-4 md:w-5 md:h-5'} aria-label="Your answer (incorrect)" />}
+            ? <Check role="img" aria-label="Correct answer" className={compact ? 'w-4 h-4' : 'w-4 h-4 md:w-5 md:h-5'} />
+            : <X role="img" aria-label="Your answer (incorrect)" className={compact ? 'w-4 h-4' : 'w-4 h-4 md:w-5 md:h-5'} />}
         </span>
       )}
     </button>

--- a/src/components/AuthLinkNotice.tsx
+++ b/src/components/AuthLinkNotice.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react'
+import { useState, useEffect, type ReactNode } from 'react'
 import { CheckCircle, AlertTriangle, X } from 'lucide-react'
 import { buttonClass } from '../lib/buttonStyles'
 import { useAuth } from '../hooks/useAuth'
@@ -40,14 +40,14 @@ const ACK_KEY = 'cloudcertprep_verified_welcome_ack'
 type Notice = { kind: 'verified' } | { kind: 'expired' } | { kind: 'error' } | { kind: 'deleted' } | null
 
 /**
- * Read the auth redirect markers from the URL exactly once on mount, then strip
- * them so a refresh is clean and the notice cannot replay from the URL. Two
- * cases land on home (the Supabase Site URL):
+ * Read the auth redirect markers from the URL exactly once on mount. Pure read -
+ * no side effects (URL stripping and localStorage writes happen in a useEffect
+ * so they do not run during render, which is StrictMode-safe). Two cases land
+ * on home (the Supabase Site URL):
  *   - ?verified=1                              -> post-confirm welcome (P0-2)
  *   - ?error=...&error_code=otp_expired (or access_denied) -> dead link (P0-3)
  * `email_unverified` is the OAuth refusal handled on /login, so it is ignored
- * here. Bails before touching history/localStorage for the ~99.9% of visits
- * with no auth param, so normal traffic pays effectively nothing.
+ * here. Bails early for the ~99.9% of visits with no auth param.
  */
 function readNoticeOnce(): Notice {
   if (typeof window === 'undefined') return null
@@ -65,17 +65,11 @@ function readNoticeOnce(): Notice {
 
   if (!verified && !deleted && !isExpired && !isOtherError) return null
 
-  // Strip every auth param so a refresh is clean (mirror _Login.tsx read-once).
-  ;['verified', 'account_deleted', 'error', 'error_code', 'error_description'].forEach(k => params.delete(k))
-  const qs = params.toString()
-  window.history.replaceState(null, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash)
-
   if (isExpired) return { kind: 'expired' } // the actionable failure wins
   if (isOtherError) return { kind: 'error' } // transient/unknown failure, still actionable
   if (deleted) return { kind: 'deleted' } // post-deletion acknowledgement
   try {
     if (localStorage.getItem(ACK_KEY)) return null
-    localStorage.setItem(ACK_KEY, new Date().toISOString())
   } catch { /* private mode: still show once for this view */ }
   return { kind: 'verified' }
 }
@@ -86,6 +80,21 @@ function readNoticeOnce(): Notice {
  */
 export default function AuthLinkNotice() {
   const [notice, setNotice] = useState<Notice>(readNoticeOnce)
+
+  // Strip auth params from the URL and write the ack after mount so these
+  // side effects don't run during render (safe if StrictMode is ever added).
+  useEffect(() => {
+    if (!notice) return
+    const params = new URLSearchParams(window.location.search)
+    ;['verified', 'account_deleted', 'error', 'error_code', 'error_description'].forEach(k => params.delete(k))
+    const qs = params.toString()
+    window.history.replaceState(null, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash)
+    if (notice.kind === 'verified') {
+      try { localStorage.setItem(ACK_KEY, new Date().toISOString()) } catch { /* private mode */ }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // Reflect the REAL session, not the URL marker: a confirm link can land here
   // without an established session (confirmed on another device, cookie not
   // persisted), in which case asserting "You are signed in" is a lie that sends
@@ -132,10 +141,10 @@ export default function AuthLinkNotice() {
   }
 
   // Verified case. A just-verified user who IS signed in already gets the
-  // returning-user welcome hero on the home page (HomeWelcome), so a toast on
-  // top of it is redundant and, on small screens, overlaps that hero's heading.
-  // So only show the verified toast when the session did NOT establish - the
-  // one case where there is no welcome hero and the user must still sign in.
+  // returning-user welcome hero on the home page, so a toast on top of it is
+  // redundant and, on small screens, overlaps that hero's heading. So only show
+  // the verified toast when the session did NOT establish - the one case where
+  // there is no welcome hero and the user must still sign in.
   // Wait for auth to resolve before deciding (avoids a flash either way).
   if (authLoading) return null
   if (user) return null

--- a/src/components/CertDashboardIsland.tsx
+++ b/src/components/CertDashboardIsland.tsx
@@ -260,10 +260,10 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
               </>
             ) : (
               <>
-                <StatTile label="Questions practiced" value={questionsPracticed.toLocaleString()} suffix={`/ ${bankTotal.toLocaleString()}`} />
+                <StatTile label="Questions practiced" value={questionsPracticed.toLocaleString('en-US')} suffix={`/ ${bankTotal.toLocaleString('en-US')}`} />
                 <StatTile label="Accuracy" value={String(accuracy)} suffix="%" hint="correct / answered" />
                 <StatTile label="Mock exams" value={String(examCount)} />
-                <StatTile label="Best score" value={bestScore > 0 ? bestScore.toLocaleString() : '0'} suffix={bestScore > 0 ? `/ ${(1000).toLocaleString()}` : undefined} />
+                <StatTile label="Best score" value={bestScore > 0 ? bestScore.toLocaleString('en-US') : '0'} suffix={bestScore > 0 ? `/ ${(1000).toLocaleString('en-US')}` : undefined} />
               </>
             )}
           </div>

--- a/src/components/DomainProgressStrip.tsx
+++ b/src/components/DomainProgressStrip.tsx
@@ -50,7 +50,7 @@ function Shell({ children }: { children: React.ReactNode }) {
   )
 }
 
-function Skeleton() {
+function StripSkeleton() {
   return (
     <Shell>
       <p className="sr-only" role="status">Loading your progress</p>
@@ -113,9 +113,9 @@ function Strip(props: DomainProgressStripProps) {
   }, [loaded])
 
   // Resolving auth: a returning user gets the skeleton; a guest gets nothing.
-  if (authLoading) return authedHint ? <Skeleton /> : null
+  if (authLoading) return authedHint ? <StripSkeleton /> : null
   if (!user) return null
-  if (!loaded) return <Skeleton />
+  if (!loaded) return <StripSkeleton />
   // On a transient network/RLS error, hide the personalization rather than
   // asserting a false "Not started yet" to a user who has practiced. The
   // prerendered SEO content below is untouched (this island renders nothing).

--- a/src/components/HeaderInteractive.tsx
+++ b/src/components/HeaderInteractive.tsx
@@ -29,7 +29,7 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [drawerClosing, setDrawerClosing] = useState(false)
   const drawerRef = useRef<HTMLDivElement>(null)
-  const drawerCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const drawerCloseTimerRef = useRef<number | null>(null)
 
   // Pre-paint auth hint: BaseLayout sets `cc-authed` before first paint from
   // the localStorage token. Mirror DomainProgressStrip's pattern to show

--- a/src/components/HeaderInteractive.tsx
+++ b/src/components/HeaderInteractive.tsx
@@ -29,17 +29,26 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [drawerClosing, setDrawerClosing] = useState(false)
   const drawerRef = useRef<HTMLDivElement>(null)
+  const drawerCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Animate the drawer out before unmounting (§8 item 5). Plays the exit
-  // animation, then removes the drawer from the DOM. Reduced-motion users (or
-  // browsers without the animationend event) fall back to an immediate close
-  // via the timeout, so the menu always closes.
+  // Pre-paint auth hint: BaseLayout sets `cc-authed` before first paint from
+  // the localStorage token. Mirror DomainProgressStrip's pattern to show
+  // auth-gated nav items (Dashboard link, History, Account) immediately,
+  // without waiting for useAuth()'s async getSession() to resolve (C1).
+  const [authedHint] = useState(() =>
+    typeof document !== 'undefined' && document.documentElement.classList.contains('cc-authed'))
+  const isAuthed = authedHint || Boolean(user)
+
+  // Animate the drawer out before unmounting. Plays the 180ms (--dur-fast)
+  // exit animation, then removes the drawer from the DOM.
   const closeMobileMenu = useCallback(() => {
     setDrawerClosing(true)
-    window.setTimeout(() => {
+    if (drawerCloseTimerRef.current !== null) clearTimeout(drawerCloseTimerRef.current)
+    drawerCloseTimerRef.current = window.setTimeout(() => {
       setMobileMenuOpen(false)
       setDrawerClosing(false)
-    }, 240)
+      drawerCloseTimerRef.current = null
+    }, 180)
   }, [])
   useFocusTrap(drawerRef, mobileMenuOpen && !drawerClosing, {
     lockBodyScroll: true,
@@ -94,7 +103,7 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
           {/* Persistent primary action (P1-4): a Practice menu (every active
               cert x its practice modes), always visible in both auth states and
               on every route. Link+Disclosure widget; see PracticeMenu. */}
-          <PracticeMenu variant="desktop" isAuthed={Boolean(user)} />
+          <PracticeMenu variant="desktop" isAuthed={isAuthed} />
           <a
             href="/about"
             className="hdr-link hidden lg:inline-block text-on-header font-medium transition-colors text-sm rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-on-header focus-visible:ring-offset-2 focus-visible:ring-offset-header-bg"
@@ -179,7 +188,7 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
             />
 
             <nav className="flex flex-col p-4 gap-1">
-              <PracticeMenu variant="mobile" onNavigate={closeMobileMenu} isAuthed={Boolean(user)} currentPath={initialPathname} />
+              <PracticeMenu variant="mobile" onNavigate={closeMobileMenu} isAuthed={isAuthed} currentPath={initialPathname} />
               <a
                 href="/"
                 onClick={closeMobileMenu}
@@ -204,7 +213,7 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
                 <BookOpen className="w-5 h-5 text-text-muted" aria-hidden="true" />
                 Blog
               </a>
-              {user && (
+              {isAuthed && (
                 <a
                   href="/history"
                   onClick={closeMobileMenu}
@@ -214,7 +223,7 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
                   Exam history
                 </a>
               )}
-              {user && (
+              {isAuthed && (
                 <a
                   href="/account"
                   onClick={closeMobileMenu}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -9,9 +9,9 @@ interface ModalProps {
   onClose: () => void
 }
 
-// Matches the exit animation duration (--dur-fast) so the dialog + backdrop
-// finish animating out before they unmount.
-const EXIT_MS = 200
+// Matches --dur-fast (180ms) so the dialog + backdrop finish animating out
+// before they unmount.
+const EXIT_MS = 180
 
 export function Modal({ isOpen, title, children, onClose }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null)

--- a/src/lib/buttonStyles.ts
+++ b/src/lib/buttonStyles.ts
@@ -130,7 +130,7 @@ export function inputClass(opts?: { hasError?: boolean; className?: string; surf
     'border transition-[border-color,box-shadow] duration-200 focus:outline-none',
     hasError
       ? 'border-danger focus:border-danger focus-visible:ring-2 focus-visible:ring-danger/40'
-      : 'border-text-muted/25 hover:border-text-muted/50 focus:border-brand focus-visible:ring-2 focus-visible:ring-brand/30',
+      : 'border-text-muted/40 hover:border-text-muted/60 focus:border-brand focus-visible:ring-2 focus-visible:ring-brand/30',
     className,
   ]
     .filter(Boolean)

--- a/src/lib/examGuard.ts
+++ b/src/lib/examGuard.ts
@@ -31,8 +31,7 @@ export function isExamActive(): boolean {
 /**
  * True while a domain-practice session is in progress (mirrors the body dataset
  * flag the practice island sets). Practice deliberately does NOT set
- * `examActive` (that flag also hides the mobile hamburger, which practice
- * keeps), so it carries its own flag; the leave broker treats both the same.
+ * `examActive`, so it carries its own flag; the leave broker treats both the same.
  */
 export function isPracticeActive(): boolean {
   return typeof document !== 'undefined' && document.body.dataset.practiceActive === 'true'

--- a/src/lib/levelAccent.ts
+++ b/src/lib/levelAccent.ts
@@ -24,21 +24,21 @@ export const LEVEL_ACCENT_RGB: Record<CertLevel, string> = {
  * UI-accent variant for ACTIVE roles on a light surface (the signed-in
  * dashboard's status dot, card halo glow, and progress-bar fills). The badge
  * colors above are tuned for recognition on dark/og art; Foundational's pale
- * silver (#A8B9C9) reads washed-out and low-contrast on the white dashboard.
- * Foundational here is a darker slate-blue (~4.5:1 on white, still visible on
- * the dark card); the other levels are already saturated enough to reuse.
- * Keep the pale silver above for the badge chip / blueprint art only.
+ * silver (#A8B9C9) and Associate's bright blue (#4C9AFF) read washed-out or
+ * low-contrast on the white dashboard track. These are darkened shades that
+ * achieve >=3:1 WCAG 1.4.11 against the bg-text-muted/15 track in both light
+ * and dark mode. Keep the originals above for badge chips / blueprint art only.
  */
 export const LEVEL_ACCENT_UI_HEX: Record<CertLevel, string> = {
   foundational: '#5B7186',
-  associate: '#4C9AFF',
-  professional: '#C8793B',
+  associate: '#2C7EE8',
+  professional: '#B87035',
   specialty: '#8B5CF6',
 }
 
 export const LEVEL_ACCENT_UI_RGB: Record<CertLevel, string> = {
   foundational: '91 113 134',
-  associate: '76 154 255',
-  professional: '200 121 59',
+  associate: '44 126 232',
+  professional: '184 112 53',
   specialty: '139 92 246',
 }

--- a/src/lib/seo-data.ts
+++ b/src/lib/seo-data.ts
@@ -240,7 +240,7 @@ export const FAQ_ENTRIES: FAQEntry[] = [
   {
     question: 'How much does the AWS Cloud Practitioner exam cost?',
     answer:
-      'The AWS Certified Cloud Practitioner (CLF-C02) exam costs 100 USD (prices vary slightly by region and local tax). AWS occasionally offers a free retake or a 50% discount voucher to candidates who hold an existing AWS certification, so check your AWS Certification account for available benefits before booking. Practising here is free; only the official exam at Pearson VUE or PSI carries the fee.',
+      'The AWS Certified Cloud Practitioner (CLF-C02) exam costs 100 USD (prices vary slightly by region and local tax). AWS occasionally offers a free retake or a 50% discount voucher to candidates who hold an existing AWS certification, so check your AWS Certification account for available benefits before booking. Practicing here is free; only the official exam at Pearson VUE or PSI carries the fee.',
     category: 'format',
     certCode: 'clf-c02',
   },
@@ -350,7 +350,7 @@ export const FAQ_ENTRIES: FAQEntry[] = [
   {
     question: 'How much does the AWS AI Practitioner exam cost?',
     answer:
-      'The AWS Certified AI Practitioner (AIF-C01) exam costs 100 USD (prices vary slightly by region and local tax). As a foundational-level exam it is the same price tier as the Cloud Practitioner. If you already hold an AWS certification, check your AWS Certification account for a 50% discount voucher before booking. Practising on CloudCertPrep is always free.',
+      'The AWS Certified AI Practitioner (AIF-C01) exam costs 100 USD (prices vary slightly by region and local tax). As a foundational-level exam it is the same price tier as the Cloud Practitioner. If you already hold an AWS certification, check your AWS Certification account for a 50% discount voucher before booking. Practicing on CloudCertPrep is always free.',
     category: 'format',
     certCode: 'aif-c01',
   },

--- a/src/pages/_History.tsx
+++ b/src/pages/_History.tsx
@@ -15,7 +15,7 @@ import { loadAllQuestions } from '../data/questions'
 import { CERTIFICATIONS, getCertDomains } from '../data/certifications'
 import { Modal } from '../components/Modal'
 import { QuestionReviewCard } from '../components/QuestionReviewCard'
-import { TrendingUp, Check, X, Trash2, AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react'
+import { TrendingUp, Check, X, Trash2, AlertTriangle, ChevronDown, ChevronRight, RotateCw } from 'lucide-react'
 import { Button } from '../components/Button'
 import { Card } from '../components/Card'
 import { Alert } from '../components/Alert'
@@ -589,17 +589,21 @@ export function History() {
               )}
 
               {loadError ? (
-                <Card padding="lg" className="text-center !py-12">
-                  <p className="text-text-primary font-medium">We could not load your exam history.</p>
-                  <p className="mt-1 text-sm text-text-muted">Check your connection and try again.</p>
-                  <Button
+                <Alert
+                  tone="danger"
+                  role="alert"
+                  className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <span>We could not load your exam history. Check your connection and try again.</span>
+                  <button
+                    type="button"
                     onClick={() => { setLoading(true); void loadHistory() }}
-                    variant="secondary"
-                    className="mt-6"
+                    className="inline-flex min-h-[44px] flex-shrink-0 items-center justify-center gap-2 rounded-full border border-danger/40 px-5 text-sm font-medium text-danger transition-colors duration-200 hover:bg-danger/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/40"
                   >
+                    <RotateCw className="h-4 w-4" aria-hidden="true" />
                     Try again
-                  </Button>
-                </Card>
+                  </button>
+                </Alert>
               ) : filteredAttempts.length === 0 ? (
                 <Card padding="lg" className="text-center !py-12">
                   <p className="text-text-muted text-lg">

--- a/src/pages/_Login.tsx
+++ b/src/pages/_Login.tsx
@@ -352,7 +352,7 @@ export function Login() {
                     <BookOpen className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">{getActiveTotalQuestions().toLocaleString()}+ Practice Questions</h3>
+                    <h3 className="text-text-primary font-semibold mb-1">{getActiveTotalQuestions().toLocaleString('en-US')}+ Practice Questions</h3>
                     <p className="text-text-muted text-sm">Up to date with the latest exam guides, across multiple AWS certifications</p>
                   </div>
                 </div>

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -1205,16 +1205,18 @@ export function MockExam() {
         {/* Custom leave-confirm modal — replaces the native beforeunload dialog
             for intercepted in-app navigation. Leaving discards the in-progress
             attempt (exam state lives in this island's memory), so this is a real
-            confirm, not just a heads-up. */}
+            confirm, not just a heads-up. The sign-out case brands itself as such
+            (mirrors the practice leave-modal, which has always done this). */}
         <Modal
           isOpen={pendingLeaveUrl !== null}
-          title="Leave the exam?"
+          title={pendingLeaveUrl === SIGN_OUT_SENTINEL ? 'Sign out?' : 'Leave the exam?'}
           onClose={() => setPendingLeaveUrl(null)}
         >
           <div className="space-y-4">
             <p className="text-text-primary">
-              Your exam is still in progress. If you leave this page now, your
-              current answers and timer will be lost and this attempt will not be saved.
+              {pendingLeaveUrl === SIGN_OUT_SENTINEL
+                ? 'Your exam is still in progress. If you sign out now, your current answers and timer will be lost and this attempt will not be saved.'
+                : 'Your exam is still in progress. If you leave this page now, your current answers and timer will be lost and this attempt will not be saved.'}
             </p>
             <div className="flex gap-4 mt-6">
               <Button onClick={() => setPendingLeaveUrl(null)} variant="secondary" className="flex-1">
@@ -1235,7 +1237,7 @@ export function MockExam() {
                 variant="danger"
                 className="flex-1"
               >
-                Leave exam
+                {pendingLeaveUrl === SIGN_OUT_SENTINEL ? 'Sign out' : 'Leave exam'}
               </Button>
             </div>
           </div>

--- a/src/pages/_Stats.tsx
+++ b/src/pages/_Stats.tsx
@@ -112,10 +112,9 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
   }
 
   useEffect(() => {
-    // Async setState (inside loadStats) is allowed by the rule's intent;
-    // disabling the synchronous heuristic explicitly.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadStats()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // First-load phase: the prerendered snapshot is still standing in (it is
@@ -235,7 +234,7 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
                     <TrendingUp className="w-5 h-5 text-text-muted flex-shrink-0 mt-0.5" aria-hidden="true" />
                     <div>
                       <p className="text-text-primary text-sm md:text-base mb-1">
-                        {getCertTotalQuestions(cert.code).toLocaleString()} practice questions available
+                        {getCertTotalQuestions(cert.code).toLocaleString('en-US')} practice questions available
                       </p>
                       <p className="text-text-muted text-xs md:text-sm">
                         Community stats will appear here once users start taking exams.
@@ -285,11 +284,11 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
                 {/* Key Metrics */}
                 <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4 mb-6">
                   <div>
-                    <p className="font-mono text-2xl md:text-3xl font-semibold tabular-nums text-text-primary">{cs.total_attempts.toLocaleString()}</p>
+                    <p className="font-mono text-2xl md:text-3xl font-semibold tabular-nums text-text-primary">{cs.total_attempts.toLocaleString('en-US')}</p>
                     <p className="text-text-muted text-xs md:text-sm mt-1">Total attempts</p>
                   </div>
                   <div>
-                    <p className="font-mono text-2xl md:text-3xl font-semibold tabular-nums text-text-primary">{cs.total_passes.toLocaleString()}</p>
+                    <p className="font-mono text-2xl md:text-3xl font-semibold tabular-nums text-text-primary">{cs.total_passes.toLocaleString('en-US')}</p>
                     <p className="text-text-muted text-xs md:text-sm mt-1">Total passes</p>
                   </div>
                   <div>
@@ -387,7 +386,7 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
           {stats && (
             <div className="border-t border-text-muted/10 pt-6">
               <p className="text-text-muted text-xs md:text-sm text-center">
-                {stats.total_users.toLocaleString()} users · {stats.total_questions_answered.toLocaleString()} questions answered across all certifications
+                {stats.total_users.toLocaleString('en-US')} users · {stats.total_questions_answered.toLocaleString('en-US')} questions answered across all certifications
               </p>
             </div>
           )}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -95,7 +95,7 @@ const softwareAppJsonLd = serializeJsonLd({
 <BaseLayout title={title} description={description} canonical={canonical} jsonLd={[itemListJsonLd, softwareAppJsonLd]} headerOverlay={true}>
   {/* Billboard hero (aws.amazon.com language, DSv4.1): vivid blue field,
       floating abstract art, inset periwinkle card carrying the locked SEO
-      copy. HOME_H1 is the single page <h1>; the lede carries the locked
+      copy. HOME_H1 is the primary <h1> (ordered first for the citation guard); the lede carries the locked
       citation phrases verbatim. Community social-proof TrustLine stays
       hidden until the attempt sample is credible. */}
   {/* Guest billboard: shown to crawlers + logged-out via cc-auth-out (CSS-hidden


### PR DESCRIPTION
## Summary

Cleanup PR closing the stabilization sprint. Fixes four user-visible inconsistencies (C1-C4) found in the second-pass adversarial audit of `MERGE-READINESS-AUDIT-2026-06-28.md` Section 9, plus a batch of low/nit items from Sections 9.2-9.4.

**C1 - Header auth-readiness divergence:** The avatar renders instantly via `cc-auth-in` CSS but the Practice menu's "Dashboard" link and the drawer's History/Account rows waited for `useAuth()` async `getSession()`. On a slow connection a returning user briefly saw their avatar but no auth-gated nav items. Fix: mirrors `DomainProgressStrip`'s `authedHint` pattern (reads `cc-authed` class synchronously on mount); the derived `isAuthed = authedHint || Boolean(user)` is passed to both `PracticeMenu` instances and the two drawer rows.

**C2 - Exam leave-modal sign-out copy:** The practice leave-modal already branches its copy on `SIGN_OUT_SENTINEL` ("Sign out?" / "Sign out"); the exam modal hardcoded "Leave the exam? / Leave exam" even when the action was a sign-out. Fix: branches the exam modal title, body, and confirm button on `pendingLeaveUrl === SIGN_OUT_SENTINEL` to match.

**C3 - Load-error retry inconsistency:** Dashboard and Stats used `Alert + danger-pill + RotateCw` for fetch errors; History used a plain `Card + secondary Button`. Fix: updates History to the shared Alert pattern.

**C4 - Island number-locale:** Astro shells pin `toLocaleString('en-US')` but React islands used bare `toLocaleString()`, causing the thousands separator to flip mid-page for non-US locales. Fix: passes `'en-US'` to every island call (`CertDashboardIsland`, `_Stats`, `_Login`).

**Nits (all low-risk):**
- Drawer close: 240ms -> 180ms (`--dur-fast`), timer stored in ref and cleared on re-entry
- `Modal.tsx` `EXIT_MS`: 200 -> 180 to match `--dur-fast`
- `AccountLinkNotice` dismiss button: added `focus-visible` ring (matches `AuthLinkNotice`'s `DismissButton`)
- `DomainProgressStrip` local `Skeleton` renamed `StripSkeleton` (was shadowing the shared `Skeleton.tsx`)
- `AuthLinkNotice`: moved `history.replaceState` + `localStorage.setItem` from `useState` initializer into `useEffect` (no side-effects during render; StrictMode-safe)
- `AnswerButton` graded icons: `role="img"` added so `aria-label` is consistently announced by screen readers
- Stale comments: `AuthLinkNotice` "HomeWelcome" reference, `index.astro` "single page h1", `examGuard.ts` "hides the mobile hamburger" (it no longer does)
- Two "Practising" -> "Practicing" in `seo-data.ts` (lines 243, 353)
- `_Stats.tsx` `loadStats` `useEffect`: corrected lint disable comments (was `set-state-in-effect`, also needed `exhaustive-deps` for the `[]` dep array)

## Test plan

- [x] `npm run lint` - clean (one pre-existing `.kiro/` parse error, unrelated to this branch)
- [x] `npm run test` - 248/248 pass
- [x] `npm run build` + full prebuild/postbuild guard chain - all green (citation, graph, person-graph, CSP, CF headers)
- [x] Build artifacts restored (`public/llms.txt`, `public/sitemap.xml`, `functions/_csp.generated.js`)
- [ ] Owner: quick visual check of changed surfaces dark+light (header drawer, History error state, exam leave modal during sign-out, /stats numbers on a non-US locale browser)
- [ ] Owner: no auth/scoring/RLS paths touched - these are pure UI/copy/locale/comment changes