### PR TITLE
fix(analytics): stop junk path events + close funnel blind spots (B1 + section-5 riders)

### DIFF
--- a/src/components/AuthLinkNotice.tsx
+++ b/src/components/AuthLinkNotice.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, type ReactNode } from 'react'
 import { CheckCircle, AlertTriangle, X } from 'lucide-react'
 import { buttonClass } from '../lib/buttonStyles'
 import { useAuth } from '../hooks/useAuth'
+import { trackEvent } from '../lib/analytics'
 
 /**
  * Non-modal top notice: a dismissible toast pinned just below the header,
@@ -90,6 +91,11 @@ export default function AuthLinkNotice() {
     const qs = params.toString()
     window.history.replaceState(null, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash)
     if (notice.kind === 'verified') {
+      // Closes the funnel's verification-completion blind spot: fired once
+      // here, gated on the same one-shot ack written right below, so a
+      // refresh (URL already stripped by the replaceState above) never
+      // refires it.
+      trackEvent('email_verified')
       try { localStorage.setItem(ACK_KEY, new Date().toISOString()) } catch { /* private mode */ }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/CertDashboardIsland.tsx
+++ b/src/components/CertDashboardIsland.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react'
 import { Alert } from './Alert'
 import { useAuth } from '../hooks/useAuth'
+import { trackEvent } from '../lib/analytics'
 import { getSupabase } from '../lib/supabase'
 import { formatRelativeDate } from '../lib/formatting'
 import { formatTime } from '../lib/scoring'
@@ -397,6 +398,7 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
               </div>
               <a
                 href={`${certPath}/domain-practice?domain=${nextDomain.id}`}
+                onClick={() => trackEvent('weakest_domain_cta_clicked', { surface: 'dashboard', variant: nextAction.kind })}
                 className="inline-flex min-h-[44px] flex-shrink-0 items-center justify-center rounded-full bg-cta px-6 text-sm font-medium text-on-cta transition-colors duration-200 hover:bg-cta-hover"
               >
                 Practice this domain

