### PR TITLE
fix(account,practice): deletion cleanup guarantees + visible practice save failure (hardening PR-11)

### DIFF
--- a/src/hooks/useSignOut.ts
+++ b/src/hooks/useSignOut.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { getSupabase } from '../lib/supabase'
 import { trackEvent } from '../lib/analytics'
+import { sweepAuthTokens } from '../lib/authCleanup'
 
 /**
  * Sign-out helper that:
@@ -34,14 +35,7 @@ export function useSignOut(): () => Promise<void> {
       // ignore: cleanup below is the guarantee
     }
     await supabase.auth.signOut({ scope: 'local' }).catch(() => {})
-    try {
-      for (let i = localStorage.length - 1; i >= 0; i--) {
-        const k = localStorage.key(i)
-        if (k && k.startsWith('sb-') && k.endsWith('-auth-token')) localStorage.removeItem(k)
-      }
-    } catch {
-      // localStorage unavailable (private mode edge cases): nothing to clear
-    }
+    sweepAuthTokens()
     // `/` is a prerendered Astro document. The Header that triggers sign-out
     // renders both inside the static-page HeaderIsland (no route table) and
     // inside AppIsland, so a react-router push could land on a router that

--- a/src/lib/authCleanup.test.ts
+++ b/src/lib/authCleanup.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { sweepAuthTokens, eraseLocalTraces } from './authCleanup'
+
+/** Minimal Storage stub backed by a Map (node env has no Web Storage). */
+function makeStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() { return map.size },
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => { map.set(k, String(v)) },
+    removeItem: (k: string) => { map.delete(k) },
+    clear: () => { map.clear() },
+  }
+}
+
+function stub(name: 'localStorage' | 'sessionStorage', value: Storage | undefined): void {
+  Object.defineProperty(globalThis, name, { value, writable: true, configurable: true })
+}
+
+beforeEach(() => {
+  stub('localStorage', makeStorage())
+  stub('sessionStorage', makeStorage())
+})
+
+afterEach(() => {
+  stub('localStorage', undefined)
+  stub('sessionStorage', undefined)
+})
+
+describe('sweepAuthTokens', () => {
+  it('removes every sb-*-auth-token key and nothing else', () => {
+    localStorage.setItem('sb-abc-auth-token', '{}')
+    localStorage.setItem('sb-xyz-auth-token', '{}')
+    localStorage.setItem('sb-abc-auth-token-code-verifier', 'v') // not a token key
+    localStorage.setItem('cloudcertprep_theme', 'dark')
+    sweepAuthTokens()
+    expect(localStorage.getItem('sb-abc-auth-token')).toBeNull()
+    expect(localStorage.getItem('sb-xyz-auth-token')).toBeNull()
+    expect(localStorage.getItem('sb-abc-auth-token-code-verifier')).toBe('v')
+    expect(localStorage.getItem('cloudcertprep_theme')).toBe('dark')
+  })
+
+  it('does not throw when localStorage is unavailable', () => {
+    stub('localStorage', undefined)
+    expect(() => sweepAuthTokens()).not.toThrow()
+  })
+})
+
+describe('eraseLocalTraces', () => {
+  it('clears the pending-attempt snapshot, session markers, and saved notice', () => {
+    localStorage.setItem('cloudcertprep_pending_attempt', '{"certCode":"clf-c02"}')
+    sessionStorage.setItem('cloudcertprep_pending_attempt_intent', 'clf-c02')
+    sessionStorage.setItem('cloudcertprep_pending_attempt_saved', 'clf-c02|123')
+    sessionStorage.setItem('cc_resume_results', 'clf-c02')
+    eraseLocalTraces()
+    expect(localStorage.getItem('cloudcertprep_pending_attempt')).toBeNull()
+    expect(sessionStorage.getItem('cloudcertprep_pending_attempt_intent')).toBeNull()
+    expect(sessionStorage.getItem('cloudcertprep_pending_attempt_saved')).toBeNull()
+    expect(sessionStorage.getItem('cc_resume_results')).toBeNull()
+  })
+
+  it('prunes only the deleted uuid from cc_home_greeted', () => {
+    localStorage.setItem('cc_home_greeted', 'user-a,user-b,user-c')
+    eraseLocalTraces('user-b')
+    expect(localStorage.getItem('cc_home_greeted')).toBe('user-a,user-c')
+  })
+
+  it('removes cc_home_greeted entirely when the deleted uuid was the only entry', () => {
+    localStorage.setItem('cc_home_greeted', 'user-a')
+    eraseLocalTraces('user-a')
+    expect(localStorage.getItem('cc_home_greeted')).toBeNull()
+  })
+
+  it('leaves cc_home_greeted alone without a userId and leaves device acks alone always', () => {
+    localStorage.setItem('cc_home_greeted', 'user-a')
+    localStorage.setItem('cloudcertprep_verified_welcome_ack', '2026-01-01')
+    localStorage.setItem('cloudcertprep_google_link_ack', '1')
+    eraseLocalTraces()
+    expect(localStorage.getItem('cc_home_greeted')).toBe('user-a')
+    expect(localStorage.getItem('cloudcertprep_verified_welcome_ack')).toBe('2026-01-01')
+    expect(localStorage.getItem('cloudcertprep_google_link_ack')).toBe('1')
+  })
+
+  it('does not throw when storage is unavailable', () => {
+    stub('localStorage', undefined)
+    stub('sessionStorage', undefined)
+    expect(() => eraseLocalTraces('user-a')).not.toThrow()
+  })
+})

