### PR TITLE
fix(auth): kill OAuth/?code= home hero flash (F1) + keep first-login greeting

### DIFF
--- a/src/components/CertDashboardIsland.tsx
+++ b/src/components/CertDashboardIsland.tsx
@@ -185,9 +185,20 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
     }
   }, [authLoading, user, cert.code, reloadKey])
 
-  // Logged-out (or still resolving): render nothing. The static guest view
-  // stays visible.
-  if (authLoading || !user) return null
+  // Genuinely logged out: render nothing and leave the static guest view
+  // (#cert-guest-view) visible. A real guest reaches this synchronously -
+  // useAuth resolves loading=false on the first render when there is no token
+  // AND no `?code=` callback, so `authLoading` here always means a token or an
+  // OAuth/magic-link exchange is in flight (a real/pending session).
+  if (!authLoading && !user) return null
+
+  // Still resolving auth (persisted token, or a `?code=` exchange that can run
+  // >1s): render the dashboard with its data skeletons, NOT nothing. The static
+  // guest view is hidden pre-paint (cc-auth-out + the optimistic `cc-authed` on
+  // a `?code=` URL - F1), so returning null while `authLoading` would blank the
+  // above-the-fold for the whole exchange. `dataLoading` stays true while
+  // `authLoading` (the fetch is gated on it), so every data section shows its
+  // skeleton; the render below never dereferences `user`.
 
   // Level accent ties the signed-in dashboard to the cert's identity (same
   // hue as the guest hero's blueprint panel and the OG tile art).

--- a/src/components/HeaderInteractive.tsx
+++ b/src/components/HeaderInteractive.tsx
@@ -71,6 +71,14 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
   useEffect(() => {
     if (authLoading) return
     document.documentElement.classList.toggle('cc-authed', Boolean(user))
+    // Tell same-page pre-paint scripts the real session has resolved (token now
+    // persisted, `user` known). The home first-login greeting (index.astro) used
+    // to re-run on a `cc-authed`-add MutationObserver, but `cc-authed` is now set
+    // optimistically PRE-paint on an OAuth `?code=` return (BaseLayout), before
+    // the token exists, so that add-transition no longer fires when the token
+    // lands. This event is the reliable "session resolved" signal instead. Fires
+    // on every resolution (incl. guest); listeners are idempotent and self-gate.
+    window.dispatchEvent(new Event('cc:session-resolved'))
   }, [authLoading, user])
 
   return (

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -229,12 +229,24 @@ const effectiveRobots = isNoindexPreview ? 'noindex' : robots
     <!-- Auth pre-paint: define a shared hasSession() helper on window, then
          apply the `cc-authed` class to <html> before paint. Logged-in
          visitors see History + Sign out immediately (no flash, no shift).
-         The HeaderInteractive island re-syncs this class to the real auth
-         result; the per-page cert landing pre-hide script (cert.astro)
-         reuses the same window.__ccHasSession() helper. Runs on bfcache
+         The class is ALSO set optimistically on an OAuth / magic-link return
+         (`?code=` in the URL): the session token is not written yet (Supabase
+         exchanges the code AFTER load - the same `hasAuthCallback` test as
+         useAuth.ts), so without this the home/cert page paints the GUEST hero
+         then hard-cuts to the signed-in view ~1s later when the PKCE exchange
+         resolves (flash F1, plus a dark->light tone change in light theme).
+         The guest markup only CSS-hides (it is never removed), and crawlers
+         never see a `?code=` URL, so the build-time HTML keeps the locked H1 as
+         the first <h1> (citation guard). A failed exchange flips back to guest
+         when HeaderInteractive re-syncs to the real auth result (rarer than
+         today's every-success flash; failures navigate away anyway). Header
+         readability + hero swap on the optimistic class are pure CSS
+         (index.css `html.cc-authed header[data-overlay]` + `.cc-auth-*`).
+         __ccHasSession() itself stays a PURE token check - cert.astro + the
+         index.astro greeting read it for the real stored user. Runs on bfcache
          restore (pageshow) too. DO NOT REMOVE. -->
     <script is:inline>
-      (function(){function h(){try{for(var i=0;i<localStorage.length;i++){var k=localStorage.key(i);if(k&&k.indexOf('sb-')===0&&k.indexOf('-auth-token')===k.length-11)return true}}catch(e){}return false}window.__ccHasSession=h;function apply(){document.documentElement.classList.toggle('cc-authed',h())}apply();window.addEventListener('pageshow',apply)})();
+      (function(){function h(){try{for(var i=0;i<localStorage.length;i++){var k=localStorage.key(i);if(k&&k.indexOf('sb-')===0&&k.indexOf('-auth-token')===k.length-11)return true}}catch(e){}return false}window.__ccHasSession=h;function apply(){document.documentElement.classList.toggle('cc-authed',h()||/[?&]code=/.test(location.search))}apply();window.addEventListener('pageshow',apply)})();
     </script>
 
     <!-- Stale-chunk recovery: after a new deploy, a still-open old tab can

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -220,22 +220,20 @@ const softwareAppJsonLd = serializeJsonLd({
         }
         apply()
         window.addEventListener('pageshow', apply)
-        // Email-confirmation / async sign-in lands here with NO session in
-        // storage yet (Supabase exchanges the URL token AFTER load), so the
-        // first apply() bails: the header keeps its white-on-transparent
-        // overlay while the hero CSS-swaps to the LIGHT signed-in view ->
-        // invisible logo/nav. HeaderInteractive toggles html.cc-authed once
-        // auth resolves; re-run apply() then (idempotent) so the overlay drops
-        // to the readable frosted header AND the first-login greeting swaps in.
-        try {
-          var root = document.documentElement
-          if (!root.classList.contains('cc-authed')) {
-            var mo = new MutationObserver(function () {
-              if (root.classList.contains('cc-authed')) { mo.disconnect(); apply() }
-            })
-            mo.observe(root, { attributes: true, attributeFilter: ['class'] })
-          }
-        } catch (e) { /* no MutationObserver: pageshow re-apply still covers bfcache */ }
+        // Email-confirmation / OAuth / magic-link sign-in lands here with NO
+        // session in storage yet (Supabase exchanges the URL `?code=` token
+        // AFTER load), so the first apply() above bails (no token) and the
+        // first-login greeting can't be chosen. `cc-authed` is now set
+        // optimistically PRE-paint on a `?code=` URL (BaseLayout), so we can NOT
+        // watch for a `cc-authed`-add to learn when the token lands - that
+        // transition already happened before the token. Instead HeaderInteractive
+        // dispatches `cc:session-resolved` once useAuth resolves (token persisted,
+        // user known); re-run apply() then. It is idempotent and reads
+        // user.created_at from the now-present token, so a brand-new account gets
+        // the first-login greeting and a returning one keeps "Welcome back". The
+        // header-overlay half is already covered by CSS (index.css
+        // html.cc-authed header[data-overlay]); apply() also drops [data-overlay].
+        window.addEventListener('cc:session-resolved', apply)
       })()
     </script>
   )}


