### PR TITLE
test(e2e): fix stale P1-7 assertion (sign-out leave-modal copy)

### DIFF
--- a/e2e/ux-audit-auth.spec.ts
+++ b/e2e/ux-audit-auth.spec.ts
@@ -159,21 +159,28 @@ test('P1-7: in-exam Sign out routes through the leave modal, then completes', as
   await page.waitForFunction(() => document.body.dataset.examActive === 'true', { timeout: 25000 })
 
   // Sign out (inside the account menu) during the exam must open the leave
-  // modal, NOT sign out immediately.
+  // modal, NOT sign out immediately. Since #121 the sign-out variant brands
+  // itself "Sign out?" with a "Sign out" confirm ("Leave the exam?"/"Leave
+  // exam" is the URL-navigation variant) - this test asserted the old shared
+  // copy and had been failing on the copy alone since then (the guard itself
+  // never broke; verified live 2026-07-02).
+  const signOutDialog = page.getByRole('dialog', { name: 'Sign out?' })
   await page.getByRole('button', { name: 'Account menu' }).click()
   await page.getByRole('button', { name: 'Sign out' }).click()
-  await expect(page.getByText('Leave the exam?')).toBeVisible()
+  await expect(signOutDialog).toBeVisible()
 
   // Stay keeps the attempt alive.
   await page.getByRole('button', { name: 'Stay in exam' }).click()
-  await expect(page.getByText('Leave the exam?')).toBeHidden()
+  await expect(signOutDialog).toBeHidden()
   expect(await page.evaluate(() => document.body.dataset.examActive)).toBe('true')
 
-  // Confirming completes the sign-out (back on '/', signed out -> Sign in shows).
+  // Confirming completes the sign-out (back on '/', signed out -> Sign in
+  // shows). The confirm click is scoped to the dialog so it can never match
+  // the account-menu's own Sign out entry.
   await page.getByRole('button', { name: 'Account menu' }).click()
   await page.getByRole('button', { name: 'Sign out' }).click()
-  await expect(page.getByText('Leave the exam?')).toBeVisible()
-  await page.getByRole('button', { name: 'Leave exam' }).click()
+  await expect(signOutDialog).toBeVisible()
+  await signOutDialog.getByRole('button', { name: 'Sign out' }).click()
   await page.waitForURL('http://localhost:4321/', { timeout: 20000 })
   await expect(page.getByRole('button', { name: 'Sign in' }).first()).toBeVisible({ timeout: 15000 })
 })


### PR DESCRIPTION
## What

Root-causes and fixes the P1-7 failure flagged by the overnight run as "pre-existing on main, highest-value morning item."

**The product was never broken.** The in-exam Sign out guard works exactly as designed: modal opens, Stay keeps the attempt, confirm completes the sign-out. What happened: the test (written in #114 against the then-shared 'Leave the exam?' copy) was never updated when #121 rebranded the sign-out variant to 'Sign out?' / 'Sign out'. Since the spec only runs with real TEST creds - credless CI skips it - the stale assertion failed silently on every local realcreds run since 2026-06-28 and looked like a product regression.

Diagnosis trail (all in `.kiro/maintenance/OVERNIGHT-RUN-STATUS-2026-07-02.md` + scratch shots): reproduced with a seeded session (no auth needed), ARIA snapshot showed mid-exam with no modal text matching, source read found the sentinel branch (`_MockExam.tsx:1218`), `git log -S` pinned the copy change to #121, live screenshot confirms the 'Sign out?' modal renders and both paths work.

## Change

Tests only. The P1-7 assertions now target `getByRole('dialog', { name: 'Sign out?' })` and scope the confirm click to the dialog (so it can never collide with the account menu's own Sign out entry).

## Verified

- `ux-audit-auth.spec.ts` (realcreds, serial): **5/5 pass** - P1-7 runs the full journey with a real throwaway user on TEST (created + cleaned by the spec's own afterAll).
- Full e2e suite: **107 passed, 0 failed**, 9 deliberately-gated skips - the first fully green full-suite run on record.
- Worth noting: this run also benefits from the TEST schema restore done earlier today (RPC + view + table parity), so the realcreds layer is now testing against a prod-shaped database.

## Takeaway for the owner

The deeper lesson is process, not code: a creds-gated test can rot invisibly. Options if you want a guard against recurrence (not in this PR): a scheduled local run of `npm run e2e:auth`, or a weekly reminder in the maintenance lane.