### PR TITLE
fix(stats): resilience against resolved RPC errors and shape drift (hardening PR-9)

### DIFF
--- a/src/components/StatsIsland.tsx
+++ b/src/components/StatsIsland.tsx
@@ -12,6 +12,7 @@
  * router-internally — every link is a real anchor to another Astro document.
  */
 import { Stats } from '../pages/_Stats'
+import { ErrorBoundary } from './ErrorBoundary'
 
 const SNAPSHOT_SELECTOR = '[data-stats-snapshot]'
 
@@ -27,5 +28,12 @@ export default function StatsIsland() {
   // -> live numbers (content going backwards). Instead the snapshot IS the
   // loading state: _Stats suppresses its first-load skeleton, and we hide the
   // snapshot the moment live numbers are ready (one forward swap, no flash).
-  return <Stats hideInitialSkeleton onLoaded={hideSnapshot} />
+  // ErrorBoundary: AppIsland wraps only the app routes, so without one here a
+  // render throw would unmount the island into a blank page (the snapshot is
+  // already display:none by then).
+  return (
+    <ErrorBoundary>
+      <Stats hideInitialSkeleton onLoaded={hideSnapshot} />
+    </ErrorBoundary>
+  )
 }

--- a/src/pages/_Stats.tsx
+++ b/src/pages/_Stats.tsx
@@ -59,6 +59,10 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
     try {
       setLoading(true)
       setError(null)
+      // Reset the footer so a retry can never leave a stale totals line from a
+      // prior success next to freshly retried cert stats; it only re-renders
+      // from a fresh, validated RPC result below.
+      setPublicTotals(null)
 
       const supabase = await getSupabase()
       // Load live totals via SECURITY DEFINER RPC (bypasses RLS on auth.users /
@@ -69,7 +73,14 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
 
       if (totalsError) {
         logError('Stats.loadStats.publicTotals', totalsError)
-      } else if (totalsData) {
+      } else if (
+        Number.isFinite(totalsData?.total_users) &&
+        Number.isFinite(totalsData?.total_questions_answered) &&
+        totalsData.total_users > 0
+      ) {
+        // Shape-validated before storing: a drifted return (missing/null field,
+        // RETURNS TABLE array wrapping) must hide the footer, not throw in
+        // render. Zero users hides it too instead of bragging about "0 users".
         setPublicTotals(totalsData)
       }
 
@@ -79,7 +90,12 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
         .rpc('get_public_exam_stats')
 
       if (examStatsError) {
+        // postgrest-js resolves almost every failure (rate limit, restart,
+        // missing function) as {error} rather than throwing, so a resolved
+        // error must fail the load too - otherwise the snapshot is swapped
+        // for "Be the first" placeholders with no error UI and no retry.
         logError('Stats.loadStats.examStats', examStatsError)
+        setError('Failed to load statistics')
       }
 
       if (examStats?.cert_stats) {
@@ -89,7 +105,7 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
         }
         setCertStats(certStatsMap)
       }
-      ok = true
+      ok = !examStatsError
 
     } catch (err: unknown) {
       logError('Stats.loadStats', err)

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -73,15 +73,11 @@ Primary key: `(user_id, cert_code, domain_id)`.
 
 **RLS:** enabled. `auth.uid() = user_id`.
 
-> **Known live-schema gotcha (found 2026-06-12):** production carries a CLF-era check constraint
-> `domain_progress_domain_id_check` that **rejects `domain_id = 5`** (23514), so AIF-C01 domain-5
-> progress upserts fail silently (the app only logs). `attempt_questions` is not affected. Fix
-> (pending owner run):
->
-> ```sql
-> ALTER TABLE public.domain_progress DROP CONSTRAINT domain_progress_domain_id_check;
-> ALTER TABLE public.domain_progress ADD CONSTRAINT domain_progress_domain_id_check CHECK (domain_id >= 1);
-> ```
+> **Resolved schema gotcha (found 2026-06-12, fixed by 2026-07-02):** production used to carry a
+> CLF-era check constraint `domain_progress_domain_id_check` that rejected `domain_id = 5`, so AIF-C01
+> domain-5 progress upserts failed silently. Confirmed fixed on prod (verified via
+> `pg_get_constraintdef`): the constraint now reads `CHECK (domain_id >= 1)`, which allows domain 5
+> (and any future domain). No further action needed.
 
 ---
 


### PR DESCRIPTION
## What

Implements hardening bundle PR-9 (the audit's "real winner": the only P2s in the #122-#128 cluster). Source: `.kiro/maintenance/POST-MERGE-HARDENING-FINDINGS-2026-07-02.md` F1 + F2 + smaller note 8, sequenced by `.kiro/maintenance/IMPLEMENTATION-QUEUE-2026-07-02.md` item 1.

- **F1 (P2):** `loadStats` now fails the load when `get_public_exam_stats` resolves with an `{error}` (`ok = !examStatsError` + sets the error state). postgrest-js resolves almost every real-world failure instead of throwing, so previously any backend hiccup silently swapped the prerendered snapshot for "Be the first" placeholders with no error UI. Now the real cached numbers stay behind the existing "Showing the latest saved figures" retry alert. Totals stay independent per the finding.
- **F2 (P2 if triggered):** `get_public_totals` results are shape-validated before storing (`Number.isFinite` on both fields, `total_users > 0`), and `StatsIsland` wraps `<Stats>` in the existing `ErrorBoundary` (AppIsland only covers app routes). A drifted RPC shape previously crashed the island into a blank page.
- **Note 8:** `publicTotals` resets at the start of every load so a failed-totals retry cannot show a stale footer next to freshly retried cert stats.
- **Rider (queue top note):** `supabase/README.md` domain-5 constraint note corrected from "pending owner run" to resolved (owner verified fixed on prod 2026-07-02 via `pg_get_constraintdef`). This was sitting uncommitted in the main working tree; committed here as instructed by the queue doc.

## Verified

- Full local gate green: `astro check` (0 errors), `lint`, `test` (248/248), `npm run build` incl. all prebuild/postbuild guards.
- Functional (preview :4500, Playwright, TEST Supabase project only; no users created): 6/6 scenarios pass. Harness + screenshots: `.kiro/maintenance/overnight-2026-07-02/stats-resilience/` (harness kept in the gitignored .kiro dir, not in this PR).
  - A: natural F1 state (TEST is missing `get_public_exam_stats`, PGRST202): snapshot stays + retry alert, island grid never swaps in. Light + dark.
  - B: injected `{"total_users":0}` (the audit's exact crash repro): grid renders, footer hidden, zero page errors (was: blank page + TypeError).
  - C: injected render-throwing cert_stats: ErrorBoundary recovery card shows (was: blank page).
  - D: totals-OK/stats-500 first load, then Try again with totals-500/stats-OK: fresh stats render with NO stale footer.
  - E: happy path: live grid + validated footer, single forward snapshot swap.

## For the owner

- TEST project is still missing `get_public_exam_stats` (owner-action item A1 in the queue); scenario A doubles as a live demo of what prod users would see during an RPC hiccup once this merges.
- The F1 fix means a resolved error now surfaces the retry alert on /stats where before it was silent. That is the finding's stated intent, but it is a user-visible behavior change worth a 10-second look at the A screenshots.