### PR DESCRIPTION
## Flash F1: kill the OAuth / `?code=` home hero flash (owner's #1 reported flash)

On a Google-OAuth / `?code=` / email-confirm return to the home page, the **guest hero painted first and then hard-cut to the signed-in welcome hero** once the PKCE exchange completed (>1s on a mid-range phone). In **light theme** it also read as **dark -> light** (the guest billboard is a fixed near-black `#0E1116` stage; the welcome hero sits on the light page bg), and the swap shifted content (**CLS 0.0906** desktop). Root cause + evidence: `.kiro/ux/FLASH-FINDINGS-2026-06-28.md` (F1).

### The fix (owner-approved)
Set the pre-paint `cc-authed` hint **optimistically true on an auth callback**, so the signed-in welcome hero + avatar + frosted readable header paint in **frame 1** instead of swapping ~1s later.

- **`BaseLayout.astro:237`** - the `cc-authed` toggle now also fires when `/[?&]code=/.test(location.search)`, mirroring `useAuth.ts:69`'s `hasAuthCallback` test **byte-for-byte** (same regex, so the two never diverge). The existing localStorage-token path is unchanged.
- **No `index.astro` / `cert.astro` overlay-script change was needed for the visual**: header readability + the hero swap on the optimistic class are already pure CSS - `index.css:422` (`html.cc-authed header[data-overlay]:not(.hdr-scrolled)` frosts the bar with readable dark/light text) + `.cc-auth-*` (`index.css:202-203`). So the header is never the invisible white-on-light state.
- `window.__ccHasSession()` stays a **pure token check** (cert.astro + the home greeting read it for the *real* stored user).
- A **failed exchange** flips back to guest when `HeaderInteractive` re-syncs `cc-authed` to `Boolean(user)` - a single signed-in->guest flip, far rarer than today's *every-success* flash, and failures already navigate away (`/login?error=...`). Trade-off accepted per the task.

### Coupled greeting fix (owner addendum, same PR)
The optimistic class is set **pre-paint, before the token exists**, which defeated the home first-login greeting's coupling: its `apply()` re-ran via a `MutationObserver` installed only `if (!cc-authed)` (`index.astro:~232`), to catch `cc-authed` being *added* later. With `cc-authed` already present pre-paint, that observer never installed -> a **brand-new federated (Google) signup would have gotten the default "Welcome back" instead of "Welcome to CloudCertPrep"**.

Fix: **`HeaderInteractive.tsx:71-74`** now dispatches `window.dispatchEvent(new Event('cc:session-resolved'))` once `useAuth` resolves (token persisted, user known), and **`index.astro`** re-runs the greeting `apply()` on that event (replacing the dead observer). `apply()` is idempotent and reads `user.created_at` from the now-present token, so <24h accounts get the first-login copy, >24h keep "Welcome back", greeted once via `cc_home_greeted`.

