### PR TITLE
feat(account): self-service deletion + DB cascade for user-data erasure

### DIFF
--- a/scripts/verify-delete-cascade.mjs
+++ b/scripts/verify-delete-cascade.mjs
@@ -1,0 +1,271 @@
+// verify-delete-cascade.mjs
+// =============================================================================
+// Prove that deleting an auth user cascade-deletes ALL of their data rows.
+//
+// It creates two throwaway users, writes rows to every user-owned table for
+// each, deletes ONLY the first user via the admin API, then re-counts:
+//   - the first user's rows in every table  -> must all be 0 (cascade worked)
+//   - the second user's rows                -> must be UNCHANGED (no collateral)
+// Then it deletes the second user and confirms its rows are gone too. Both
+// throwaway users are always cleaned up, even on failure.
+//
+// This is the verification for supabase/sql/delete-account-cascade.sql. Run it
+// AFTER the owner has applied that SQL to a project:
+//   - BEFORE the SQL is applied, the gap tables (attempt_questions.user_id,
+//     domain_progress.user_id) will show leftover rows -> "CASCADE INCOMPLETE".
+//     That is the expected baseline that proves the gap exists.
+//   - AFTER the SQL is applied, every count is 0 -> "CASCADE OK".
+//
+// USAGE
+//   node scripts/verify-delete-cascade.mjs
+//     Reads creds from .env.local. REFUSES to run unless VITE_SUPABASE_URL
+//     points at the TEST project (ref lqnchqfltmognaoudoqc). This is the only
+//     mode an agent/CI should ever use.
+//
+//   node scripts/verify-delete-cascade.mjs --allow-prod
+//     OWNER ONLY. Lets the script run against a non-test ref (i.e. PROD) so the
+//     owner can confirm cascade on production after applying the SQL there. It
+//     still only ever touches throwaway `cc-cascade-verify-*` users it creates
+//     and deletes; it never reads or mutates a real user's data. Pass this flag
+//     consciously - it CREATES and DELETES real auth users on whatever project
+//     .env.local points at.
+//
+// SAFETY: this script DELETES users. Pointed at the wrong project it would
+// delete throwaway users there (never real ones - it only deletes ids it just
+// created). The test-ref guard below is the backstop; do not weaken it.
+// =============================================================================
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const TEST_REF = 'lqnchqfltmognaoudoqc' // cloudcertprep-test
+const ALLOW_PROD = process.argv.includes('--allow-prod')
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Read creds from .env.local ONLY (never process.env, so a stray shell var can't
+// silently repoint this at prod). Mirrors e2e/ux-audit-auth.spec.ts.
+function readEnvLocal() {
+  try {
+    return Object.fromEntries(
+      readFileSync(resolve(__dirname, '../.env.local'), 'utf8')
+        .split('\n')
+        .filter(l => l.includes('='))
+        .map(l => {
+          const i = l.indexOf('=')
+          return [l.slice(0, i).trim(), l.slice(i + 1).trim()]
+        }),
+    )
+  } catch {
+    return {}
+  }
+}
+
+const env = readEnvLocal()
+const url = env.VITE_SUPABASE_URL
+const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!url || !serviceKey) {
+  console.error('✗ .env.local must set VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.')
+  process.exit(1)
+}
+
+const ref = (() => { try { return new URL(url).hostname.split('.')[0] } catch { return '' } })()
+
+if (ref !== TEST_REF && !ALLOW_PROD) {
+  console.error(`✗ Refusing to run: VITE_SUPABASE_URL points at "${ref}", not the test ref "${TEST_REF}".`)
+  console.error('  This script creates and deletes real auth users. Run it against the TEST project.')
+  console.error('  Owner only, to confirm cascade on PROD after applying the SQL there: pass --allow-prod.')
+  process.exit(1)
+}
+if (ref !== TEST_REF && ALLOW_PROD) {
+  console.warn(`⚠  --allow-prod: running against NON-TEST ref "${ref}". This will create + delete`)
+  console.warn('   throwaway cc-cascade-verify-* users on that project. It never touches real users.\n')
+}
+
+const { createClient } = await import('@supabase/supabase-js')
+const admin = createClient(url, serviceKey, { auth: { autoRefreshToken: false, persistSession: false } })
+
+const PW = 'Sup3rStr0ng-Verify-2026'
+const stamp = Date.now()
+const CERT = 'clf-c02'
+const DOMAIN = 1 // avoid the domain_progress_domain_id_check gotcha (rejects 5)
+
+// Tables checked after deletion. The first three are real tables with a user_id
+// cascade target; question_mastery is the read-only VIEW over attempt_questions
+// (per supabase/README.md) - counted read-only to confirm the view empties when
+// its underlying rows are erased. All must reach 0 for the deleted user.
+const COUNT_TABLES = ['exam_attempts', 'attempt_questions', 'domain_progress', 'question_mastery']
+
+const createdUserIds = []
+
+async function createUser(tag) {
+  const email = `cc-cascade-verify-${tag}-${stamp}@example.com`
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password: PW,
+    email_confirm: true,
+  })
+  if (error) throw new Error(`createUser(${tag}) failed: ${error.message}`)
+  createdUserIds.push(data.user.id)
+  return data.user
+}
+
+// Best-effort: writes rows to every user-owned table. Reports (does not throw)
+// per-table insert errors so a single schema mismatch does not abort the run -
+// the remaining tables still exercise the cascade.
+async function seedRows(userId) {
+  const results = {}
+
+  const ea = await admin.from('exam_attempts').insert({
+    user_id: userId,
+    cert_code: CERT,
+    score_percent: 80,
+    scaled_score: 800,
+    passed: true,
+    time_taken_seconds: 600,
+    total_questions: 65,
+    correct_answers: 52,
+    domain_scores: { [DOMAIN]: 80 },
+  }).select('id').single()
+  results.exam_attempts = ea.error ? `ERROR: ${ea.error.message}` : 'ok'
+  const attemptId = ea.data?.id ?? null
+
+  // Two attempt_questions rows: one tied to the exam attempt, one with
+  // attempt_id NULL (the Domain Practice shape that the exam_attempts cascade
+  // can never reach - this is the row the user_id cascade must catch).
+  const aq = await admin.from('attempt_questions').insert([
+    {
+      attempt_id: attemptId,
+      user_id: userId,
+      cert_code: CERT,
+      question_id: `VERIFY-D${DOMAIN}-0001`,
+      domain_id: DOMAIN,
+      user_answer: 'A',
+      correct_answer: 'A',
+      is_correct: true,
+      was_flagged: false,
+    },
+    {
+      attempt_id: null, // Domain Practice row, no parent exam_attempt
+      user_id: userId,
+      cert_code: CERT,
+      question_id: `VERIFY-D${DOMAIN}-0002`,
+      domain_id: DOMAIN,
+      user_answer: 'B',
+      correct_answer: 'B',
+      is_correct: false,
+      was_flagged: false,
+    },
+  ])
+  results.attempt_questions = aq.error ? `ERROR: ${aq.error.message}` : 'ok'
+
+  const dp = await admin.from('domain_progress').upsert({
+    user_id: userId,
+    cert_code: CERT,
+    domain_id: DOMAIN,
+    questions_attempted: 2,
+    questions_correct: 1,
+    mastery_percent: 50,
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'user_id,domain_id,cert_code' })
+  results.domain_progress = dp.error ? `ERROR: ${dp.error.message}` : 'ok'
+
+  return results
+}
+
+async function countRows(userId) {
+  const counts = {}
+  for (const table of COUNT_TABLES) {
+    const { count, error } = await admin
+      .from(table)
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+    counts[table] = error ? `ERROR: ${error.message}` : (count ?? 0)
+  }
+  return counts
+}
+
+function printCounts(label, counts) {
+  console.log(`  ${label}:`)
+  for (const [table, n] of Object.entries(counts)) {
+    console.log(`    ${table.padEnd(20)} ${n}`)
+  }
+}
+
+async function main() {
+  console.log(`Cascade verification against ref "${ref}"\n`)
+
+  const userA = await createUser('a')
+  const userB = await createUser('b')
+  console.log(`Created throwaway users:\n  A ${userA.id} <${userA.email}>\n  B ${userB.id} <${userB.email}>\n`)
+
+  console.log('Seeding rows for user A:')
+  printCounts('insert results', await seedRows(userA.id))
+  console.log('Seeding rows for user B (cross-account control):')
+  printCounts('insert results', await seedRows(userB.id))
+  console.log()
+
+  const beforeA = await countRows(userA.id)
+  const beforeB = await countRows(userB.id)
+  printCounts('User A rows BEFORE delete', beforeA)
+  console.log()
+
+  console.log(`Deleting auth user A (${userA.id}) ...\n`)
+  const { error: delErr } = await admin.auth.admin.deleteUser(userA.id)
+  if (delErr) throw new Error(`deleteUser(A) failed: ${delErr.message}`)
+
+  const afterA = await countRows(userA.id)
+  const afterB = await countRows(userB.id)
+  printCounts('User A rows AFTER delete (must all be 0)', afterA)
+  console.log()
+  printCounts('User B rows AFTER deleting A (must be UNCHANGED)', afterB)
+  console.log()
+
+  // Verdicts. Treat read errors as failures (we could not prove erasure).
+  const aLeftover = Object.entries(afterA).filter(([, n]) => typeof n !== 'number' || n > 0)
+  // Collateral = user B lost rows it still had before A was deleted (compare B
+  // against its OWN baseline), or B's count became unreadable.
+  const bCollateral = COUNT_TABLES.filter(t => {
+    const expected = beforeB[t]
+    const actual = afterB[t]
+    if (typeof actual !== 'number') return true
+    return typeof expected === 'number' && actual < expected
+  })
+
+  let ok = true
+  if (aLeftover.length === 0) {
+    console.log('✓ CASCADE OK - every table for the deleted user is empty.')
+  } else {
+    ok = false
+    console.log('✗ CASCADE INCOMPLETE - rows survived the user deletion:')
+    for (const [t, n] of aLeftover) console.log(`    ${t}: ${n}`)
+    console.log('  Apply supabase/sql/delete-account-cascade.sql (STEP 3) and re-run.')
+  }
+  if (bCollateral.length > 0) {
+    ok = false
+    console.log('✗ COLLATERAL DAMAGE - user B lost rows when A was deleted:')
+    for (const t of bCollateral) console.log(`    ${t}`)
+  } else {
+    console.log("✓ NO COLLATERAL - user B's rows were untouched.")
+  }
+
+  process.exitCode = ok ? 0 : 2
+}
+
+// Always clean up every user this run created, even on error.
+async function cleanup() {
+  for (const id of createdUserIds) {
+    await admin.auth.admin.deleteUser(id).catch(() => {})
+  }
+}
+
+main()
+  .catch(err => {
+    console.error(`\n✗ ${err.message}`)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await cleanup()
+    console.log('\n(throwaway users cleaned up)')
+  })

