### PR TITLE
feat(results): share my result / copy my breakdown (Growth Build 1, phase 1)

### DIFF
--- a/src/components/ShareResultButton.tsx
+++ b/src/components/ShareResultButton.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react'
+import { Share2, Check, Copy } from 'lucide-react'
+import { trackEvent } from '../lib/analytics'
+import { copyText } from '../lib/clipboard'
+
+interface ShareResultButtonProps {
+  /** Full text to share/copy, prebuilt by the caller (lib/shareResult.ts). */
+  text: string
+  /** Idle label, e.g. "Share my result" / "Copy my domain breakdown". */
+  label: string
+  /** Extra share_result params (outcome/cert/authed) for phase-2 gating. */
+  analytics: Record<string, unknown>
+  /**
+   * Skip navigator.share and go straight to the clipboard. The fail-state
+   * variant is "copy for study notes", not a share-sheet moment.
+   */
+  copyOnly?: boolean
+}
+
+type CopyState = 'idle' | 'copied' | 'failed'
+
+/**
+ * Quiet share/copy pill for the results screen (Growth Build 1, phase 1).
+ * navigator.share where available (mobile), clipboard fallback with a
+ * transient "Copied" state elsewhere. Deliberately low-key styling: for
+ * guests it must stay visually secondary to UnlockCTA, whose sign-in is the
+ * more valuable conversion.
+ */
+export function ShareResultButton({ text, label, analytics, copyOnly = false }: ShareResultButtonProps) {
+  const [copyState, setCopyState] = useState<CopyState>('idle')
+  const resetTimer = useRef<number | null>(null)
+
+  useEffect(() => () => {
+    if (resetTimer.current !== null) window.clearTimeout(resetTimer.current)
+  }, [])
+
+  function flashState(state: 'copied' | 'failed') {
+    setCopyState(state)
+    if (resetTimer.current !== null) window.clearTimeout(resetTimer.current)
+    resetTimer.current = window.setTimeout(() => setCopyState('idle'), 2000)
+  }
+
+  async function handleClick() {
+    if (!copyOnly && typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ text })
+        trackEvent('share_result', { ...analytics, method: 'web_share' })
+        return
+      } catch (err) {
+        // AbortError = the user closed the share sheet: not a failure, not a
+        // share. Anything else (unsupported payload) falls through to copy.
+        if (err instanceof DOMException && err.name === 'AbortError') return
+      }
+    }
+    const copied = await copyText(text)
+    flashState(copied ? 'copied' : 'failed')
+    if (copied) trackEvent('share_result', { ...analytics, method: 'clipboard' })
+  }
+
+  const Icon = copyState === 'copied' ? Check : copyOnly ? Copy : Share2
+  const shownLabel =
+    copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Could not copy' : label
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-border-hairline bg-bg-card px-5 text-sm font-medium text-text-primary transition-colors duration-200 hover:border-text-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-muted/40"
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      <span aria-live="polite">{shownLabel}</span>
+    </button>
+  )
+}

--- a/src/components/ShareResultButton.tsx
+++ b/src/components/ShareResultButton.tsx
@@ -1,20 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
-import { Share2, Check, Copy } from 'lucide-react'
+import { Share2, Check } from 'lucide-react'
 import { trackEvent } from '../lib/analytics'
 import { copyText } from '../lib/clipboard'
 
 interface ShareResultButtonProps {
   /** Full text to share/copy, prebuilt by the caller (lib/shareResult.ts). */
   text: string
-  /** Idle label, e.g. "Share my result" / "Copy my domain breakdown". */
+  /** Idle label, e.g. "Share my result". */
   label: string
-  /** Extra share_result params (outcome/cert/authed) for phase-2 gating. */
+  /** Extra share_result params (cert/authed) for phase-2 gating. */
   analytics: Record<string, unknown>
-  /**
-   * Skip navigator.share and go straight to the clipboard. The fail-state
-   * variant is "copy for study notes", not a share-sheet moment.
-   */
-  copyOnly?: boolean
 }
 
 type CopyState = 'idle' | 'copied' | 'failed'
@@ -26,7 +21,7 @@ type CopyState = 'idle' | 'copied' | 'failed'
  * guests it must stay visually secondary to UnlockCTA, whose sign-in is the
  * more valuable conversion.
  */