### Follow-up (2nd flash-audit pass): cert-hub skeleton during `authLoading`
The global optimistic `cc-authed` also hides the static guest view on `/aws/<cert>?code=`, but `CertDashboardIsland` returned `null` while `authLoading` (`return null` when `authLoading || !user`), so - unlike home (static welcome hero) - the above-the-fold sat empty until the exchange resolved. Fixed in **`CertDashboardIsland.tsx:190`**: render the dashboard with its data skeletons during `authLoading` (a genuine guest resolves `loading=false` synchronously with no token + no `?code=`, so `authLoading` here always means a real/pending session), and return `null` only when genuinely resolved-and-logged-out. Verified: the cert dashboard skeleton renders once the island mounts (~50ms unthrottled); a genuine guest still shows the guest view. The residual pre-mount gap (a `client:only` island can't mount until its chunk loads) is **unchanged parity** with a normal persisted-token cert load - height-reserved (PR-5), no CLS - not introduced by this PR. Bounded + uncommon (common OAuth returns to home, now flash-free). Proof shot: `shots/cert-oauth-FIXED-dashboard-skeleton.png`.

### CLS nuance (precise)
The **0.0000 CLS** above is the **success path** (welcome hero from frame 1, no swap). The **failed-exchange** fallback (signed-in -> guest flip) still shifts ~**0.09** - that CLS is **moved** (from *every* success today to only the *rarer* failure), **not eliminated**. Accepted, since failures already navigate away.

### SEO / guards
The guest hero (carrying the locked H1) is **only CSS-hidden, never removed**, and crawlers never see `?code=` URLs, so the build-time static HTML is unchanged. `check:citation`, `check:graph`, `check:person-graph` all pass; the inline pre-paint script is inside the byte-hashed CSP and `csp:hash` rehashes it on build (regenerated `_headers`/`_csp`/sitemap/llms restored, not committed, per convention).

## Verification (CI cannot see this - a human must)
Prod build (`npm run build`) -> `npm run preview` -> Playwright, **cloudcertprep-test** only, light + dark, desktop + mobile, `reducedMotion: 'reduce'`:

| Scenario | Result |
|---|---|
| **`/?code=` first paint** (light+dark, desktop+mobile) | welcome hero + avatar + frosted readable header from frame 1; **no** guest hero, **no** dark->light swap; **CLS 0.0000** (was 0.0906) |
| **Failed exchange** | falls back to the guest hero cleanly (one signed-in->guest flip, then stable) |
| **Normal `/` logged-out** | unchanged: guest hero, "Sign in", CLS 0.0000 |
| **Normal `/` persisted-token** | unchanged: welcome hero from frame 1, CLS 0.0000 |
| **Callback CLS (success path)** | 0.0000 (was 0.0906 desktop); the *failure* fallback flip is still ~0.09 - moved to the rare path, not eliminated |
| **Cert `/aws/<cert>?code=`** | dashboard skeleton renders during `authLoading` (not blank); genuine guest still shows guest view |
| **First-login greeting** (<24h, token lands via event) | kicker -> **"Welcome to CloudCertPrep"** + first-login subline |
| **Returning (>24h)** | stays "Welcome back" |
| **Once-only** | already-greeted id -> stays "Welcome back" (`cc_home_greeted` honored) |
| **End-to-end event** | `cc:session-resolved` fires from `HeaderInteractive` on real auth resolution |

Gates green: `npx astro check` (0 errors), `npm run lint` (src clean), `npm run test` (248 passed), `npm run build` (all guards pass).

### Before / after (LIGHT mode) - local proof shots
This is a visual fix; please spot-check **one real Google sign-in in light mode**. Screenshots are in `.kiro/ux/flash-2026-06-28/shots/`:
- **Before (the bug):** `home-oauth-light-desktop_preswap.png` - dark `#0E1116` billboard, "Free open-source AWS certification practice exams", "Sign in".
- **After (the fix):** `home-oauth-light-desktop_FIXED.png` - light welcome hero, "Welcome back / Ready when you are.", avatar, frosted readable header, from frame 1.
- **First-login greeting:** `home-oauth-light-desktop_FIXED-first-login-greeting.png` - "Welcome to CloudCertPrep".
- **Failure fallback:** `home-oauth-light-desktop_FIXED-failure-fallback.png` - clean guest hero after a failed exchange.

## Files
- `src/layouts/BaseLayout.astro` - optimistic `cc-authed` on `?code=`.
- `src/components/HeaderInteractive.tsx` - dispatch `cc:session-resolved` on auth resolve.
- `src/pages/index.astro` - greeting re-runs on `cc:session-resolved` (replaces the dead `cc-authed`-add observer).
- `src/components/CertDashboardIsland.tsx` - render the dashboard skeleton during `authLoading` (cert `?code=` follow-up); return null only when genuinely logged out.

No new deps. No scoring/auth-exchange logic touched (only the pre-paint hint + a notify event + a loading-state render guard).
