### PR TITLE
feat(dashboard,results): weakest-domain next action + zero-data empty state (Growth Build 2)

### DIFF
--- a/e2e/weakest-domain-next-action.spec.ts
+++ b/e2e/weakest-domain-next-action.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type Page, type Route } from '@playwright/test'
+import { seedSession } from './seededSession'
+
+/**
+ * Growth Build 2: weakest-domain next action (H2 + M4 + M5).
+ * Source: GROWTH-RETENTION-FINDINGS-2026-07-02.md section 3, Build 2.
+ *
+ * Covers:
+ *  - dashboard NEXT UP card: weakest practiced domain (argmin over bank
+ *    mastery, semantics in lib/domainStats.findNextDomainAction) with the
+ *    ?domain= deep link into domain practice
+ *  - unstarted-beats-weakest phrasing ("You have not practiced X yet",
+ *    never "weakest" for a domain with zero attempts)
+ *  - zero-data empty state: Best score N/A + baseline hint, NEXT UP points
+ *    at the first domain
+ *  - signed-in FAIL results: a "Practice your weakest domain" link into
+ *    domain practice; guests keep UnlockCTA instead
+ *
+ * Seeded-session only (no real backend / Turnstile): domain_progress and
+ * exam_attempts reads are stubbed per test.
+ */
+
+test.use({ reducedMotion: 'reduce' })
+
+const CERT_URL = '/aws/clf-c02'
+const EXAM_URL = '/aws/clf-c02/practice-exam'
+
+function progressRow(domainId: number, attempted: number, correct: number) {
+  return {
+    user_id: 'seed-user-0000-0000-0000-000000000000',
+    cert_code: 'clf-c02',
+    domain_id: domainId,
+    questions_attempted: attempted,
+    questions_correct: correct,
+    mastery_percent: 0, // stored value is ignored; the dashboard re-derives
+    updated_at: new Date().toISOString(),
+  }
+}
+
+/** Serve domain_progress from `rows`; every other REST read gets []. */
+function restStub(rows: unknown[]) {
+  return (route: Route) => {
+    const url = route.request().url()
+    const body = url.includes('domain_progress') ? JSON.stringify(rows) : '[]'
+    return route.fulfill({ status: 200, contentType: 'application/json', body })
+  }
+}
+
+/** Start the exam and wait until the timed exam screen is active. */
+async function startExam(page: Page) {
+  await page.getByRole('button', { name: 'Start exam', exact: true }).click()
+  await page.waitForFunction(() => document.body.dataset.examActive === 'true', { timeout: 25000 })
+}
+
+/** Submit the active exam (zero answers = guaranteed fail) -> results screen. */
+async function submitExam(page: Page) {
+  await page.getByRole('button', { name: 'Submit exam' }).first().click()
+  const dialog = page.getByRole('dialog', { name: 'Ready to submit?' })
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Submit for grading' }).click()
+  await expect(page.getByRole('button', { name: 'Retake exam' })).toBeVisible({ timeout: 15000 })
+}
+
+test('dashboard NEXT UP names the weakest practiced domain with a deep link', async ({ page }) => {
+  await seedSession(page, {
+    rest: restStub([
+      progressRow(1, 60, 50),
+      progressRow(2, 50, 40),
+      progressRow(3, 30, 1), // lowest bank mastery by far
+      progressRow(4, 40, 30),
+    ]),
+  })
+  await page.goto(CERT_URL)
+
+  await expect(page.getByText('Weakest domain:')).toBeVisible({ timeout: 15000 })
+  const cta = page.getByRole('link', { name: 'Practice this domain' })
+  await expect(cta).toHaveAttribute('href', '/aws/clf-c02/domain-practice?domain=3')
+})
+
+test('an unstarted domain outranks a weak practiced one and is not called weakest', async ({ page }) => {
+  await seedSession(page, {
+    rest: restStub([
+      progressRow(1, 30, 2), // weak, but practiced
+      progressRow(2, 50, 40),
+      progressRow(4, 40, 30),
+      // domain 3 has no row at all -> unstarted
+    ]),
+  })
+  await page.goto(CERT_URL)
+
+  await expect(page.getByText('You have not practiced')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByText('Weakest domain:')).toHaveCount(0)
+  const cta = page.getByRole('link', { name: 'Practice this domain' })
+  await expect(cta).toHaveAttribute('href', '/aws/clf-c02/domain-practice?domain=3')
+})
+
+test('zero-data dashboard: Best score N/A + baseline hint, NEXT UP points at the first domain', async ({ page }) => {
+  await seedSession(page) // default stub: every REST read returns []
+  await page.goto(CERT_URL)
+
+  await expect(page.getByText('Take your first mock exam to set a baseline')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByText('N/A')).toBeVisible()
+  await expect(page.getByText('You have not practiced')).toBeVisible()
+  const cta = page.getByRole('link', { name: 'Practice this domain' })
+  await expect(cta).toHaveAttribute('href', '/aws/clf-c02/domain-practice?domain=1')
+})
+
+test('signed-in FAIL results link "Practice your weakest domain" into domain practice', async ({ page }) => {
+  await seedSession(page)
+  await page.goto(EXAM_URL)
+  // Auth must be resolved so the results screen sees a signed-in user.
+  await expect(page.getByRole('button', { name: 'Account menu' }).first()).toBeVisible({ timeout: 15000 })
+
+  await startExam(page)
+  await submitExam(page) // zero answers -> fail
+
+  const practiceCta = page.getByRole('link', { name: /Practice your weakest domain/ })
+  await expect(practiceCta).toBeVisible()
+  // All domains tie at 0% on an all-blank submit; the tiebreak is the first
+  // domain in cert order.
+  await expect(practiceCta).toHaveAttribute('href', '/aws/clf-c02/domain-practice?domain=1')
+})
+
+test('guest FAIL results keep UnlockCTA and do NOT show the weakest-domain link', async ({ page }) => {
+  await page.goto(EXAM_URL)
+  await startExam(page)
+  await submitExam(page)
+
+  await expect(page.getByRole('link', { name: /Practice your weakest domain/ })).toHaveCount(0)
+  await expect(page.getByText('Sign in to target your weak domains')).toBeVisible()
+})