-export function ShareResultButton({ text, label, analytics, copyOnly = false }: ShareResultButtonProps) {
+export function ShareResultButton({ text, label, analytics }: ShareResultButtonProps) {
   const [copyState, setCopyState] = useState<CopyState>('idle')
   const resetTimer = useRef<number | null>(null)
 
@@ -41,7 +36,7 @@ export function ShareResultButton({ text, label, analytics, copyOnly = false }: 
   }
 
   async function handleClick() {
-    if (!copyOnly && typeof navigator.share === 'function') {
+    if (typeof navigator.share === 'function') {
       try {
         await navigator.share({ text })
         trackEvent('share_result', { ...analytics, method: 'web_share' })
@@ -57,7 +52,7 @@ export function ShareResultButton({ text, label, analytics, copyOnly = false }: 
     if (copied) trackEvent('share_result', { ...analytics, method: 'clipboard' })
   }
 
-  const Icon = copyState === 'copied' ? Check : copyOnly ? Copy : Share2
+  const Icon = copyState === 'copied' ? Check : Share2
   const shownLabel =
     copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Could not copy' : label
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -69,6 +69,7 @@ export const KNOWN_EVENTS = [
   // Engagement
   'cta_start_practice_exam', // primary "Start Practice Exam" CTA
   'unlock_cta_clicked',      // guest sign-in nudge in practice/exam
+  'share_result',            // results-screen share/copy (method: web_share | clipboard; outcome: pass | fail)
   'report_question_clicked',
   'donate_click',
   'github_click',

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -69,7 +69,7 @@ export const KNOWN_EVENTS = [
   // Engagement
   'cta_start_practice_exam', // primary "Start Practice Exam" CTA
   'unlock_cta_clicked',      // guest sign-in nudge in practice/exam
-  'share_result',            // results-screen share/copy (method: web_share | clipboard; outcome: pass | fail)
+  'share_result',            // results-screen share, pass-only (method: web_share | clipboard; params: cert, authed)
   'report_question_clicked',
   'donate_click',
   'github_click',

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,15 @@
+/**
+ * Clipboard helper (Growth Build 1: the repo's first share affordance).
+ * The async Clipboard API needs a secure context and a user gesture, so call
+ * this from click handlers only. Returns false instead of throwing so callers
+ * can render a quiet failure state.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    if (!navigator.clipboard?.writeText) return false
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/lib/shareResult.test.ts
+++ b/src/lib/shareResult.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { buildPassShareText, buildFailBreakdownText } from './shareResult'
+import { SITE_URL } from './seo-data'
+
+describe('buildPassShareText', () => {
+  const text = buildPassShareText({
+    certShortName: 'CLF-C02',
+    scaledScore: 830,
+    correctCount: 52,
+    totalQuestions: 65,
+  })
+
+  it('matches the findings-doc share shape', () => {
+    expect(text).toBe(
+      `I scored 830/1000 on the CLF-C02 practice exam at CloudCertPrep (52/65 correct). Free + open source: ${SITE_URL}`
+    )
+  })
+
+  it('links the bare site URL with no score data in params', () => {
+    expect(text).toContain(SITE_URL)
+    expect(text).not.toContain('?')
+  })
+})
+
+describe('buildFailBreakdownText', () => {
+  const text = buildFailBreakdownText({
+    certShortName: 'CLF-C02',
+    correctCount: 32,
+    totalQuestions: 65,
+    domains: [
+      { name: 'Cloud Concepts', percent: 70 },
+      { name: 'Security and Compliance', percent: 45 },
+      { name: 'Cloud Technology and Services', percent: 0 },
+    ],
+  })
+
+  it('lists every domain with its percent plus the overall line', () => {
+    expect(text).toContain('CLF-C02 practice exam domain breakdown (CloudCertPrep):')
+    expect(text).toContain('Cloud Concepts: 70%')
+    expect(text).toContain('Security and Compliance: 45%')
+    expect(text).toContain('Cloud Technology and Services: 0%')
+    expect(text).toContain('Overall: 32/65 correct.')
+  })
+
+  it('never bakes pass/fail language, celebration, or a scaled score into a fail share', () => {
+    expect(text).not.toMatch(/fail/i)
+    expect(text).not.toMatch(/pass/i)
+    expect(text).not.toMatch(/congrat/i)
+    expect(text).not.toMatch(/\/1000/)
+    expect(text).not.toMatch(/scored/i)
+  })
+
+  it('links the bare site URL with no score data in params', () => {
+    expect(text).toContain(SITE_URL)
+    expect(text).not.toContain('?')
+  })
+})

--- a/src/lib/shareResult.test.ts
+++ b/src/lib/shareResult.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildPassShareText, buildFailBreakdownText } from './shareResult'
+import { buildPassShareText } from './shareResult'
 import { SITE_URL } from './seo-data'
 
 describe('buildPassShareText', () => {
@@ -14,40 +14,6 @@ describe('buildPassShareText', () => {
     expect(text).toBe(
       `I scored 830/1000 on the CLF-C02 practice exam at CloudCertPrep (52/65 correct). Free + open source: ${SITE_URL}`
     )
-  })
-
-  it('links the bare site URL with no score data in params', () => {
-    expect(text).toContain(SITE_URL)
-    expect(text).not.toContain('?')
-  })
-})
-
-describe('buildFailBreakdownText', () => {
-  const text = buildFailBreakdownText({
-    certShortName: 'CLF-C02',
-    correctCount: 32,
-    totalQuestions: 65,
-    domains: [
-      { name: 'Cloud Concepts', percent: 70 },
-      { name: 'Security and Compliance', percent: 45 },
-      { name: 'Cloud Technology and Services', percent: 0 },
-    ],
-  })
-
-  it('lists every domain with its percent plus the overall line', () => {
-    expect(text).toContain('CLF-C02 practice exam domain breakdown (CloudCertPrep):')
-    expect(text).toContain('Cloud Concepts: 70%')
-    expect(text).toContain('Security and Compliance: 45%')
-    expect(text).toContain('Cloud Technology and Services: 0%')
-    expect(text).toContain('Overall: 32/65 correct.')
-  })
-
-  it('never bakes pass/fail language, celebration, or a scaled score into a fail share', () => {
-    expect(text).not.toMatch(/fail/i)
-    expect(text).not.toMatch(/pass/i)
-    expect(text).not.toMatch(/congrat/i)
-    expect(text).not.toMatch(/\/1000/)
-    expect(text).not.toMatch(/scored/i)
   })
 
   it('links the bare site URL with no score data in params', () => {

--- a/src/lib/shareResult.ts
+++ b/src/lib/shareResult.ts
@@ -1,13 +1,10 @@
 import { SITE_URL } from './seo-data'
 
 /**
- * Share-text builders for the exam results screen (Growth Build 1, phase 1).
- * Pure and unit-tested. Two hard rules from the growth findings:
- *  - the shared link is always the bare site URL: score data never rides in
- *    URL params (keeps the citation-guard surface and cache behavior clean);
- *  - nothing celebratory, and no pass/fail language or scaled score, is ever
- *    built for a failed attempt. The fail variant is a neutral study-notes
- *    breakdown.
+ * Share-text builder for the exam results screen (Growth Build 1, phase 1).
+ * Pure and unit-tested. Hard rule from the growth findings: the shared link
+ * is always the bare site URL, score data never rides in URL params (keeps
+ * the citation-guard surface and cache behavior clean).
  */
 
 export interface PassShareInput {
@@ -24,26 +21,4 @@ export function buildPassShareText(input: PassShareInput): string {
     `at CloudCertPrep (${input.correctCount}/${input.totalQuestions} correct). ` +
     `Free + open source: ${SITE_URL}`
   )
-}
-
-export interface FailBreakdownInput {
-  certShortName: string
-  correctCount: number
-  totalQuestions: number
-  /** Domain name + this exam's per-domain percent, in display order. */
-  domains: Array<{ name: string; percent: number }>
-}
-
-/**
- * Neutral per-domain breakdown for a failed attempt, meant as self-study
- * notes rather than a brag. Deliberately omits the scaled score and any
- * pass/fail wording.
- */
-export function buildFailBreakdownText(input: FailBreakdownInput): string {
-  const lines = input.domains.map(d => `${d.name}: ${d.percent}%`)
-  return [
-    `${input.certShortName} practice exam domain breakdown (CloudCertPrep):`,
-    ...lines,
-    `Overall: ${input.correctCount}/${input.totalQuestions} correct. Free practice: ${SITE_URL}`,
-  ].join('\n')
 }

--- a/src/lib/shareResult.ts
+++ b/src/lib/shareResult.ts
@@ -1,0 +1,49 @@
+import { SITE_URL } from './seo-data'
+
+/**
+ * Share-text builders for the exam results screen (Growth Build 1, phase 1).
+ * Pure and unit-tested. Two hard rules from the growth findings:
+ *  - the shared link is always the bare site URL: score data never rides in
+ *    URL params (keeps the citation-guard surface and cache behavior clean);
+ *  - nothing celebratory, and no pass/fail language or scaled score, is ever
+ *    built for a failed attempt. The fail variant is a neutral study-notes
+ *    breakdown.
+ */
+
+export interface PassShareInput {
+  certShortName: string
+  scaledScore: number
+  correctCount: number
+  totalQuestions: number
+}
+
+/** Celebratory share text. Callers must gate on `passed`. */
+export function buildPassShareText(input: PassShareInput): string {
+  return (
+    `I scored ${input.scaledScore}/1000 on the ${input.certShortName} practice exam ` +
+    `at CloudCertPrep (${input.correctCount}/${input.totalQuestions} correct). ` +
+    `Free + open source: ${SITE_URL}`
+  )
+}
+
+export interface FailBreakdownInput {
+  certShortName: string
+  correctCount: number
+  totalQuestions: number
+  /** Domain name + this exam's per-domain percent, in display order. */
+  domains: Array<{ name: string; percent: number }>
+}
+
+/**
+ * Neutral per-domain breakdown for a failed attempt, meant as self-study
+ * notes rather than a brag. Deliberately omits the scaled score and any
+ * pass/fail wording.
+ */
+export function buildFailBreakdownText(input: FailBreakdownInput): string {
+  const lines = input.domains.map(d => `${d.name}: ${d.percent}%`)
+  return [
+    `${input.certShortName} practice exam domain breakdown (CloudCertPrep):`,
+    ...lines,
+    `Overall: ${input.correctCount}/${input.totalQuestions} correct. Free practice: ${SITE_URL}`,
+  ].join('\n')
+}

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -16,7 +16,7 @@ import { MatchingInput } from '../components/MatchingInput'
 import { Modal } from '../components/Modal'
 import { PassFailBanner } from '../components/PassFailBanner'
 import { ShareResultButton } from '../components/ShareResultButton'
-import { buildPassShareText, buildFailBreakdownText } from '../lib/shareResult'
+import { buildPassShareText } from '../lib/shareResult'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import { QuestionReviewCard } from '../components/QuestionReviewCard'
 import { UnlockCTA } from '../components/landing/UnlockCTA'
@@ -804,41 +804,29 @@ export function MockExam() {
           />
           {/* Share affordance lives WITH the banner (the celebration moment),
               not in the bottom action stack, which stays donate's territory.
-              A pass gets the celebratory text share; a fail gets a neutral
-              copy-my-breakdown for study notes (never celebratory copy, no
-              scaled score, no pass/fail wording). Guests get it too, since a
+              Pass only, per owner decision: a fail screen stays focused on
+              its real actions (weakest-domain practice / sign-in CTA), so no
+              share/copy affordance is shown there. Guests get it too, since a
               pre-signup share is pure top-of-funnel, but the quiet pill styling
               keeps it secondary to UnlockCTA. Score data never rides in the
               shared URL. (Growth Build 1, phase 1) */}
-          <div className="flex justify-end">
-            <ShareResultButton
-              text={
-                results!.passed
-                  ? buildPassShareText({
-                      certShortName: cert.shortName,
-                      scaledScore: results!.scaledScore,
-                      correctCount: results!.correctCount,
-                      totalQuestions: results!.totalQuestions,
-                    })
-                  : buildFailBreakdownText({
-                      certShortName: cert.shortName,
-                      correctCount: results!.correctCount,
-                      totalQuestions: results!.totalQuestions,
-                      domains: cert.domains.map(d => ({
-                        name: d.name,
-                        percent: results!.domainScores[String(d.id)] ?? 0,
-                      })),
-                    })
-              }
-              label={results!.passed ? 'Share my result' : 'Copy my domain breakdown'}
-              copyOnly={!results!.passed}
-              analytics={{
-                outcome: results!.passed ? 'pass' : 'fail',
-                cert: cert.code,
-                authed: Boolean(user),
-              }}
-            />
-          </div>
+          {results!.passed && (
+            <div className="flex justify-end">
+              <ShareResultButton
+                text={buildPassShareText({
+                  certShortName: cert.shortName,
+                  scaledScore: results!.scaledScore,
+                  correctCount: results!.correctCount,
+                  totalQuestions: results!.totalQuestions,
+                })}
+                label="Share my result"
+                analytics={{
+                  cert: cert.code,
+                  authed: Boolean(user),
+                }}
+              />
+            </div>
+          )}
           {submitError && (
             <Alert tone="warning">
               {submitError}

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -15,6 +15,8 @@ import { OrderingInput } from '../components/OrderingInput'
 import { MatchingInput } from '../components/MatchingInput'
 import { Modal } from '../components/Modal'
 import { PassFailBanner } from '../components/PassFailBanner'
+import { ShareResultButton } from '../components/ShareResultButton'
+import { buildPassShareText, buildFailBreakdownText } from '../lib/shareResult'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import { QuestionReviewCard } from '../components/QuestionReviewCard'
 import { UnlockCTA } from '../components/landing/UnlockCTA'
@@ -800,6 +802,43 @@ export function MockExam() {
             scaledScore={results!.scaledScore}
             percent={results!.percentScore}
           />
+          {/* Share affordance lives WITH the banner (the celebration moment),
+              not in the bottom action stack, which stays donate's territory.
+              A pass gets the celebratory text share; a fail gets a neutral
+              copy-my-breakdown for study notes (never celebratory copy, no
+              scaled score, no pass/fail wording). Guests get it too, since a
+              pre-signup share is pure top-of-funnel, but the quiet pill styling
+              keeps it secondary to UnlockCTA. Score data never rides in the
+              shared URL. (Growth Build 1, phase 1) */}
+          <div className="flex justify-end">
+            <ShareResultButton
+              text={
+                results!.passed
+                  ? buildPassShareText({
+                      certShortName: cert.shortName,
+                      scaledScore: results!.scaledScore,
+                      correctCount: results!.correctCount,
+                      totalQuestions: results!.totalQuestions,
+                    })
+                  : buildFailBreakdownText({
+                      certShortName: cert.shortName,
+                      correctCount: results!.correctCount,
+                      totalQuestions: results!.totalQuestions,
+                      domains: cert.domains.map(d => ({
+                        name: d.name,
+                        percent: results!.domainScores[String(d.id)] ?? 0,
+                      })),
+                    })
+              }
+              label={results!.passed ? 'Share my result' : 'Copy my domain breakdown'}
+              copyOnly={!results!.passed}
+              analytics={{
+                outcome: results!.passed ? 'pass' : 'fail',
+                cert: cert.code,
+                authed: Boolean(user),
+              }}
+            />
+          </div>
           {submitError && (
             <Alert tone="warning">
               {submitError}


### PR DESCRIPTION
## What

Implements Growth Build 1 phase 1 from `.kiro/ux/GROWTH-RETENTION-FINDINGS-2026-07-02.md` (section 3, Build 1 = H1 + M6), sequenced by the implementation queue item 2. This is the first share affordance the product has anywhere (finding M3).

- **Pass:** a quiet 'Share my result' pill rendered WITH the PassFailBanner (the celebration moment; the bottom action stack stays donate's territory, resolving the placement conflict the finding called out). Uses `navigator.share` where available, clipboard fallback with a transient 'Copied' state.
- **Fail:** a neutral 'Copy my domain breakdown' clipboard action for self-study notes. Fail-state rule followed exactly as written: never celebratory copy, no scaled score, no pass/fail wording in anything shareable; unit tests assert this.
- Share text follows the findings-doc shape: "I scored 820/1000 on the CLF-C02 practice exam at CloudCertPrep (52/65 correct). Free + open source: https://www.cloudcertprep.io". The link is the bare canonical `SITE_URL` (no query params, per the second-order gotcha) and unfurls branded via the existing OG images.
- Guests get the affordance too (pre-signup share is the point) but the low-key pill stays visually secondary to UnlockCTA.
- `share_result` added to the KNOWN_EVENTS registry; fired with `method` (web_share | clipboard), `outcome` (pass | fail), `cert`, `authed` so phase 2 (canvas PNG) can be gated on real uptake as the finding requires.

**Explicitly NOT in this PR (per the queue):** phase 2 canvas PNG card, blog share links, community-stats context line (Build 3, deferred by owner).

New files: `src/lib/shareResult.ts` (+ unit tests), `src/lib/clipboard.ts`, `src/components/ShareResultButton.tsx`.

## Verified

- Full local gate green: astro check (0 errors), lint, unit tests 253/253 (5 new), production build incl. all SEO guards (results screen is a noindex app surface; no indexable page changed).
- Functional (preview :4500, Playwright, guest rehydrate path, zero backend writes): 4/4 scenarios.
  - Pass light: exact share text lands on the clipboard, 'Copied' state shows, `share_result {method: clipboard, outcome: pass, authed: false}` captured via stubbed Umami, UnlockCTA still present and dominant.
  - Fail light: breakdown copy contains all domain lines + overall, and matches `!/fail|pass|congrat|scored/i` with no `/1000`.
  - Both variants render + copy in dark theme.
  - Shots + harness: `.kiro/maintenance/overnight-2026-07-02/results-share/` (gitignored).

## For the owner

- `navigator.share` cannot be exercised headlessly (no share sheet in headless Chromium); the clipboard fallback is the verified path. A 10-second phone tap on the deployed preview would confirm the native share sheet.
- Placement judgment call: the pill is right-aligned directly under the banner (under the score block). Screenshots in the artifacts dir if you want to bikeshed the alignment.