### PR TITLE
fix(auth): heal stale auth hints (failed exchange, bfcache restore, exam CTAs) - hardening PR-10

### DIFF
--- a/src/components/HeaderInteractive.tsx
+++ b/src/components/HeaderInteractive.tsx
@@ -37,7 +37,12 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
   // without waiting for useAuth()'s async getSession() to resolve (C1).
   const [authedHint] = useState(() =>
     typeof document !== 'undefined' && document.documentElement.classList.contains('cc-authed'))
-  const isAuthed = authedHint || Boolean(user)
+  // The hint only bridges the resolve window; the resolved `user` is
+  // authoritative after it. `authedHint || user` would latch true for the
+  // page's lifetime, leaving authed nav for a signed-out visitor after a
+  // failed `?code=` exchange / dead token / cross-tab sign-out (hardening F4,
+  // third instance of the "cc-authed means a real session" bug class).
+  const isAuthed = authLoading ? authedHint : Boolean(user)
 
   // Animate the drawer out before unmounting. Plays the 180ms (--dur-fast)
   // exit animation, then removes the drawer from the DOM.
@@ -71,6 +76,21 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
   useEffect(() => {
     if (authLoading) return
     document.documentElement.classList.toggle('cc-authed', Boolean(user))
+    // The PKCE exchange has settled, so the `code`/`state` params are spent.
+    // Strip them (hardening F8a): BaseLayout's `pageshow` script re-applies
+    // the optimistic `cc-authed` from ANY `?code=` URL, so a retained param
+    // re-plays authed-looking chrome for a guest on every bfcache restore /
+    // Back visit after a FAILED exchange (supabase-js leaves the URL alone on
+    // failure), and a bookmarked `?code=` URL repeats the doomed exchange.
+    // No consumer reads `code` after resolve (_ResetPassword exchanges during
+    // client init and only checks `user`).
+    if (/[?&]code=/.test(window.location.search)) {
+      const params = new URLSearchParams(window.location.search)
+      params.delete('code')
+      params.delete('state')
+      const qs = params.toString()
+      window.history.replaceState(null, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash)
+    }
     // Tell same-page pre-paint scripts the real session has resolved (token now
     // persisted, `user` known). The home first-login greeting (index.astro) used
     // to re-run on a `cc-authed`-add MutationObserver, but `cc-authed` is now set

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -38,28 +38,47 @@ function setState(next: AuthState) {
   listeners.forEach(cb => cb())
 }
 
-function init() {
-  if (initialised || typeof window === 'undefined') return
-  initialised = true
-
-  // Best-effort sync check for a persisted Supabase session token. If none,
-  // resolve loading=false immediately so the logged-out chrome paints
-  // without a placeholder. A stale token only briefly keeps loading=true
-  // until getSession() confirms; never shows a logged-out user a flash.
-  //
-  // SYNC: same scan also lives at window.__ccHasSession (BaseLayout.astro
-  // inline pre-paint script). The two implementations must stay in lockstep.
-  // Inline scripts can't import TS modules, so this duplication is forced.
-  let hasToken = false
+// Best-effort sync check for a persisted Supabase session token.
+//
+// SYNC: same scan also lives at window.__ccHasSession (BaseLayout.astro
+// inline pre-paint script). The two implementations must stay in lockstep.
+// Inline scripts can't import TS modules, so this duplication is forced.
+function hasStoredToken(): boolean {
   try {
     for (let i = 0; i < localStorage.length; i++) {
       const k = localStorage.key(i)
       if (k && k.startsWith('sb-') && k.endsWith('-auth-token')) {
-        hasToken = true
-        break
+        return true
       }
     }
   } catch { /* localStorage unavailable */ }
+  return false
+}
+
+function init() {
+  if (initialised || typeof window === 'undefined') return
+  initialised = true
+
+  // If no token, resolve loading=false immediately so the logged-out chrome
+  // paints without a placeholder. A stale token only briefly keeps
+  // loading=true until getSession() confirms; never shows a logged-out user
+  // a flash.
+  const hasToken = hasStoredToken()
+
+  // bfcache restore: a restored page keeps its frozen React heap, so a user
+  // who signed out (or deleted their account) in another tab/page still
+  // renders as signed in here even though the class-level chrome heals
+  // (hardening F8). On restore, re-run the token scan and downgrade to guest
+  // when no token remains - the same shape as _Login's bfcache loading reset
+  // (#125). Upgrades are deliberately left to the next real navigation: a
+  // bare token proves nothing without a getSession round-trip.
+  window.addEventListener('pageshow', (e: PageTransitionEvent) => {
+    if (!e.persisted) return
+    if (!hasStoredToken() && state.user !== null) {
+      prevUser = null
+      setState({ user: null, loading: false })
+    }
+  })
 
   // An OAuth / magic-link / recovery callback returns as `?code=...` on whatever
   // page `redirectTo` pointed at. For OAuth that is wherever the user started

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -769,8 +769,12 @@ export function MockExam() {
               just out of the primary action path. Copy is non-blocking:
               guest mode works fine, this is purely the upside of signing
               in. `safeFrom` in `goToLogin` returns the user to this exam
-              page after sign-in so friction is minimal. */}
-          {!user && (
+              page after sign-in so friction is minimal. The `!authLoading`
+              arm keeps it from flashing at a just-signed-in user during the
+              `?code=` exchange window, when `user` is still null (hardening
+              F5; CertDashboardIsland/_DomainPractice already do this). A real
+              guest resolves loading=false synchronously, so no pop for them. */}
+          {!user && !authLoading && (
             <div className="mt-4 md:mt-6">
               <UnlockCTA
                 onSignIn={() => goToLogin(navigate, location)}
@@ -854,8 +858,12 @@ export function MockExam() {
           {/* Guest signup CTA at the highest-intent moment — right after a
               completed exam (audit A1). Guests only; the message leads with the
               improvement angle on a fail and the save-your-win angle on a pass.
-              Reuses the permitted `unlock_cta_clicked` event via location. */}
-          {!user && (
+              Reuses the permitted `unlock_cta_clicked` event via location.
+              `!authLoading`: during the `?code=` exchange a just-signed-in
+              user is not a guest; without the arm this flashes "Sign in to
+              save" for the whole exchange window (hardening F5, part of F3's
+              flash). */}
+          {!user && !authLoading && (
             <UnlockCTA
               onSignIn={() => {
                 // Bind the stored snapshot to THIS save action: flushPendingAttempt


### PR DESCRIPTION
## What

Implements hardening bundle PR-10 (F4 + F5 + F8) from `.kiro/maintenance/POST-MERGE-HARDENING-FINDINGS-2026-07-02.md`, sequenced by the implementation queue item 4. All three are instances of the recurring "consumer assumes `cc-authed` means a real session" bug class that #123 already had to fix twice.

- **F4 (one line + comment):** `HeaderInteractive`'s `isAuthed` is now `authLoading ? authedHint : Boolean(user)`. The old `authedHint || Boolean(user)` latched true for the page's lifetime, so a signed-out visitor kept Dashboard/History/Account nav (dead-ending on sign-in cards) after a failed `?code=` exchange, a dead token, or a cross-tab sign-out. DomainProgressStrip's self-healing pattern, correctly mirrored this time.
- **F5 (two gates):** both exam-page guest UnlockCTAs (`_MockExam` start + results screens) gain the `!authLoading` arm that `CertDashboardIsland` and `_DomainPractice` already had. No more "Sign in to save this attempt" flashing at a just-signed-in user during the exchange window. Real guests resolve `loading=false` synchronously, so their CTA still paints immediately.
- **F8a:** once auth resolves, `HeaderInteractive` strips the spent `code`/`state` params (`history.replaceState`). Safety check done: no consumer reads `code` post-resolve; `_ResetPassword` exchanges during client init and only checks `user` afterwards.
- **F8b:** `useAuth` adds a `pageshow(persisted)` listener (same shape as the #125 login-button fix) that re-runs the token scan and downgrades the frozen React heap to guest when no token remains. Upgrades stay deliberately deferred to a real navigation, per the finding. Token scan extracted to `hasStoredToken()` (still in lockstep with BaseLayout's inline `__ccHasSession`).

**Housekeeping (local, gitignored, not in this diff):** `.kiro/ux/FLASH-FINDINGS-2026-06-28.md` F4 entry corrected to "fixed for the email path only" per the queue top note.

## Verified

- Full local gate green: astro check (0 errors), lint, unit 248/248, production build + all guards.
- Full e2e suite: 105+ passed; only the **pre-existing** `ux-audit-auth` P1-7 failure (reproduced on pristine main, see overnight status doc) plus one unrelated flake (`github_click`) that passes standalone and on the rerun.
- Functional (preview :4500, Playwright): 5/5 scenarios, shots + harness in `.kiro/maintenance/overnight-2026-07-02/auth-hints/`.
  - Failed `?code=` exchange (real bogus exchange against TEST, with seeded PKCE verifier): after settle, guest chrome + NO Dashboard in the Practice menu (was: latched authed nav) + `code`/`state` stripped from the URL.
  - Slow-exchange window (token endpoint delayed 2.5s): exam-page UnlockCTA hidden during the window, present after the failed exchange resolves to guest.
  - Synthetic `pageshow(persisted)` after token removal: header downgrades to guest (Account menu gone, Sign in back). True bfcache restores are not headlessly drivable (same caveat as every prior audit), so F8b got the synthetic-event equivalent.
  - Regressions: seeded signed-in page keeps authed nav; plain guest page unchanged.

## For the owner

- F8b covers the DOWNGRADE half only (by design, per the finding): a page restored after signing in elsewhere still renders as guest until a real navigation. Upgrading would need a getSession round-trip on restore - flag if you want that follow-up.
- One real-world spot-check that remains owner-only: a genuine Google OAuth return on a phone (real bfcache + real exchange timing).