--- a/src/components/CertDashboardIsland.tsx
+++ b/src/components/CertDashboardIsland.tsx
@@ -31,7 +31,7 @@ import { formatTime } from '../lib/scoring'
 import { logError } from '../lib/logger'
 import { CERTIFICATIONS } from '../data/certifications'
 import { LEVEL_ACCENT_UI_HEX, LEVEL_ACCENT_UI_RGB } from '../lib/levelAccent'
-import { calculateDomainMastery } from '../lib/domainStats'
+import { calculateDomainMastery, findNextDomainAction } from '../lib/domainStats'
 import type { DomainProgress } from '../types'
 
 /** Minimal domain shape needed by the dashboard sidebar. */
@@ -225,6 +225,22 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
   const accuracy = questionsPracticed > 0 ? Math.round((questionsCorrect / questionsPracticed) * 100) : 0
   const bestScore = recentAttempts.reduce((max, a) => Math.max(max, a.scaled_score), 0)
 
+  // NEXT UP: the one action the mastery data points at (Growth Build 2 / H2).
+  // Standings use the same bank-capped derivation as the grid cards below;
+  // "practiced" keys off attempted (not correct) so a domain with 0 correct
+  // out of real attempts is honestly "weakest", not "unstarted".
+  const nextAction = findNextDomainAction(cert.domains.map(d => {
+    const progress = domainProgress.find(p => p.domain_id === d.id)
+    const attempted = Math.min(progress?.questions_attempted || 0, d.questionCount)
+    const correct = Math.min(progress?.questions_correct || 0, attempted)
+    return {
+      domainId: d.id,
+      percent: calculateDomainMastery(correct, d.id, cert.code),
+      practiced: attempted > 0,
+    }
+  }))
+  const nextDomain = nextAction ? cert.domains.find(d => d.id === nextAction.domainId) : undefined
+
   return (
     <div className="max-w-6xl mx-auto pt-6 md:pt-10 pb-16 md:pb-24 space-y-8 md:space-y-10 stagger" aria-busy={dataLoading}>
         {dataLoading && <p className="sr-only" role="status">Loading your dashboard</p>}
@@ -274,7 +290,15 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
                 <StatTile label="Questions practiced" value={questionsPracticed.toLocaleString('en-US')} suffix={`/ ${bankTotal.toLocaleString('en-US')}`} />
                 <StatTile label="Accuracy" value={String(accuracy)} suffix="%" hint="correct / answered" />
                 <StatTile label="Mock exams" value={String(examCount)} />
-                <StatTile label="Best score" value={bestScore > 0 ? bestScore.toLocaleString('en-US') : '0'} suffix={bestScore > 0 ? `/ ${(1000).toLocaleString('en-US')}` : undefined} />
+                {/* Empty state: scaled scores start at 100, so a literal 0 is
+                    misleading (HALO-CRITIQUE P1). Placeholder + the one next
+                    action instead. */}
+                <StatTile
+                  label="Best score"
+                  value={bestScore > 0 ? bestScore.toLocaleString('en-US') : 'N/A'}
+                  suffix={bestScore > 0 ? `/ ${(1000).toLocaleString('en-US')}` : undefined}
+                  hint={bestScore > 0 ? undefined : 'Take your first mock exam to set a baseline'}
+                />
               </>
             )}
           </div>