--- a/src/lib/authCleanup.ts
+++ b/src/lib/authCleanup.ts
@@ -1,0 +1,60 @@
+import { clearPendingAttemptStorage } from './pendingAttempt'
+
+/**
+ * Local cleanup helpers shared by sign-out and account deletion.
+ *
+ * Extracted from useSignOut (hardening F6): the delete flow used to rely on a
+ * single `signOut({scope:'local'})` that can reject at the storage layer,
+ * landing the user on `/?account_deleted=1` with a live-looking token - the
+ * signed-in welcome hero under a "your account has been deleted" toast.
+ */
+
+/**
+ * Guaranteed credential sweep: remove every `sb-*-auth-token` key the app's
+ * pre-paint auth detection scans for. An explicit logout or account deletion
+ * must never leave a credential behind, even when supabase-js's own sign-out
+ * fails (offline, revoked token, storage fault).
+ */
+export function sweepAuthTokens(): void {
+  try {
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const k = localStorage.key(i)
+      if (k && k.startsWith('sb-') && k.endsWith('-auth-token')) localStorage.removeItem(k)
+    }
+  } catch {
+    // localStorage unavailable (private mode edge cases): nothing to clear
+  }
+}
+
+/**
+ * Erase app-owned local traces after account deletion (hardening F7).
+ *
+ * Without this, the surviving pending-attempt snapshot + resume marker can
+ * rehydrate the deleted user's full results screen (score + domain breakdown)
+ * for the next person in the SAME tab within 24h - directly contradicting the
+ * just-shown "all your data have been deleted" message. Also prunes the
+ * deleted uuid from the `cc_home_greeted` list so a re-signup gets a clean
+ * first-login greeting. Device-scoped one-time-notice acks are deliberately
+ * left alone: they are cosmetic and not the deleted user's data.
+ */
+export function eraseLocalTraces(userId?: string): void {
+  clearPendingAttemptStorage()
+  try {
+    // Owned by _MockExam (RESUME_RESULTS_KEY): the guest results-resume marker.
+    sessionStorage.removeItem('cc_resume_results')
+  } catch {
+    // sessionStorage unavailable: nothing to clear
+  }
+  if (userId) {
+    try {
+      const greeted = (localStorage.getItem('cc_home_greeted') || '').split(',').filter(Boolean)
+      const next = greeted.filter(id => id !== userId)
+      if (next.length !== greeted.length) {
+        if (next.length > 0) localStorage.setItem('cc_home_greeted', next.join(','))
+        else localStorage.removeItem('cc_home_greeted')
+      }
+    } catch {
+      // localStorage unavailable: nothing to prune
+    }
+  }
+}

--- a/src/lib/pendingAttempt.ts
+++ b/src/lib/pendingAttempt.ts
@@ -273,3 +273,17 @@ export async function flushPendingAttempt(userId: string): Promise<boolean> {
     flushing = false
   }
 }
+
+/**
+ * Remove every pending-attempt artifact this module owns: the snapshot, the
+ * save intent, and the saved notice. Called on account deletion (hardening
+ * F7) so a deleted user's guest results can never rehydrate or flush for the
+ * next person in the same tab.
+ */
+export function clearPendingAttemptStorage(): void {
+  try { localStorage.removeItem(PENDING_KEY) } catch { /* ignore */ }
+  try {
+    sessionStorage.removeItem(SAVE_INTENT_KEY)
+    sessionStorage.removeItem(SAVED_NOTICE_KEY)
+  } catch { /* ignore */ }
+}

