### PR TITLE
fix(exam): make the guest-save loader reachable on the OAuth return (hardening PR-12)

### DIFF
--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -663,14 +663,23 @@ export function MockExam() {
   const answeredCount = Array.from(answers.values()).filter(isQuestionAnswered).length
   const flaggedCount = Array.from(answers.values()).filter(s => s.flagged).length
 
+  // Guest-save loader, hoisted ABOVE the screen switch (hardening F3). The
+  // arm effect is deliberately screen-agnostic (start OR results), but the
+  // sole render consumer used to live inside the 'start' branch only - which
+  // the OAuth return never shows: the rehydrate effect swaps to 'results'
+  // one task later, so the loader was unreachable on the exact path it was
+  // built for and the bare results screen + stale "Sign in to save" CTA
+  // flashed until the redirect (#125 fixed the email path only). Mirrors the
+  // arm effect's own screen exclusions: never over an active exam or review.
+  if (savingToHistory && (screen === 'start' || screen === 'results')) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-8">
+        <LoadingSpinner text="Saving your attempt..." />
+      </div>
+    )
+  }
+
   if (screen === 'start') {
-    if (savingToHistory) {
-      return (
-        <div className="flex-1 flex items-center justify-center p-8">
-          <LoadingSpinner text="Saving your attempt..." />
-        </div>
-      )
-    }
     return (
       <div className="p-4 md:p-8">
         <div className="max-w-2xl mx-auto">


### PR DESCRIPTION
## What

Implements hardening PR-12 (finding F3, promoted from optional by the queue): the #125 "Saving your attempt..." loader was unreachable on the OAuth guest-save return it was built for. The arm effect is deliberately screen-agnostic, but the sole render consumer lived inside the `'start'` screen branch - and the guest rehydrate effect swaps to `'results'` one task later, so OAuth returners saw the bare results screen + a stale "Sign in to save this attempt" CTA until the abrupt jump to `/history?saved=1` (the original FLASH F4, roughly intact). Only the email path was actually fixed by #125.

**Fix (one hoist):** render `savingToHistory` above the screen switch, gated to the same `start`/`results` screens the arm effect targets - never over an active exam or review. Source: `.kiro/maintenance/POST-MERGE-HARDENING-FINDINGS-2026-07-02.md` F3, first proposed option.

## Verified

- Full local gate green: astro check (0 errors), lint, unit 248/248, build + guards. e2e suite green except the known pre-existing P1-7 (see PR #135 / status doc); the PR-4a loader-gating tests still pass.
- Functional (preview :4500, Playwright, ZERO real backend traffic): the audit called this window headlessly unreproducible, but delaying + fabricating the token-exchange response holds it open. 3/3 scenarios, shots + harness in `.kiro/maintenance/overnight-2026-07-02/oauth-loader/`:
  - **OAuth-shaped success** (`?code=`, no session on landing, 2.5s exchange, stubbed `exam_attempts` insert): loader covers the entire window - no bare results, no stale CTA (screenshot `oauth-during-exchange.png`) - then lands on `/history?saved=1`.
  - **Failed exchange:** loader drops via the existing 8s fallback; the still-guest user gets their rehydrated results + sign-in CTA back, nothing stuck.
  - **Email-path regression:** session-on-landing still flushes + redirects.

## For the owner

- The fabricated exchange proves the loader/render mechanics; the one thing it cannot prove is real Google timing. The flash doc's recommended 30-second real-Google guest-save spot-check still applies before flipping FLASH-FINDINGS F4 to fully FIXED (entry already corrected to "email only" + pointer, local .kiro).
- Merge-order note: independent of PR #136 (auth hints), but both touch `_MockExam.tsx` in nearby regions - merge either first; if both are queued the second may need a trivial rebase.