@@ -347,6 +371,38 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
           <p className="text-sm text-text-muted mb-4">
             The percentage is how much of each domain's full question bank you have answered correctly.
           </p>
+          {/* NEXT UP: one card, one action (Growth Build 2 / H2). Unstarted
+              domains outrank low-mastery ones and are phrased "not practiced
+              yet", never "weakest" (untouched domains score 0 by construction,
+              which is not a diagnosis). Copy stays action-framed: the moment
+              this says "you are N% ready" it has become the parked
+              pro-candidate H3. Skeleton while loading so the card does not
+              push the grid down when data resolves (PR-5 CLS). */}
+          {dataLoading ? (
+            <div className="mb-4 rounded-2xl border border-border-hairline bg-bg-card p-5 md:p-6 animate-pulse" aria-hidden="true">
+              <div className="h-3 w-16 rounded bg-text-muted/15" />
+              <div className="mt-3 h-4 w-2/3 rounded bg-text-muted/15" />
+            </div>
+          ) : nextAction && nextDomain && (
+            <div className="mb-4 bg-bg-card border border-border-hairline rounded-2xl shadow-card p-5 md:p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <div>
+                <p className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-text-muted">Next up</p>
+                <p className="mt-1.5 text-text-primary font-medium">
+                  {nextAction.kind === 'unstarted' ? (
+                    <>You have not practiced <span className="font-semibold">{nextDomain.name}</span> yet</>
+                  ) : (
+                    <>Weakest domain: <span className="font-semibold">{nextDomain.name}</span> ({nextAction.percent}%)</>
+                  )}
+                </p>
+              </div>
+              <a
+                href={`${certPath}/domain-practice?domain=${nextDomain.id}`}
+                className="inline-flex min-h-[44px] flex-shrink-0 items-center justify-center rounded-full bg-cta px-6 text-sm font-medium text-on-cta transition-colors duration-200 hover:bg-cta-hover"
+              >
+                Practice this domain
+              </a>
+            </div>
+          )}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
             {dataLoading
               ? cert.domains.map(domain => (

--- a/src/lib/domainStats.test.ts
+++ b/src/lib/domainStats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calculateDomainMastery } from './domainStats'
+import { calculateDomainMastery, findNextDomainAction } from './domainStats'
 import { getCertDomainCounts } from '../data/certifications'
 
 describe('calculateDomainMastery', () => {
@@ -31,5 +31,53 @@ describe('calculateDomainMastery', () => {
 
   it('returns 0 for an unknown certification', () => {
     expect(calculateDomainMastery(10, 1, 'nope-c00')).toBe(0)
+  })
+})
+
+describe('findNextDomainAction', () => {
+  it('returns null for an empty list', () => {
+    expect(findNextDomainAction([])).toBeNull()
+  })
+
+  it('points at the first unstarted domain, in input order', () => {
+    expect(findNextDomainAction([
+      { domainId: 1, percent: 40, practiced: true },
+      { domainId: 2, percent: 0, practiced: false },
+      { domainId: 3, percent: 0, practiced: false },
+    ])).toEqual({ kind: 'unstarted', domainId: 2 })
+  })
+
+  it('never calls an unstarted domain weakest, even when a practiced one scores lower', () => {
+    // Practiced domain 1 sits at 5%, below nothing-yet domain 4's implicit 0.
+    // The unstarted domain still wins, with the unstarted phrasing.
+    const next = findNextDomainAction([
+      { domainId: 1, percent: 5, practiced: true },
+      { domainId: 4, percent: 0, practiced: false },
+    ])
+    expect(next).toEqual({ kind: 'unstarted', domainId: 4 })
+  })
+
+  it('picks the lowest-percent domain once everything is practiced', () => {
+    expect(findNextDomainAction([
+      { domainId: 1, percent: 62, practiced: true },
+      { domainId: 2, percent: 41, practiced: true },
+      { domainId: 3, percent: 80, practiced: true },
+      { domainId: 4, percent: 55, practiced: true },
+      { domainId: 5, percent: 47, practiced: true },
+    ])).toEqual({ kind: 'weakest', domainId: 2, percent: 41 })
+  })
+
+  it('breaks ties toward the first domain in input order', () => {
+    expect(findNextDomainAction([
+      { domainId: 1, percent: 50, practiced: true },
+      { domainId: 2, percent: 50, practiced: true },
+    ])).toEqual({ kind: 'weakest', domainId: 1, percent: 50 })
+  })
+
+  it('handles a fully-new user (all unstarted) by pointing at the first domain', () => {
+    expect(findNextDomainAction([
+      { domainId: 1, percent: 0, practiced: false },
+      { domainId: 2, percent: 0, practiced: false },
+    ])).toEqual({ kind: 'unstarted', domainId: 1 })
   })
 })

--- a/src/lib/domainStats.ts
+++ b/src/lib/domainStats.ts
@@ -19,3 +19,36 @@ export function calculateDomainMastery(
   if (!total) return 0
   return Math.min(100, Math.round((questionsCorrect / total) * 100))
 }
+
+/** One domain's standing, fed to `findNextDomainAction`. */
+export interface DomainStanding {
+  domainId: number
+  /** Display percent for this domain (bank mastery or exam accuracy). */
+  percent: number
+  /** False when the user has never answered a question in this domain. */
+  practiced: boolean
+}
+
+export type NextDomainAction =
+  | { kind: 'unstarted'; domainId: number }
+  | { kind: 'weakest'; domainId: number; percent: number }
+
+/**
+ * Pick the single next domain to practice (Growth Build 2 / H2).
+ * The semantics live here, in one tested place, because mastery is bank
+ * coverage: every untouched domain scores 0, so a naive argmin would always
+ * point at whatever the user has not started and call it "weakest". Rules:
+ * an unstarted domain (first in input order) wins and must be phrased
+ * "you have not practiced X yet", never "weakest"; otherwise the
+ * lowest-percent practiced domain is the honest weakest (first wins ties).
+ */
+export function findNextDomainAction(standings: DomainStanding[]): NextDomainAction | null {
+  if (standings.length === 0) return null
+  const unstarted = standings.find(s => !s.practiced)
+  if (unstarted) return { kind: 'unstarted', domainId: unstarted.domainId }
+  let weakest = standings[0]
+  for (const s of standings) {
+    if (s.percent < weakest.percent) weakest = s
+  }
+  return { kind: 'weakest', domainId: weakest.domainId, percent: weakest.percent }
+}

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -4,7 +4,7 @@ import { Flag, AlertCircle, LayoutGrid, Heart, ArrowLeft } from 'lucide-react'
 import { Button } from '../components/Button'
 import { Card } from '../components/Card'
 import { Alert } from '../components/Alert'
-import { filterChipClass, reviewCellClass } from '../lib/buttonStyles'
+import { buttonClass, filterChipClass, reviewCellClass } from '../lib/buttonStyles'
 import { useTimer } from '../hooks/useTimer'
 import { useAuth } from '../hooks/useAuth'
 import { useSEO } from '../hooks/useSEO'
@@ -33,6 +33,7 @@ import { registerExamLeaveHandler, confirmExamLeave, isIntentionalLeave, SIGN_OU
 import { useSignOut } from '../hooks/useSignOut'
 import { storePendingAttempt, consumePendingAttemptSavedNotice, markPendingAttemptSaveIntent, PENDING_ATTEMPT_SAVED_EVENT, peekPendingAttempt, hasPendingAttemptSaveIntent, type PendingAttempt } from '../lib/pendingAttempt'
 import { getProviderLabel } from '../data/certifications'
+import { findNextDomainAction } from '../lib/domainStats'
 
 type ExamScreen = 'start' | 'exam' | 'results' | 'review'
 
@@ -879,6 +880,29 @@ export function MockExam() {
           )}
 
           <div className="mt-6 space-y-3">
+            {/* Signed-in FAIL: route the moment of highest motivation straight
+                into targeted domain practice (M5; guests get the adaptive
+                UnlockCTA above instead). Weakest here is THIS exam's per-domain
+                accuracy (results.domainScores), a legitimate "weakest" for the
+                moment. Real anchor, not a router push: domain-practice is a
+                separate Astro document with its own chrome (see useCertNavigate
+                M0c). Brand variant = the platform's "start practising" action. */}
+            {user && !results!.passed && (() => {
+              const weakest = findNextDomainAction(cert.domains.map(d => ({
+                domainId: d.id,
+                percent: results!.domainScores[String(d.id)] ?? 0,
+                practiced: true,
+              })))
+              const weakestDomain = weakest ? cert.domains.find(d => d.id === weakest.domainId) : undefined
+              return weakestDomain ? (
+                <a
+                  href={`/${cert.provider}/${cert.code}/domain-practice?domain=${weakestDomain.id}`}
+                  className={buttonClass({ variant: 'brand', fullWidth: true })}
+                >
+                  Practice your weakest domain: {weakestDomain.name}
+                </a>
+              ) : null
+            })()}
             {/* Per-question review needs the loaded Question objects. A snapshot
                 rehydrate (P1-6) has none (questions stays empty on a fresh remount),
                 so gate on questions.length. Stateless, so it also stays correct


### PR DESCRIPTION
## What

Implements Growth Build 2 from `.kiro/ux/GROWTH-RETENTION-FINDINGS-2026-07-02.md` (section 3, Build 2 = H2 + M4 + M5), sequenced by the implementation queue item 3.

- **Shared argmin helper** `findNextDomainAction` in `lib/domainStats.ts` (unit-tested, 6 new tests): the practiced/unstarted semantics live in one place. An unstarted domain always outranks a low-mastery practiced one and is phrased "You have not practiced X yet", never "weakest" - mastery is bank coverage, so a naive argmin would always point at whatever the user has not started (the finding's caveat 1).
- **Dashboard NEXT UP card** above the domain-mastery grid: "Weakest domain: Cloud Technology and Services (0%)" or the unstarted variant, CTA "Practice this domain" deep-linking `/aws/<cert>/domain-practice?domain=<id>` (the existing param). A same-height skeleton renders while data loads so the card never pushes the grid down post-fetch (the finding's CLS gotcha).
- **Signed-in FAIL results**: "Practice your weakest domain: <name>" (from `results.domainScores`, this exam's accuracy) at the top of the action stack - closes the M5 dead-end at the moment of highest motivation. Guests keep UnlockCTA (unchanged). Rendered as a real anchor because domain-practice is a separate Astro document (useCertNavigate M0c).
- **Zero-data empty state** (M4 / HALO-CRITIQUE P1): BEST SCORE renders N/A + hint "Take your first mock exam to set a baseline" instead of a misleading 0.
- **AIF domain 5**: treated normally - the constraint bug the finding warned about was verified FIXED on prod 2026-07-02 (queue top note); no defensive exclusion.
- Copy is action-framed everywhere; nothing estimates readiness (the parked PRO-candidate H3 boundary is respected).

## Verified

- Full local gate green: astro check (0 errors), lint, unit 254/254 (6 new), production build + all guards.
- New CI-ready e2e spec `e2e/weakest-domain-next-action.spec.ts` (seeded-session, zero real backend): 5/5 pass - weakest/unstarted/zero-data dashboard variants with exact `?domain=` hrefs, signed-in fail link (all-blank submit, tiebreak to domain 1), guest exclusion.
- Full e2e suite: 110 passed, 1 failed - **the failure is pre-existing on origin/main** (`ux-audit-auth.spec.ts` P1-7 in-exam sign-out, realcreds layer, skipped in CI). Reproduced identically on a pristine c73951e worktree; see the overnight status doc. Not caused by this PR.
- Screenshots (light + dark, all variants incl. fail results): `.kiro/maintenance/overnight-2026-07-02/weakest-domain/`.

## For the owner

- **Pre-existing local failure worth a look:** P1-7 (in-exam Sign out -> leave modal) fails on pristine main with real TEST creds. Either the TEST project state drifted or a regression slipped in while CI (credless) skipped the spec.
- Judgment call: the fail-branch CTA uses the brand (orange) variant - buttonStyles documents brand as the platform's single "start practising" conversion action - so it does not compete with the primary Review button. Screenshot `fail-results-light.png`.