--- a/src/pages/_Account.tsx
+++ b/src/pages/_Account.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { goToLogin } from '../lib/navigation'
 import { useAuth } from '../hooks/useAuth'
 import { useSEO } from '../hooks/useSEO'
 import { getSupabase } from '../lib/supabase'
+import { sweepAuthTokens, eraseLocalTraces } from '../lib/authCleanup'
 import { logError } from '../lib/logger'
 import { Button } from '../components/Button'
 import { Card } from '../components/Card'
@@ -48,6 +49,21 @@ export function Account() {
   const [confirmText, setConfirmText] = useState('')
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
+  // Synchronous re-entrancy guard (note 1): setDeleting is async, so a
+  // state-only check lets rapid double-clicks both reach the invoke. Same
+  // idiom as _MockExam's submittingRef.
+  const deletingRef = useRef(false)
+
+  // If the session dies while the delete modal is open (cross-tab sign-out or
+  // deletion), the Delete button would silently no-op on `!user?.id` (note 4).
+  // Close the modal instead: the page behind it already swaps to the
+  // signed-out card. Never mid-delete (the local sign-out inside handleDelete
+  // must not close its own progress view before the redirect).
+  useEffect(() => {
+    if (!authLoading && !user && showDeleteModal && !deletingRef.current) {
+      setShowDeleteModal(false)
+    }
+  }, [authLoading, user, showDeleteModal])
 
   async function handleExport() {
     if (!user?.id) return
@@ -118,21 +134,49 @@ export function Account() {
 
   async function handleDelete() {
     if (!user?.id) return
+    if (deletingRef.current) return
+    deletingRef.current = true
+    const userId = user.id
     setDeleting(true)
     setDeleteError(null)
     try {
       const supabase = await getSupabase()
-      const { error } = await supabase.functions.invoke('delete-account', { method: 'POST' })
+      // 30s race (note 3): functions.invoke never times out on its own, and
+      // the modal is deliberately unclosable mid-delete - a hung request would
+      // lock the user on the spinner forever. The deletion itself is
+      // idempotent server-side, so timing out into the retry copy is safe.
+      const { error } = await Promise.race([
+        supabase.functions.invoke('delete-account', { method: 'POST' }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('delete-account timed out after 30s')), 30000)),
+      ])
       if (error) throw error
       // The account (and session) no longer exist; clear the local token and
-      // leave the app. The home banner acknowledges the deletion.
+      // leave the app. The home banner acknowledges the deletion. signOut can
+      // itself reject at the storage layer, which used to land the user on
+      // /?account_deleted=1 with a live-looking token (signed-in hero under
+      // the "account deleted" toast) - the guaranteed sweep closes that (F6),
+      // and the traces erase keeps the deleted user's pending-attempt results
+      // from rehydrating for the next person in this tab (F7).
       await supabase.auth.signOut({ scope: 'local' }).catch(() => {})
+      sweepAuthTokens()
+      eraseLocalTraces(userId)
       window.location.assign('/?account_deleted=1')
     } catch (err: unknown) {
+      // FunctionsHttpError.message is a fixed string; log the response
+      // status/body too so a real failure is diagnosable (note 2).
       logError('Account.delete', err)
+      const ctx = (err as { context?: unknown }).context
+      if (ctx instanceof Response) {
+        const body = await ctx.clone().text().catch(() => '')
+        logError('Account.delete.context', { status: ctx.status, body: body.slice(0, 500) })
+      }
+      deletingRef.current = false
       setDeleting(false)
+      // Retry-first copy (note 5): the operation is idempotent, so "try
+      // again" is the accurate first suggestion; email stays the fallback.
       setDeleteError(
-        `We could not delete your account automatically. Please email ${SUPPORT_EMAIL} and we will erase it within 30 days.`,
+        `We could not delete your account. Please try again in a moment. If it keeps failing, email ${SUPPORT_EMAIL} and we will erase it within 30 days.`,
       )
     }
   }

--- a/src/pages/_DomainPractice.tsx
+++ b/src/pages/_DomainPractice.tsx
@@ -89,6 +89,10 @@ export function DomainPractice() {
   // failed start is a visible, retryable error instead of a dead Start button
   // (mirrors the mock exam's loadError). (item 7)
   const [loadError, setLoadError] = useState<string | null>(null)
+  // Save failure on finishPractice (hardening note 9): a swallowed error used
+  // to silently lose the session's progress (realistic since cross-tab
+  // account deletion mid-practice); the results screen shows this instead.
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [answering, setAnswering] = useState(false)
   const [pendingLeaveUrl, setPendingLeaveUrl] = useState<string | null>(null)
   // "End session early" confirm. Distinct from the leave guard: ending the
@@ -288,6 +292,7 @@ export function DomainPractice() {
   async function startPractice() {
     setLoading(true)
     setLoadError(null)
+    setSaveError(null)
     try {
       // Re-fetch mastery data so back-to-back sessions use fresh weights
       await refreshMastery()
@@ -420,6 +425,9 @@ export function DomainPractice() {
         await updateDomainProgress(user.id, selectedDomain!, cert.code)
       } catch (error: unknown) {
         logError('DomainPractice.finishPractice', error)
+        // Visible failure notice, mirroring _MockExam's save-failure copy: the
+        // user must know their progress was not recorded (note 9).
+        setSaveError('Your practice results could not be saved to your progress. You can still review your answers below.')
       }
     }
 
@@ -619,6 +627,11 @@ export function DomainPractice() {
     return (
       <div className="p-4 md:p-8">
           <div className="max-w-4xl mx-auto">
+            {saveError && (
+              <Alert tone="warning" role="alert" className="mb-4">
+                {saveError}
+              </Alert>
+            )}
             {/* Summary Header */}
             <Card padding="md" className="text-center mb-4 animate-enter">
               <h1 className="text-2xl md:text-3xl font-semibold text-text-primary mb-3">Practice session complete!</h1>


### PR DESCRIPTION
## What

Implements hardening bundle PR-11 from `.kiro/maintenance/POST-MERGE-HARDENING-FINDINGS-2026-07-02.md` (F6 + F7 + smaller notes 1-5, plus note 9 promoted by the queue), sequenced as implementation-queue item 6.

- **F6:** `useSignOut`'s guaranteed `sb-*-auth-token` sweep is extracted to `lib/authCleanup.sweepAuthTokens()` (useSignOut now consumes it; behavior unchanged) and `handleDelete` calls it after the local sign-out. Closes the ghost state where a rejecting `signOut` landed the user on `/?account_deleted=1` with a live-looking token (signed-in hero under the deletion toast, up to ~1h).
- **F7:** `eraseLocalTraces(userId)` clears the pending-attempt snapshot + save intent + saved notice (via a new `clearPendingAttemptStorage()` owned by `pendingAttempt.ts`), the `cc_resume_results` marker, and prunes the deleted uuid from `cc_home_greeted`. Device-scoped one-time-notice acks are deliberately left (cosmetic, not user data, per the finding).
- **Notes 1-5:** synchronous `deletingRef` re-entrancy guard (house `submittingRef` idiom); `err.context` status/body logged on failure (FunctionsHttpError.message is a fixed string); 30s `Promise.race` on the invoke so a hung request cannot lock the deliberately-unclosable modal; the modal closes if the session dies while it is open (Delete used to silently no-op); retry-first error copy with the email path as fallback (deletion is proven idempotent).
- **Note 9:** `_DomainPractice.finishPractice` no longer swallows a failed save with only a console log - the results screen shows a visible warning mirroring `_MockExam`'s save-failure pattern (realistic since a cross-tab account deletion mid-practice fails exactly this insert).

**Not touched:** the edge function source (note 6 posture items) - changing it without deploying would drift repo vs deployed, and deploys are out of scope for this run.

## Verified

- Full local gate green: astro check (0 errors), lint, unit 255/255 (7 new authCleanup tests), build + guards, e2e suite green minus the known pre-existing P1-7.
- Functional (preview :4500, Playwright, edge function + all REST writes intercepted - no real invocation, no users): 4/4 scenarios, shots + harness in `.kiro/maintenance/overnight-2026-07-02/deletion-polish/`.
  - Success path: redirect lands with the token swept, every trace erased, `cc_home_greeted` pruned to the other user, guest home + deletion toast (no welcome-back ghost).
  - Failure (500): retry-first copy renders, Delete stays clickable for the retry, no redirect.
  - Hung invoke: mid-delete spinner confirmed at 4s, broken out into the error copy after the 30s race (was: locked forever).
  - Practice save failure (real 5-question session driven, `attempt_questions` POST 500): the new warning renders on the results screen (was: silent loss).

## For the owner

- **Note 4 (modal closes on session death) is code-reviewed but not functionally driven:** triggering a genuine cross-tab session death headlessly needs PR #136's pageshow re-sync or supabase's own multitab signal; the effect is a 5-line declarative gate. Worth a 10-second manual check after both PRs merge.
- The 30s timeout can theoretically race a SLOW-but-succeeding deletion: the user sees the retry copy while the account is actually gone. The next retry then 401s into the same copy, and the email path resolves it. Accepted as strictly better than the locked-modal alternative; flagging since it is a judgment call.