--- a/src/components/HeaderInteractive.tsx
+++ b/src/components/HeaderInteractive.tsx
@@ -164,7 +164,14 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
             the page the user is already on). */}
         {initialPathname !== '/login' && (
           <Button
-            onClick={() => { if (!guardExamLeave('/login')) window.location.assign('/login') }}
+            onClick={() => {
+              // The only sign-in entry point analytics couldn't previously see
+              // (funnel step 3b). Fire-and-forget: record the click regardless
+              // of whether guardExamLeave defers the navigation behind a
+              // confirm modal.
+              trackEvent('unlock_cta_clicked', { location: 'header' })
+              if (!guardExamLeave('/login')) window.location.assign('/login')
+            }}
             variant="primary"
             size="sm"
             className="cc-auth-out whitespace-nowrap"
@@ -300,6 +307,7 @@ export default function HeaderInteractive({ initialPathname }: { initialPathname
               ) : (
                 <Button
                   onClick={() => {
+                    trackEvent('unlock_cta_clicked', { location: 'header' })
                     closeMobileMenu()
                     if (!guardExamLeave('/login')) window.location.assign('/login')
                   }}

--- a/src/components/landing/UnlockCTA.tsx
+++ b/src/components/landing/UnlockCTA.tsx
@@ -8,12 +8,11 @@ import { trackEvent } from '../../lib/analytics'
  * sign-in conversion by placement and decide which deserve more prominence.
  */
 export type UnlockCTALocation =
-  | 'home_about'
-  | 'cert_about'
   | 'mock_exam_start'
   | 'exam_results'
   | 'domain_practice_wall'
   | 'practice_results'
+  | 'header'
 
 interface UnlockCTAProps {
   /** Click handler — typically `() => goToLogin(navigate, location)`. */

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -33,6 +33,14 @@ let prevUser: User | null = null
 // is stale and must not clobber it. (M2)
 let authEventLanded = false
 
+// Tab-scoped de-dupe for the `sign_in` event below. sessionStorage (not a
+// module variable): this is an MPA that reinitializes the whole auth module
+// (module state, incl. `prevUser`, resets to null) on every full page
+// navigation, but sessionStorage survives across navigations within the same
+// tab. See the long comment at the trackEvent('sign_in', ...) call for why
+// this is needed.
+const SIGN_IN_TRACKED_KEY = 'cc_sign_in_tracked'
+
 function setState(next: AuthState) {
   state = next
   listeners.forEach(cb => cb())
@@ -150,20 +158,66 @@ function init() {
 
       // Detect the real "user just signed in" moment. Excludes
       // TOKEN_REFRESHED, USER_UPDATED, INITIAL_SESSION.
+      //
+      // INVESTIGATED (2026-07, section-5 rider): the pre-ship baseline showed
+      // ~3.6 `sign_in` events per Umami visit (2.31k events / 649 visits).
+      // `prevUser === null` alone does not stop this, because the over-fire is
+      // NOT tab focus or token refresh triggering this branch directly - it is
+      // supabase-js itself. GoTrueClient's `_recoverAndRefresh()` (called from
+      // `_initialize()` on every client construction, i.e. on every full page
+      // load here, since this is an MPA that reinitializes the whole auth
+      // module per navigation - see the CWV comment above) issues a genuine
+      // `SIGNED_IN` broadcast whenever it finds a still-valid persisted
+      // session, NOT the `INITIAL_SESSION` event the newer supabase-js API
+      // added specifically to distinguish "recovered an existing session" from
+      // "just signed in". Because `prevUser` resets to null on every fresh
+      // navigation along with the rest of this module's state, that recovery
+      // broadcast satisfies this gate on every page view for an
+      // already-signed-in visitor, not only on a real sign-in - explaining the
+      // ~3.6x. (The same function also reruns on tab-focus/visibility-change,
+      // but that repeat is already deduped within one page's lifetime by
+      // `prevUser` no longer being null by then.)
+      //
+      // Fix: a sessionStorage flag survives across full-page navigations
+      // within the same tab (module state does not), so it catches exactly
+      // the case module state cannot, without touching any other file.
+      let alreadyTrackedThisTab = false
+      try {
+        alreadyTrackedThisTab = sessionStorage.getItem(SIGN_IN_TRACKED_KEY) === '1'
+      } catch { /* private mode: fall back to the old (over-firing) behavior */ }
+
       if (
         event === 'SIGNED_IN'
         && prevUser === null
         && newUser !== null
+        && !alreadyTrackedThisTab
       ) {
+        // OAuth signup vs return (funnel step 5b): a brand-new account's
+        // created_at lands within moments of this very sign-in event; a
+        // returning user's created_at is far in the past. ~2 min is generous
+        // enough to absorb the OAuth redirect round-trip without false
+        // positives on a real return visit.
+        const createdAtMs = Date.parse(newUser.created_at)
+        const isNewUser = !Number.isNaN(createdAtMs) && Date.now() - createdAtMs < 2 * 60 * 1000
+
         trackEvent('sign_in', {
           method: newUser.app_metadata?.provider ?? 'email',
+          new_user: isNewUser,
         })
+        try { sessionStorage.setItem(SIGN_IN_TRACKED_KEY, '1') } catch { /* private mode */ }
 
         // First-link confirmation (R5.4): when Google was merged into a
         // pre-existing account (multiple identities incl. google), surface a
         // one-time notice. The helper self-guards via a localStorage ack flag,
         // so this is safe to call on every genuine sign-in.
         maybeNotifyGoogleLink(newUser)
+      }
+
+      // Clear the tab-scoped de-dupe flag on sign-out, so a genuine later
+      // sign-in in the same tab (e.g. a different person on a shared device)
+      // is tracked again instead of staying silently suppressed.
+      if (event === 'SIGNED_OUT') {
+        try { sessionStorage.removeItem(SIGN_IN_TRACKED_KEY) } catch { /* private mode */ }
       }
 
       prevUser = newUser

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -30,14 +30,18 @@ function gtag(...args: unknown[]): void {
   }
 }
 
-/** Fire a virtual page view. Call on every route change. */
+/**
+ * Fire a virtual page view. Call on every route change. GA4 only: Umami
+ * already auto-tracks every pageview itself via its own pushState hook
+ * (verified against the deployed tracker), so a manual `window.umami.track(path)`
+ * call here would be redundant and, worse, wrong - a bare string argument to
+ * `umami.track()` records a custom EVENT named that string, not a pageview.
+ * That bug used to log one junk event name per distinct SPA route (fixed
+ * 2026-07, see B1 in the funnel-analytics findings). The GA branch stays
+ * dormant as documented at the top of this file.
+ */
 export function trackPageView(path: string): void {
   gtag('event', 'page_view', { page_path: path })
-  // Umami tracks page views automatically on script load, but we also fire
-  // explicit calls for SPA navigation so client-side route changes register.
-  if (typeof window.umami?.track === 'function') {
-    window.umami.track(path)
-  }
 }
 
 /**
@@ -48,27 +52,40 @@ export function trackPageView(path: string): void {
  */
 export const KNOWN_EVENTS = [
   // Lifecycle / navigation
-  'landing',            // one-shot UTM attribution on first paint
-  'page_view',          // virtual page view on SPA route change
+  'landing',            // one-shot UTM-only attribution on first paint; organic/
+                         // direct landings rely on Umami's own auto-tracked pageview
+  'page_view',          // GA4 only (dormant). Umami never receives this name - it
+                         // auto-tracks pageviews itself, so this never appears in
+                         // the Umami events panel
   'page_not_found',     // 404 page hit
   // Auth
   'sign_up',            // email sign-up submitted
+  'email_verified',     // confirm link lands on ?verified=1 (one-shot, gated on the
+                         // same localStorage ack as the welcome toast; refreshes
+                         // do not refire)
   'sign_in_initiated',  // OAuth button clicked (method: github | google)
-  'sign_in',            // unauth -> auth transition (fired once, any method)
+  'sign_in',            // unauth -> auth transition (params: method; new_user, true
+                         // when user.created_at is within ~2 min of this event)
   'sign_out',           // sign-out
-  // Mock exam flow
+  // Mock exam flow. exam_started/exam_completed carry `guest: <bool>` (the
+  // funnel's guest-vs-signed-in denominator).
   'exam_started',
   'exam_abandoned',     // beforeunload during an active exam
   'timer_expired',      // exam timer hit zero
   'exam_completed',
   // Practice + per-question (question_answered is fired by BOTH the domain
-  // practice flow and the mock exam; the `surface` param disambiguates)
+  // practice flow and the mock exam; the `surface` param disambiguates).
+  // practice_started/practice_completed carry `guest: <bool>` like the exam
+  // events above; question_answered deliberately does not, to keep that
+  // high-volume payload lean.
   'practice_started',
   'question_answered',
   'practice_completed',
   // Engagement
   'cta_start_practice_exam', // primary "Start Practice Exam" CTA
-  'unlock_cta_clicked',      // guest sign-in nudge in practice/exam
+  'unlock_cta_clicked',      // guest sign-in nudge in practice/exam/header
+  'weakest_domain_cta_clicked', // "next up" CTA (surface: dashboard | exam_results;
+                                 // variant: weakest | unstarted)
   'share_result',            // results-screen share, pass-only (method: web_share | clipboard; params: cert, authed)
   'report_question_clicked',
   'donate_click',

--- a/src/pages/_DomainPractice.tsx
+++ b/src/pages/_DomainPractice.tsx
@@ -26,7 +26,7 @@ import { calculateDomainMastery } from '../lib/domainStats'
 import type { Question, OptionKey, DomainProgress } from '../types'
 import { loadDomainQuestions } from '../data/questions'
 import { isAnswerCorrect, correctAnswerFor } from '../lib/scoring'
-import { trackEvent, trackPageView } from '../lib/analytics'
+import { trackEvent } from '../lib/analytics'
 import { useSpacedRepetition } from '../hooks/useSpacedRepetition'
 import { shuffleAndMapQuestions, toggleMultiAnswer, getQuestionType, encodeAnswerForDb, type OptionKeyMap } from '../lib/utils'
 import {
@@ -315,10 +315,7 @@ export function DomainPractice() {
       finishingRef.current = false // re-arm the dup-write guard for this fresh session
       setScreen('practice')
       window.scrollTo(0, 0)
-      trackEvent('practice_started', { domain_id: selectedDomain, question_count: questionCount })
-      // Keep the visitor "online" in Umami during the practice session by
-      // emitting a virtual page view (see MockExam, task 13.10). (R15.5)
-      trackPageView(`/${cert.provider}/${cert.code}/domain-practice/active`)
+      trackEvent('practice_started', { domain_id: selectedDomain, question_count: questionCount, guest: !user })
     } catch (err: unknown) {
       // A failed chunk fetch (offline / network) used to dead-end the Start
       // button silently because there was no catch. Surface a retryable error
@@ -431,7 +428,7 @@ export function DomainPractice() {
       }
     }
 
-    trackEvent('practice_completed', { domain_id: selectedDomain, correct: results.filter(r => r).length, total: questionResults.length })
+    trackEvent('practice_completed', { domain_id: selectedDomain, correct: results.filter(r => r).length, total: questionResults.length, guest: !user })
     setScreen('results')
     window.scrollTo(0, 0)
   }

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -28,7 +28,7 @@ import { goToLogin } from '../lib/navigation'
 import type { Question, OptionKey } from '../types'
 import { loadAllQuestions } from '../data/questions'
 import { shuffleAndMapQuestions, toggleMultiAnswer, getQuestionType, encodeAnswerForDb, type OptionKeyMap } from '../lib/utils'
-import { trackEvent, trackPageView } from '../lib/analytics'
+import { trackEvent } from '../lib/analytics'
 import { KOFI_URL } from '../lib/constants'
 import { MAX_MULTI_ANSWER, TIMER_PULSE_THRESHOLD } from '../lib/constants'
 import { registerExamLeaveHandler, confirmExamLeave, isIntentionalLeave, SIGN_OUT_SENTINEL, markIntentionalLeave } from '../lib/examGuard'
@@ -417,12 +417,7 @@ export function MockExam() {
       timer.reset()
       timer.start()
       document.body.dataset.examActive = 'true'
-      trackEvent('exam_started')
-      // Keep the visitor visible in Umami's active-visitor count during the
-      // long (up to 90-min) exam session by emitting a virtual page view; a
-      // timed exam otherwise fires no page views and drops off "online" after
-      // ~5 min. (R15.5, task 13.10)
-      trackPageView(`/${cert.provider}/${cert.code}/practice-exam/active`)
+      trackEvent('exam_started', { guest: !user })
       window.scrollTo(0, 0)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to load questions'
@@ -656,7 +651,7 @@ export function MockExam() {
     setScreen('results')
     delete document.body.dataset.examActive
     window.scrollTo(0, 0)
-    trackEvent('exam_completed', { passed, scaled_score: scaledScore, score_percent: Math.round(percentScore) })
+    trackEvent('exam_completed', { passed, scaled_score: scaledScore, score_percent: Math.round(percentScore), guest: isGuest })
     setLoading(false)
   }
 
@@ -941,6 +936,7 @@ export function MockExam() {
               return weakestDomain ? (
                 <a
                   href={`/${cert.provider}/${cert.code}/domain-practice?domain=${weakestDomain.id}`}
+                  onClick={() => trackEvent('weakest_domain_cta_clicked', { surface: 'exam_results', variant: weakest!.kind })}
                   className={buttonClass({ variant: 'brand', fullWidth: true })}
                 >
                   Practice your weakest domain: {weakestDomain.name}


### PR DESCRIPTION
## Summary

Source: `.kiro/growth/FUNNEL-ANALYTICS-FINDINGS-2026-07-02.md` (sections 2 + 5), `.kiro/maintenance/IMPLEMENTATION-QUEUE-2026-07-03.md` item 2.

One file cluster, no new deps, no UI changes.

### B1 fix (junk path events, ~4.8k/30d measured)
- `trackPageView` (`src/lib/analytics.ts`) no longer calls `window.umami.track(path)`. A bare string to Umami's `track()` records a custom EVENT named that string, not a pageview - and the deployed tracker already auto-tracks every pageview (incl. SPA route changes via its own pushState hook), so the manual call was pure noise. The GA4 branch is untouched (still dormant).
- Removed the two "virtual pageview" call sites this bug produced: `/practice-exam/active` in `_MockExam.tsx` and `/domain-practice/active` in `_DomainPractice.tsx`. `exam_started`/`practice_started` already mark those same moments, so nothing analytically is lost.

### Section-5 funnel riders
- **`email_verified`**: fires in `AuthLinkNotice.tsx` where it resolves `kind === 'verified'`, gated on the same one-shot localStorage ack that already backs the welcome toast, so a refresh (URL is stripped immediately) never refires it. Closes the verification-completion blind spot (`sign_up` minus `email_verified` = drop-off).
- **`new_user` param on `sign_in`** (`useAuth.ts`): true when `user.created_at` is within ~2 minutes of the event. Closes OAuth signup-vs-return (OAuth is 73% of sign-ins per the baseline, and email `sign_up` alone badly undercounts real signups).
- **`guest` param** added to `exam_started`, `exam_completed`, `practice_started`, `practice_completed` only - `question_answered`'s payload is untouched (stays lean; it's the highest-volume event).
- **`weakest_domain_cta_clicked {surface: 'dashboard' | 'exam_results', variant: 'weakest' | 'unstarted'}`**: fires on the dashboard "NEXT UP" card CTA (`CertDashboardIsland.tsx`) and the exam-results "Practice your weakest domain" link (`_MockExam.tsx`). This is the event #135 (Growth Build 2) shipped without.
- **Header Sign-in tracking (owner decision D1: reuse `unlock_cta_clicked`)**: desktop and mobile-drawer Sign-in buttons in `HeaderInteractive.tsx` now fire `unlock_cta_clicked {location: 'header'}` before navigating - fire-and-forget, navigation is never blocked. This was the only sign-in entry point analytics couldn't see (roughly half of `/login` arrivals per the baseline had no CTA attribution).
- **Registry hygiene**: `KNOWN_EVENTS` updated for every new name/param; fixed the stale `page_view`/`landing` comments (B2) to reflect that `page_view` is GA-only/dormant and `landing` is UTM-only; trimmed the dead `home_about`/`cert_about` `UnlockCTALocation` values (B3, no mount sites since v6) and added `'header'`.

## `sign_in` over-fire investigation (baseline: ~3.6 events/visit, 2.31k/649 visits)

Root cause identified by reading `@supabase/auth-js` (2.110.0) source, then confirmed empirically with a throwaway seeded-session Playwright test (not part of this PR):

`GoTrueClient._recoverAndRefresh()` runs both (a) during `_initialize()` on every client construction, and (b) on every `visibilitychange` back to visible. Whenever it finds a still-valid, non-expiring persisted session in storage, it calls `_notifyAllSubscribers('SIGNED_IN', session)` directly - a **genuine** `SIGNED_IN` event, not the newer `INITIAL_SESSION` event the API added specifically to distinguish "recovered an existing session" from "just signed in".

This site is an MPA (`useAuth.ts`'s own module-level state, including `prevUser`, resets on every full navigation - by design, to keep auth JS off the guest/marketing bundle). Because of that, the existing `prevUser === null` guard can't tell "recovered an existing session on this fresh page load" apart from "the user just signed in": on every page view for an already-signed-in visitor, `_recoverAndRefresh()`'s broadcast satisfies the guard. A signed-in user browsing 3-4 pages in one Umami "visit" window reproduces the ~3.6x almost exactly. (Tab-focus re-fires of the same function are a real but secondary contributor - already deduped within one page's lifetime since `prevUser` is no longer null by then.)

**Fix**: a `sessionStorage` flag (`cc_sign_in_tracked`) that survives across full-page navigations within the same tab, unlike module state. `sign_in` now fires at most once per browser tab session; cleared on `SIGNED_OUT` so a genuine later sign-in (e.g. a different person on a shared device) is tracked again. Cheap, no new files, contained entirely in `useAuth.ts`.

Empirical confirmation (throwaway Playwright test against a seeded persisted session, port-isolated from other concurrent work on this machine):
- First page load: `sign_in` fires once, `{method: 'email', new_user: false}`.
- Second full navigation in the same tab: zero `sign_in` events (previously would have refired).

## Verification

- `npm run check` (astro check + eslint + vitest): 0 errors/warnings, 263 tests passing.
- `npm run build`: all guards green (validate-questions, seo-assets, citation, internal-graph, person-graph, csp:hash).
- `npm run e2e`: full suite, 121 tests - 112 passing, 9 `test.fixme` (pre-existing, require real Supabase creds per the spec's own design, unrelated to this change). Verified twice independently (once via the default config, once via a dedicated port to rule out interference from other concurrent agent sessions sharing this machine's default port 4321) with consistent 112/121 results.
- Manual/Playwright verification against `npm run preview` (dedicated port, isolated from other concurrent sessions):
  - SPA navigation into an active exam emits zero path-named junk events (previously 2 per exam start: the AppIsland route-change event and the virtual-pageview call).
  - `exam_started`/`practice_started` carry `guest: true` for a guest session.
  - `email_verified` fires exactly once on a `?verified=1` landing.
  - Header "Sign in" fires `unlock_cta_clicked {location: 'header'}`.
  - `weakest_domain_cta_clicked {surface: 'dashboard', variant: 'weakest'}` fires from the dashboard NEXT UP CTA.
  - `sign_in` over-fire dedupe confirmed as described above.

## Deviations from spec
None. Scope matches the queue item exactly: `analytics.ts`, `AuthLinkNotice.tsx`, `useAuth.ts`, the 4 start/complete event call sites, `CertDashboardIsland.tsx`/`_MockExam.tsx` CTA sites (event call sites only, nothing else touched in `_MockExam.tsx`), plus `HeaderInteractive.tsx`/`UnlockCTA.tsx` for the header-tracking decision (D1).

Not merging - opening for review per the standing rule (squash-merge by owner only).