--- a/src/pages/_Account.tsx
+++ b/src/pages/_Account.tsx
@@ -8,6 +8,8 @@ import { logError } from '../lib/logger'
 import { Button } from '../components/Button'
 import { Card } from '../components/Card'
 import { Alert } from '../components/Alert'
+import { Modal } from '../components/Modal'
+import { Input } from '../components/Input'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import { Download, Trash2, UserCircle } from 'lucide-react'
 
@@ -19,10 +21,13 @@ const SUPPORT_EMAIL = 'alex@cloudcertprep.io'
  * GDPR controls:
  *   - Right to portability: "Download my data (JSON)" reads the user's own
  *     rows (RLS-scoped) and saves a JSON file entirely client-side.
- *   - Right to erasure: handled via an email request for now. In-app
- *     self-service deletion (the `delete-account` Edge Function) is deferred
- *     until that function is deployed and its table list is audited against
- *     the live schema. See .kiro/ux/audit-2026-06-24/DEFERRED-delete-account.md.
+ *   - Right to erasure: "Delete my account" invokes the `delete-account` Edge
+ *     Function (RLS cannot remove an auth.users row from the client; only the
+ *     service_role can). On success the local session is cleared and the user
+ *     is sent home with ?account_deleted=1 (AuthLinkNotice acknowledges it). If
+ *     the function is unreachable, the error copy falls back to the email path
+ *     (still GDPR-compliant) rather than failing silently. The DB-side cascade
+ *     (supabase/sql/delete-account-cascade.sql) guarantees all data rows go too.
  */
 export function Account() {
   const { user, loading: authLoading } = useAuth()
@@ -38,6 +43,11 @@ export function Account() {
   const [exporting, setExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
   const [exportDone, setExportDone] = useState(false)
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [confirmText, setConfirmText] = useState('')
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   async function handleExport() {
     if (!user?.id) return
@@ -106,6 +116,27 @@ export function Account() {
     }
   }
 
+  async function handleDelete() {
+    if (!user?.id) return
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      const supabase = await getSupabase()
+      const { error } = await supabase.functions.invoke('delete-account', { method: 'POST' })
+      if (error) throw error
+      // The account (and session) no longer exist; clear the local token and
+      // leave the app. The home banner acknowledges the deletion.
+      await supabase.auth.signOut({ scope: 'local' }).catch(() => {})
+      window.location.assign('/?account_deleted=1')
+    } catch (err: unknown) {
+      logError('Account.delete', err)
+      setDeleting(false)
+      setDeleteError(
+        `We could not delete your account automatically. Please email ${SUPPORT_EMAIL} and we will erase it within 30 days.`,
+      )
+    }
+  }
+
   if (authLoading) {
     return (
       <div className="p-4 md:p-8 min-h-[320px]">
@@ -170,31 +201,63 @@ export function Account() {
               </Button>
             </Card>
 
-            {/* Danger zone (GDPR erasure). In-app self-service deletion is
-                deferred until the delete-account Edge Function is deployed and
-                its table list audited; erasure is handled via an email request
-                meanwhile. See .kiro/ux/audit-2026-06-24/DEFERRED-delete-account.md. */}
+            {/* Danger zone (GDPR erasure) */}
             <Card padding="md" className="!border-danger/30">
               <h2 className="text-lg font-semibold tracking-[-0.01em] text-danger mb-1">Delete account</h2>
               <p className="text-text-muted text-sm mb-4 max-w-prose">
-                To permanently delete your account and all your data (exam attempts, domain progress, and your sign-in), email us from your account address and we will erase everything within 30 days. This cannot be undone.
+                Permanently delete your account and all your data: exam attempts, domain progress, and your sign-in. This cannot be undone.
               </p>
               <Button
-                onClick={() => {
-                  window.location.href =
-                    `mailto:${SUPPORT_EMAIL}` +
-                    `?subject=${encodeURIComponent('Account deletion request')}` +
-                    `&body=${encodeURIComponent(`Please delete my CloudCertPrep account and all associated data.\n\nAccount email: ${user.email ?? ''}`)}`
-                }}
-                variant="secondary"
+                onClick={() => { setConfirmText(''); setDeleteError(null); setShowDeleteModal(true) }}
+                variant="danger"
                 leftIcon={<Trash2 className="w-4 h-4" aria-hidden="true" />}
               >
-                Email a deletion request
+                Delete my account
               </Button>
             </Card>
           </div>
         )}
       </div>
+
+      <Modal
+        isOpen={showDeleteModal}
+        title="Delete your account?"
+        onClose={() => { if (!deleting) setShowDeleteModal(false) }}
+      >
+        <div className="space-y-4">
+          <p className="text-text-primary">
+            This permanently erases your account, exam history, and progress. It cannot be undone.
+          </p>
+          <p className="text-sm text-text-muted">
+            Type <span className="font-mono font-semibold text-text-primary">DELETE</span> to confirm.
+          </p>
+          <Input
+            value={confirmText}
+            onChange={e => setConfirmText(e.target.value)}
+            aria-label="Type DELETE to confirm account deletion"
+            placeholder="DELETE"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            disabled={deleting}
+          />
+          {deleteError && <Alert tone="danger" role="alert">{deleteError}</Alert>}
+          {deleting ? (
+            <div className="py-4">
+              <LoadingSpinner text="Deleting your account..." />
+            </div>
+          ) : (
+            <div className="flex gap-3 mt-2">
+              <Button onClick={() => setShowDeleteModal(false)} variant="secondary" className="flex-1">
+                Cancel
+              </Button>
+              <Button onClick={handleDelete} disabled={confirmText !== 'DELETE'} variant="danger" className="flex-1">
+                Delete account
+              </Button>
+            </div>
+          )}
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/src/pages/_Stats.tsx
+++ b/src/pages/_Stats.tsx
@@ -9,11 +9,9 @@ import { CERTIFICATION_LIST, getCertTotalQuestions, getCertDomains } from '../da
 import { Trophy, TrendingUp, Clock, Check, RotateCw } from 'lucide-react'
 import { logError } from '../lib/logger'
 
-interface PlatformStats {
+interface PublicTotals {
   total_users: number
   total_questions_answered: number
-  total_exams_attempted: number
-  total_exams_passed: number
 }
 
 interface RecentWin {
@@ -47,7 +45,7 @@ interface StatsProps {
 }
 
 export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}) {
-  const [stats, setStats] = useState<PlatformStats | null>(null)
+  const [publicTotals, setPublicTotals] = useState<PublicTotals | null>(null)
   const [certStats, setCertStats] = useState<Record<string, CertStats>>({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -63,19 +61,16 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
       setError(null)
 
       const supabase = await getSupabase()
-      // Load platform stats from singleton table
-      const { data: statsData, error: statsError } = await supabase
-        .from('platform_stats')
-        .select('*')
-        .eq('id', 'singleton')
-        .single()
+      // Load live totals via SECURITY DEFINER RPC (bypasses RLS on auth.users /
+      // attempt_questions). Falls back silently if the function is not yet
+      // deployed on this env - the footer just won't render rather than erroring.
+      const { data: totalsData, error: totalsError } = await supabase
+        .rpc('get_public_totals')
 
-      if (statsError && statsError.code !== 'PGRST116') {
-        logError('Stats.loadStats.platformStats', statsError)
-      }
-
-      if (statsData) {
-        setStats(statsData)
+      if (totalsError) {
+        logError('Stats.loadStats.publicTotals', totalsError)
+      } else if (totalsData) {
+        setPublicTotals(totalsData)
       }
 
       // Load aggregate exam stats via SECURITY DEFINER RPC
@@ -382,11 +377,11 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
             )
           })}
 
-          {/* Platform Totals */}
-          {stats && (
+          {/* Platform Totals - live counts via get_public_totals() RPC */}
+          {publicTotals && (
             <div className="border-t border-text-muted/10 pt-6">
               <p className="text-text-muted text-xs md:text-sm text-center">
-                {stats.total_users.toLocaleString('en-US')} users · {stats.total_questions_answered.toLocaleString('en-US')} questions answered across all certifications
+                {publicTotals.total_users.toLocaleString('en-US')} users · {publicTotals.total_questions_answered.toLocaleString('en-US')} questions answered across all certifications
               </p>
             </div>
           )}

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -129,7 +129,7 @@ const breadcrumbItems = [
         <section>
           <h2 class="text-lg md:text-xl font-semibold text-text-primary mb-3">Data retention</h2>
           <p class="text-text-muted text-base leading-[1.7]">
-            We retain your account data for as long as your account is active. To delete your account, email a deletion request and we will remove all your personal data within 30 days. Anonymized, aggregated statistics (e.g., total exams passed) may be retained indefinitely as they cannot identify you.
+            We retain your account data for as long as your account is active. If you delete your account from your account settings, your personal data is erased immediately and permanently. If you instead email a deletion request, we will remove all your personal data within 30 days. Anonymized, aggregated statistics (e.g., total exams passed) may be retained indefinitely as they cannot identify you.
           </p>
         </section>
 
@@ -175,7 +175,7 @@ const breadcrumbItems = [
             </li>
           </ul>
           <p class="text-text-muted text-base leading-[1.7] mt-3">
-            If you have an account, you can export your data at any time from your <a href="/account" class="text-text-primary underline underline-offset-2 hover:text-text-primary/70 transition-colors">account settings</a>. To delete your account, or for any other request, email <a href="mailto:alex@cloudcertprep.io" class="text-text-primary underline underline-offset-2 hover:text-text-primary/70 transition-colors">alex@cloudcertprep.io</a> and we will respond within 30 days.
+            If you have an account, you can export your data or permanently delete your account at any time from your <a href="/account" class="text-text-primary underline underline-offset-2 hover:text-text-primary/70 transition-colors">account settings</a>. For any other request, email <a href="mailto:alex@cloudcertprep.io" class="text-text-primary underline underline-offset-2 hover:text-text-primary/70 transition-colors">alex@cloudcertprep.io</a> and we will respond within 30 days.
           </p>
         </section>
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -39,8 +39,8 @@ One row per question shown in an attempt. Used for History review and `domain_pr
 | Column | Type | Notes |
 |---|---|---|
 | `id` | `uuid` PK | |
-| `attempt_id` | `uuid` FK | References `exam_attempts(id)`, cascade on delete |
-| `user_id` | `uuid` FK | Denormalised for RLS efficiency |
+| `attempt_id` | `uuid` FK | References `exam_attempts(id)`, cascade on delete. NULL for Domain Practice rows (no parent exam). |
+| `user_id` | `uuid` FK | References `auth.users(id)`, cascade on delete. Denormalised for RLS efficiency. The user_id cascade is load-bearing: Domain Practice rows have `attempt_id = NULL`, so the attempt_id cascade never reaches them. |
 | `cert_code` | `text` NOT NULL | |
 | `question_id` | `text` NOT NULL | e.g. `'CLF-D3-0142'` |
 | `domain_id` | `integer` NOT NULL | 1-N (any positive integer) |
@@ -61,7 +61,7 @@ One row per `(user_id, cert_code, domain_id)`. Materialised view of attempt_ques
 
 | Column | Type | Notes |
 |---|---|---|
-| `user_id` | `uuid` FK | |
+| `user_id` | `uuid` FK | References `auth.users(id)`, cascade on delete |
 | `cert_code` | `text` NOT NULL | |
 | `domain_id` | `integer` NOT NULL | |
 | `questions_attempted` | `integer` NOT NULL | Unique question count |
@@ -145,8 +145,17 @@ Full source: see `src/pages/_Stats.tsx` for the call site. If you change the fun
 Self-service GDPR "right to erasure" backing the **Delete account** button on `/account`.
 RLS lets a user delete their own data rows but cannot remove the `auth.users` row itself
 (only the service_role can), so deletion runs server-side. The function authenticates the
-caller from their forwarded JWT, deletes their `attempt_questions`, `exam_attempts`, and
+caller from their forwarded JWT (it deletes ONLY that caller's own `auth.uid()`, never an id
+from the request body), deletes their `attempt_questions`, `exam_attempts`, and
 `domain_progress` rows, then deletes the `auth.users` row.
+
+The data tables now carry `ON DELETE CASCADE` FKs to `auth.users(id)` (see
+`supabase/sql/delete-account-cascade.sql`), so deleting the auth row alone erases the data;
+the explicit per-table deletes in the function are kept as defence-in-depth. `question_mastery`
+is deliberately NOT in the delete list - it is a read-only VIEW over `attempt_questions`
+(below), so erasing `attempt_questions` empties it. `platform_stats` is excluded too (a public
+aggregate, not personal data). Apply the cascade SQL to a project before relying on it for
+deletion; verify with `node scripts/verify-delete-cascade.mjs`.
 
 **Deploy (owner, one-time):**
 

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -4,11 +4,23 @@
 // auth.users row itself - only the service_role / Admin API can. So account
 // deletion has to run server-side. This Edge Function:
 //   1. Identifies the caller from their JWT (the Authorization header that
-//      supabase.functions.invoke forwards automatically).
-//   2. Deletes the caller's data rows with the service_role client (explicit,
-//      so it works even if a table's FK lacks ON DELETE CASCADE - see the
-//      attempt_questions note in src/pages/_History.tsx).
-//   3. Deletes the auth.users row (cascades to anything still referencing it).
+//      supabase.functions.invoke forwards automatically). It deletes ONLY this
+//      authenticated caller's own auth.uid(); it never reads an id from the
+//      request body, so a user can never delete another account.
+//   2. Defence-in-depth: deletes the caller's data rows explicitly with the
+//      service_role client BEFORE deleting the auth user. Once
+//      supabase/sql/delete-account-cascade.sql is applied, deleting the
+//      auth.users row alone cascades these away - but the explicit deletes guard
+//      against a future cascade regression, matching the owner's "no orphaned
+//      data" posture. The list is exactly the user-keyed BASE TABLES:
+//        attempt_questions, exam_attempts, domain_progress
+//      `question_mastery` is deliberately ABSENT: it is a read-only VIEW over
+//      attempt_questions (see supabase/README.md), so it has no rows of its own
+//      and is not deletable - erasing attempt_questions empties it. If the live
+//      schema ever turns it into a real table, add it here AND to the cascade SQL.
+//      `platform_stats` is excluded too (a public aggregate, not personal data).
+//   3. Deletes the auth.users row (the cascade then removes anything still
+//      referencing it).
 //
 // Deploy (owner, one-time):
 //   supabase functions deploy delete-account --project-ref <ref>

--- a/supabase/sql/delete-account-cascade.sql
+++ b/supabase/sql/delete-account-cascade.sql
@@ -1,0 +1,179 @@
+-- delete-account-cascade.sql
+-- =============================================================================
+-- Make deleting an auth user cascade-delete all of their data rows.
+--
+-- WHO RUNS THIS: the OWNER, by hand, in the Supabase SQL editor. A coding agent
+-- never applies this. Apply to the TEST project (ref lqnchqfltmognaoudoqc)
+-- FIRST, verify with scripts/verify-delete-cascade.mjs, THEN apply to PROD
+-- (ref gegbjeluttwwiccyukka).
+--
+-- WHAT IT DOES: FK-constraint changes ONLY. It recreates the user-owned foreign
+-- keys with `on delete cascade`. There is NO `drop table`, NO `delete from`, NO
+-- `truncate`, NO data mutation. Adding `on delete cascade` does NOT delete any
+-- existing rows; it only changes what a FUTURE `delete from auth.users` does.
+-- Cascade direction is parent -> child only: deleting an auth.users row deletes
+-- the child rows; deleting a child row never deletes the user.
+--
+-- WHY: today, deleting an auth user (dashboard or admin API) can leave orphaned
+-- personal data behind (a GDPR / data-hygiene gap), and it blocks self-service
+-- account deletion. See .kiro/maintenance/DELETE-USER-CASCADE-2026-06-28.md.
+--
+-- STATUS (2026-06-29): scripts/verify-delete-cascade.mjs confirms the TEST
+-- project (lqnchqfltmognaoudoqc) ALREADY cascades fully - deleting an auth user
+-- removed its exam_attempts, domain_progress, AND both attempt_questions rows
+-- (including the attempt_id = NULL practice row that only the user_id cascade can
+-- reach), with no collateral to other users. So on a project that is already
+-- wired, STEP 3 is a safe idempotent no-op assertion. PROD has NOT been checked
+-- from here (we never point tooling at prod): run STEP 1 on PROD to see its
+-- current rules, then STEP 3 to guarantee them, then verify with
+-- `node scripts/verify-delete-cascade.mjs --allow-prod`.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- STEP 1 (READ-ONLY) - Inventory the user-owned foreign keys and their current
+-- ON DELETE rule. Run this FIRST and read the output. It is the authoritative
+-- answer to "which tables, which constraint names, and do they already cascade".
+-- If a constraint name below differs from the conventional `<table>_<col>_fkey`
+-- used in STEP 3, substitute the REAL name from this output.
+--
+-- confdeltype legend: a = NO ACTION, r = RESTRICT, c = CASCADE, n = SET NULL,
+--                     d = SET DEFAULT
+-- -----------------------------------------------------------------------------
+select
+  rel.relname                          as table_name,
+  att.attname                          as column_name,
+  con.conname                          as constraint_name,
+  fnsp.nspname || '.' || fref.relname  as references,
+  case con.confdeltype
+    when 'c' then 'CASCADE'
+    when 'n' then 'SET NULL'
+    when 'd' then 'SET DEFAULT'
+    when 'r' then 'RESTRICT'
+    else 'NO ACTION'
+  end                                  as on_delete
+from pg_constraint con
+join pg_class      rel  on rel.oid  = con.conrelid
+join pg_namespace  nsp  on nsp.oid  = rel.relnamespace
+join pg_class      fref on fref.oid = con.confrelid
+join pg_namespace  fnsp on fnsp.oid = fref.relnamespace
+join lateral unnest(con.conkey) as cols(attnum) on true
+join pg_attribute  att  on att.attrelid = rel.oid and att.attnum = cols.attnum
+where con.contype = 'f'
+  and nsp.nspname = 'public'
+order by rel.relname, att.attname;
+
+
+-- -----------------------------------------------------------------------------
+-- STEP 1b (READ-ONLY) - List every PUBLIC object that has a `user_id` column and
+-- whether it is a BASE TABLE or a VIEW. This confirms the full set of user-keyed
+-- objects (catch anything the app code does not reference) AND settles the
+-- `question_mastery` question: supabase/README.md documents it as a read-only
+-- VIEW over attempt_questions (SECURITY INVOKER). If it shows as VIEW here, it
+-- needs NO cascade FK and must NOT be added to the edge-function delete loop
+-- (a computed view has no rows of its own and is not deletable). If it instead
+-- shows as BASE TABLE, apply the APPENDIX block at the bottom of this file.
+-- `platform_stats` has NO user_id (it is a public singleton aggregate) and is
+-- intentionally excluded everywhere.
+-- -----------------------------------------------------------------------------
+select c.table_name, t.table_type, c.data_type
+from information_schema.columns c
+join information_schema.tables  t
+  on t.table_schema = c.table_schema and t.table_name = c.table_name
+where c.column_name = 'user_id'
+  and c.table_schema = 'public'
+order by t.table_type, c.table_name;
+
+
+-- -----------------------------------------------------------------------------
+-- STEP 2 (READ-ONLY) - Pre-existing orphan audit. Rows whose user_id no longer
+-- matches any auth.users id are data left behind by PAST deletions (before this
+-- cascade existed). They MUST read 0 for every table, otherwise the
+-- `add constraint ... references auth.users(id)` in STEP 3 will FAIL (the
+-- orphan rows violate the new FK). If any count is > 0, decide per table:
+-- delete the accountless rows (GDPR cleanup) or investigate first. Surface the
+-- counts in the PR; never silently skip.
+-- -----------------------------------------------------------------------------
+select 'exam_attempts'     as table_name, count(*) as orphan_rows
+  from public.exam_attempts     t left join auth.users u on u.id = t.user_id where u.id is null
+union all
+select 'attempt_questions', count(*)
+  from public.attempt_questions t left join auth.users u on u.id = t.user_id where u.id is null
+union all
+select 'domain_progress',   count(*)
+  from public.domain_progress   t left join auth.users u on u.id = t.user_id where u.id is null;
+
+-- If (and only if) the audit shows orphans AND you have decided to remove them,
+-- run the matching delete(s) below BEFORE STEP 3. Commented out by default.
+--   delete from public.exam_attempts     t where not exists (select 1 from auth.users u where u.id = t.user_id);
+--   delete from public.attempt_questions t where not exists (select 1 from auth.users u where u.id = t.user_id);
+--   delete from public.domain_progress   t where not exists (select 1 from auth.users u where u.id = t.user_id);
+
+
+-- -----------------------------------------------------------------------------
+-- STEP 3 (DDL) - Recreate the user-owned FKs with ON DELETE CASCADE.
+--
+-- Run inside a transaction. On PROD: take a snapshot / PITR checkpoint first,
+-- then run this transaction, verify the constraints with STEP 1 again, and only
+-- then `commit;` (or `rollback;` if anything looks off). `drop constraint if
+-- exists` makes each statement idempotent and safe to re-run; per
+-- supabase/README.md, exam_attempts.user_id and attempt_questions.attempt_id may
+-- already cascade - recreating them is a no-op in effect.
+--
+-- attempt_questions.user_id is the LOAD-BEARING addition: Domain Practice writes
+-- attempt_questions rows with attempt_id = NULL (no parent exam_attempt), so the
+-- attempt_id -> exam_attempts cascade never reaches them. Without an explicit
+-- user_id -> auth.users cascade, those practice rows survive a user deletion.
+-- (See the comment at src/pages/_History.tsx ~line 340.)
+-- -----------------------------------------------------------------------------
+begin;
+
+-- exam_attempts.user_id -> auth.users(id)  (README says this already cascades;
+-- recreating asserts it.)
+alter table public.exam_attempts
+  drop constraint if exists exam_attempts_user_id_fkey;
+alter table public.exam_attempts
+  add  constraint exam_attempts_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade;
+
+-- attempt_questions.user_id -> auth.users(id)  (THE gap: covers attempt_id NULL
+-- practice rows.)
+alter table public.attempt_questions
+  drop constraint if exists attempt_questions_user_id_fkey;
+alter table public.attempt_questions
+  add  constraint attempt_questions_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade;
+
+-- attempt_questions.attempt_id -> exam_attempts(id)  (README says this already
+-- cascades; recreating asserts it - deleting an exam_attempt removes its rows.)
+alter table public.attempt_questions
+  drop constraint if exists attempt_questions_attempt_id_fkey;
+alter table public.attempt_questions
+  add  constraint attempt_questions_attempt_id_fkey
+  foreign key (attempt_id) references public.exam_attempts(id) on delete cascade;
+
+-- domain_progress.user_id -> auth.users(id)  (gap: README lists a plain FK.)
+alter table public.domain_progress
+  drop constraint if exists domain_progress_user_id_fkey;
+alter table public.domain_progress
+  add  constraint domain_progress_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade;
+
+-- Re-run STEP 1 here and confirm all four show on_delete = CASCADE before commit.
+commit;
+
+
+-- -----------------------------------------------------------------------------
+-- APPENDIX - ONLY IF STEP 1b shows `question_mastery` as a BASE TABLE.
+-- Per supabase/README.md it is a VIEW, in which case SKIP this entirely. If the
+-- live schema diverges and it is a real table keyed by user_id, uncomment and
+-- run this too, AND add 'question_mastery' to the edge-function delete loop in
+-- supabase/functions/delete-account/index.ts.
+-- -----------------------------------------------------------------------------
+-- begin;
+-- alter table public.question_mastery
+--   drop constraint if exists question_mastery_user_id_fkey;
+-- alter table public.question_mastery
+--   add  constraint question_mastery_user_id_fkey
+--   foreign key (user_id) references auth.users(id) on delete cascade;
+-- commit;


### PR DESCRIPTION
## Self-service account deletion + DB cascade for full user-data erasure

Two linked deliverables (`.kiro/maintenance/DELETE-USER-CASCADE-2026-06-28.md`):
**A)** deleting an auth user must cascade-delete all their data; **B)** users can
delete their own account from `/account` (was a `mailto`). A is verified first;
B is gated on A being live.

### Phase A - DB cascade (owner applies the SQL; this PR only writes + verifies it)

`supabase/sql/delete-account-cascade.sql` - FK-constraint changes ONLY (no
`drop table` / `delete` / `truncate`; adding `on delete cascade` does not delete
existing rows). Recreates the user-owned FKs to `auth.users(id)` with
`on delete cascade`:

| FK | Why |
|---|---|
| `exam_attempts.user_id` | README says it already cascades; reasserted |
| `attempt_questions.user_id` | **the load-bearing gap** - Domain Practice rows have `attempt_id = NULL`, so the `exam_attempts` cascade never reaches them (see `src/pages/_History.tsx` ~L340) |
| `attempt_questions.attempt_id -> exam_attempts(id)` | already cascades; reasserted |
| `domain_progress.user_id` | README listed a plain FK |

**Excluded on purpose:** `question_mastery` is a read-only **VIEW** over
`attempt_questions` (`supabase/README.md`) - no rows of its own, not deletable;
erasing `attempt_questions` empties it. (This corrects the earlier
`DEFERRED-delete-account.md` note that assumed it was a table.) `platform_stats`
is a public aggregate, not personal data.

The SQL leads with **STEP 1 (read-only inspection)** that lists every public FK to
`auth.users` with its current `on delete` rule, **STEP 1b** that classifies every
`user_id` object as TABLE vs VIEW (settles `question_mastery` authoritatively and
catches any table the app code does not reference), and **STEP 2 (read-only orphan
audit)** - run these first and read the output. If a constraint name differs from
the conventional `<table>_<col>_fkey`, substitute the real one from STEP 1.

**Verification:** `node scripts/verify-delete-cascade.mjs` creates two throwaway
users, writes rows to every user table, deletes one via the admin API, and asserts
that user's rows are all gone while the other user's are untouched. It is **test-ref
guarded** (refuses to run unless `.env.local` points at the test project) and always
cleans up its throwaway users.

> **Finding (2026-06-29):** run against the TEST project it already reports
> **CASCADE OK** - exam_attempts, domain_progress, AND both attempt_questions rows
> (including the `attempt_id = NULL` practice row) were erased, no collateral. So
> the mechanism already works on test. STEP 3 is therefore a safe **idempotent
> no-op assertion** where cascade already exists. **PROD has not been checked from
> here** (tooling is never pointed at prod): run STEP 1 on prod to see its real
> rules, apply STEP 3, then `node scripts/verify-delete-cascade.mjs --allow-prod`.

### Phase B - self-service deletion (this PR's app changes)

- **Edge function** `supabase/functions/delete-account/index.ts`: resolves the
  caller from their JWT and deletes **only that caller's own `auth.uid()`** (never a
  body id - no cross-account deletion). Explicit per-table deletes kept as
  defence-in-depth on top of the cascade; `question_mastery` correctly absent.
- **`/account`**: restored the "Delete my account" danger card + a type-`DELETE`
  confirm modal -> `supabase.functions.invoke('delete-account')` -> local sign-out ->
  redirect to `/?account_deleted=1` (the existing `AuthLinkNotice` banner). On error
  it falls back to the email path. Data export is unchanged.
- **Privacy copy** restored to self-service erasure; `supabase/README.md` schema
  docs updated (FK cascades + the view/aggregate exclusions).

Screenshots (dark + light, type-DELETE gating verified) captured via the
seeded-session harness.

### Gates
`astro check` (0 errors), `npm run lint`, `npm run test` (248 passing),
`npm run build` (all guards green). Build-regenerated `_csp/llms/sitemap` are
intentionally not committed.

### OWNER ACTIONS (merge is gated on both)
1. **Apply the Phase-A SQL on TEST** (Supabase SQL editor): run STEP 1 / 1b / 2,
   review, paste the orphan counts below, then run STEP 3 (in the transaction).
   Re-run `node scripts/verify-delete-cascade.mjs` -> expect CASCADE OK.
2. **Apply it on PROD**: snapshot / PITR first, run STEP 3 inside the transaction,
   verify constraints with STEP 1, `commit`, then
   `node scripts/verify-delete-cascade.mjs --allow-prod`.
3. **Deploy the edge function:** `supabase functions deploy delete-account`.
4. **Do not merge until 1-3 are done** - the UI would otherwise invoke a function
   that is not deployed / rely on a cascade that is not live.

Pre-existing orphan counts (paste STEP 2 output here): _exam_attempts: _,
_attempt_questions: _, _domain_progress: _.
