### PR TITLE
docs(supabase): correct domain_progress key topology

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -69,7 +69,10 @@ One row per `(user_id, cert_code, domain_id)`. Materialised view of attempt_ques
 | `mastery_percent` | `numeric` NOT NULL | 0-100, `questions_correct / cert.domains[domain_id].questionCount * 100` |
 | `updated_at` | `timestamptz` NOT NULL | |
 
-Primary key: `(user_id, cert_code, domain_id)`.
+Primary key: `id` (uuid). The app's upsert conflict target is the separate UNIQUE constraint
+`(user_id, domain_id, cert_code)`. (Corrected 2026-07-02 against live prod via `pg_constraint`:
+this doc previously claimed the composite was the primary key - that layout exists on the TEST
+project, not on prod.)
 
 **RLS:** enabled. `auth.uid() = user_id`.
 


### PR DESCRIPTION
One-line-of-substance doc fix found during the 2026-07-02 TEST/prod parity work.

The README stated `domain_progress`'s primary key is `(user_id, cert_code, domain_id)`. A `pg_constraint` dump from live prod shows the actual layout: **PK is `id` (uuid)**, and the composite `(user_id, domain_id, cert_code)` is a separate **UNIQUE** constraint - which is what the app's upsert `onConflict` actually relies on. The composite-as-PK layout turned out to be the TEST project's, not prod's (that difference also blocked a naive parity fix earlier today; full story in `.kiro/maintenance/OVERNIGHT-RUN-STATUS-2026-07-02.md`).

Doc-only. Unit suite + lint run green as a formality.