### PR TITLE
fix(auth): OAuth guest-save loader + login button stuck after bfcache (F4/F5)

### DIFF
--- a/src/pages/_Login.tsx
+++ b/src/pages/_Login.tsx
@@ -78,6 +78,20 @@ export function Login() {
   const [success, setSuccess] = useState('')
   const [loading, setLoading] = useState(false)
 
+  // Restoring from the bfcache after an OAuth redirect must reset `loading`. The
+  // Google / GitHub handlers set `loading` true then hand off to
+  // `signInWithOAuth`, which navigates away WITHOUT clearing it (only the catch
+  // does). Pressing Back restores this page from the bfcache with `loading`
+  // frozen true, leaving the submit + OAuth buttons stuck on the spinner.
+  // `pageshow` with `persisted` is the bfcache-restore signal; clear the flag so
+  // the form is usable again. (A fresh reload re-mounts with loading=false, so
+  // the persisted guard keeps this to the restore case.)
+  useEffect(() => {
+    const onPageShow = (e: PageTransitionEvent) => { if (e.persisted) setLoading(false) }
+    window.addEventListener('pageshow', onPageShow)
+    return () => window.removeEventListener('pageshow', onPageShow)
+  }, [])
+
   // Cloudflare Turnstile token. Passed to Supabase as options.captchaToken on
   // every auth call; Supabase validates it server-side. Tokens are single-use,
   // so the widget is reset after each attempt. When no site key is configured

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -136,7 +136,7 @@ export function MockExam() {
   const navigate = useNavigate()
   const location = useLocation()
   const { goHome } = useCertNavigate()
-  const { user } = useAuth()
+  const { user, loading: authLoading } = useAuth()
   const signOut = useSignOut()
   const cert = useCert()
   const [screen, setScreen] = useState<ExamScreen>('start')
@@ -319,20 +319,26 @@ export function MockExam() {
     }
   }, [])
 
-  // A signed-in user who lands on the start screen with a pending guest attempt
-  // is about to have it flushed + be redirected to /history (above). Show a
-  // loader instead of the start screen so they don't see the intro flash.
+  // A user who lands here with a pending guest attempt + a live save intent is
+  // about to have it flushed + be redirected to /history (above). Show a loader
+  // instead of the bare intro/results screen so they don't see it flash. Two arms:
+  //  - a resolved `user` (email/password return: the session is present on landing), OR
+  //  - auth still RESOLVING (`authLoading`): the OAuth / magic-link return lands on
+  //    this exam route as `?code=...` with NO session yet, and useAuth holds
+  //    loading=true for the whole PKCE exchange (~1s+ on a mid-range phone). Without
+  //    this arm `user` is null for the exchange window and the bare results screen
+  //    shows (the guest rehydrate below swaps to results while user is null). The arm
+  //    is deliberately screen-agnostic for that reason; only mid-exam/review are
+  //    excluded. The 8s fallback drops the loader if no flush ultimately lands (e.g.
+  //    a failed exchange). The flush itself is intent-gated (PR-3), so a stale
+  //    no-intent pending attempt never shows the spinner. (item 4b)
   useEffect(() => {
-    if (!user || screen !== 'start') return
-    // Only show the loader when a flush is genuinely coming: a pending snapshot
-    // AND a live save intent. PR-3 gated the flush itself on the intent, so a
-    // signed-in user with a stale, no-intent pending attempt would otherwise see
-    // the spinner for up to 8s while nothing actually saves. (item 4b)
+    if ((!user && !authLoading) || (screen !== 'start' && screen !== 'results')) return
     const t = window.setTimeout(() => {
       if (peekPendingAttempt() && hasPendingAttemptSaveIntent()) setSavingToHistory(true)
     }, 0)
     return () => window.clearTimeout(t)
-  }, [user, screen])
+  }, [user, authLoading, screen])
   // Fallback: if the flush never completes (e.g. it failed), drop the loader
   // after a few seconds so the user is never stuck on it.
   useEffect(() => {


### PR DESCRIPTION
Two pre-existing OAuth-path UX bugs found while verifying the F1 flash PR (#123). Independent of #123 (different files: `_MockExam.tsx`, `_Login.tsx`), so this is a separate small PR.

## F5 - login black button stuck loading after Back from Google
`handleGoogleSignIn` / `handleGitHubSignIn` set the **shared** `loading` true, then hand off to `signInWithOAuth` (full redirect) which never clears it (only the `catch` does). Pressing Back restores the page from the **bfcache** with `loading` frozen true, so the black submit button (and the OAuth buttons) stay stuck on the spinner.
**Fix:** reset `loading` on `pageshow` when `event.persisted` (the bfcache-restore signal).
**Verified end-to-end:** after clicking Google the button reads `Loading...`; after a `pageshow(persisted)` restore it returns to `Sign in` (usable).

## F4 - guest-save via Google flashes the exam screen before /history
The guest-save "Saving your attempt..." anti-flash loader was gated on a **resolved `user`** (`user && screen === 'start'`). On the OAuth / magic-link return the page lands as `?code=...` with **no session yet** (the PKCE exchange resolves ~1s+ AFTER load), so `user` is null for the exchange window and the bare exam **results** screen shows (the guest rehydrate swaps to results while `user` is null) until the flush + redirect.
**Fix:** also show the loader while auth is still resolving (`useAuth().loading`) and on the rehydrated `results` screen, not just `user && start`. Still intent-gated; the existing 8s fallback drops it if no flush lands (e.g. a failed exchange).
**Why `authLoading` is the right signal:** supabase-js `getSession()` awaits `_initialize()` which awaits the `?code=` exchange, so `useAuth().loading` stays true for the whole exchange, which spans the (local, faster) exam-island hydration. Confirmed at the supabase-js source level. The realistic success-path frame can't be driven headlessly (a faked `?code=` has no real round-trip), so please spot-check one real Google guest-save.

## Checks
`npx astro check` (0 errors) + `npm run lint` + `npm run test` (248 pass) + `npm run build` all green. Build-regenerated `_csp`/`sitemap`/`llms` intentionally NOT committed.

Full write-up: `.kiro/ux/FLASH-FINDINGS-2026-06-28.md` (F4/F5).