### PR TITLE
fix(copy): submit-modal plural, sub-minute time, sentence case, practice-exam naming

### DIFF
--- a/e2e/weakest-domain-next-action.spec.ts
+++ b/e2e/weakest-domain-next-action.spec.ts
@@ -98,7 +98,7 @@ test('zero-data dashboard: Best score N/A + baseline hint, NEXT UP points at the
   await seedSession(page) // default stub: every REST read returns []
   await page.goto(CERT_URL)
 
-  await expect(page.getByText('Take your first mock exam to set a baseline')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByText('Take your first practice exam to set a baseline')).toBeVisible({ timeout: 15000 })
   await expect(page.getByText('N/A')).toBeVisible()
   await expect(page.getByText('You have not practiced')).toBeVisible()
   const cta = page.getByRole('link', { name: 'Practice this domain' })

--- a/src/components/CertDashboardIsland.tsx
+++ b/src/components/CertDashboardIsland.tsx
@@ -282,14 +282,14 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
               <>
                 <SkeletonStatTile label="Questions practiced" />
                 <SkeletonStatTile label="Accuracy" />
-                <SkeletonStatTile label="Mock exams" />
+                <SkeletonStatTile label="Practice exams" />
                 <SkeletonStatTile label="Best score" />
               </>
             ) : (
               <>
                 <StatTile label="Questions practiced" value={questionsPracticed.toLocaleString('en-US')} suffix={`/ ${bankTotal.toLocaleString('en-US')}`} />
                 <StatTile label="Accuracy" value={String(accuracy)} suffix="%" hint="correct / answered" />
-                <StatTile label="Mock exams" value={String(examCount)} />
+                <StatTile label="Practice exams" value={String(examCount)} />
                 {/* Empty state: scaled scores start at 100, so a literal 0 is
                     misleading (HALO-CRITIQUE P1). Placeholder + the one next
                     action instead. */}
@@ -297,7 +297,7 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
                   label="Best score"
                   value={bestScore > 0 ? bestScore.toLocaleString('en-US') : 'N/A'}
                   suffix={bestScore > 0 ? `/ ${(1000).toLocaleString('en-US')}` : undefined}
-                  hint={bestScore > 0 ? undefined : 'Take your first mock exam to set a baseline'}
+                  hint={bestScore > 0 ? undefined : 'Take your first practice exam to set a baseline'}
                 />
               </>
             )}
@@ -319,7 +319,7 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
                 <FileText className="w-5 h-5 text-text-primary" aria-hidden="true" />
               </span>
               <h3 className="mt-4 text-lg md:text-xl font-semibold tracking-[-0.01em] text-text-primary">
-                Mock exam
+                Practice exam
                 <ArrowRight
                   className="ml-1.5 inline-block w-4 h-4 align-[-2px] text-text-primary/50 transition-[transform,color] duration-200 group-hover:translate-x-1 group-hover:text-text-primary"
                   aria-hidden="true"
@@ -511,12 +511,12 @@ function CertDashboard({ cert }: { cert: CertDashboardCert }) {
           ) : recentAttempts.length === 0 ? (
             <div className="bg-bg-card rounded-2xl border border-border-hairline p-8 md:p-10 text-center">
               <p className="text-text-primary font-medium">No attempts yet</p>
-              <p className="mt-1 text-sm text-text-muted">Take your first mock exam to start tracking your progress.</p>
+              <p className="mt-1 text-sm text-text-muted">Take your first practice exam to start tracking your progress.</p>
               <a
                 href={`${certPath}/practice-exam`}
                 className="mt-5 inline-flex min-h-[44px] items-center justify-center rounded-full bg-cta px-6 text-sm font-medium text-on-cta transition-colors duration-200 hover:bg-cta-hover"
               >
-                Start a mock exam
+                Start a practice exam
               </a>
             </div>
           ) : (

--- a/src/pages/_DomainPractice.tsx
+++ b/src/pages/_DomainPractice.tsx
@@ -552,7 +552,7 @@ export function DomainPractice() {
 
             <div className="flex items-center justify-between mb-8">
               <span className="text-text-primary font-medium" id="question-count-label">
-                Number of Questions:
+                Number of questions:
               </span>
               <div className="flex items-center gap-3 md:gap-4" role="group" aria-labelledby="question-count-label">
                 <button

--- a/src/pages/_Login.tsx
+++ b/src/pages/_Login.tsx
@@ -366,7 +366,7 @@ export function Login() {
                     <BookOpen className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">{getActiveTotalQuestions().toLocaleString('en-US')}+ Practice Questions</h3>
+                    <h3 className="text-text-primary font-semibold mb-1">{getActiveTotalQuestions().toLocaleString('en-US')}+ practice questions</h3>
                     <p className="text-text-muted text-sm">Up to date with the latest exam guides, across multiple AWS certifications</p>
                   </div>
                 </div>
@@ -376,7 +376,7 @@ export function Login() {
                     <FileText className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">Full-Length Practice Exams</h3>
+                    <h3 className="text-text-primary font-semibold mb-1">Full-length practice exams</h3>
                     <p className="text-text-muted text-sm">Timed exams in the same format as the real thing</p>
                   </div>
                 </div>
@@ -386,7 +386,7 @@ export function Login() {
                     <Target className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">Domain Practice</h3>
+                    <h3 className="text-text-primary font-semibold mb-1">Domain practice</h3>
                     <p className="text-text-muted text-sm">Practice one domain at a time with instant feedback</p>
                   </div>
                 </div>
@@ -396,7 +396,7 @@ export function Login() {
                     <TrendingUp className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">Progress Tracking</h3>
+                    <h3 className="text-text-primary font-semibold mb-1">Progress tracking</h3>
                     <p className="text-text-muted text-sm">Monitor your scores across all domains and review past attempts</p>
                   </div>
                 </div>
@@ -406,7 +406,7 @@ export function Login() {
                     <CheckCircle className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">100% Free</h3>
+                    <h3 className="text-text-primary font-semibold mb-1">100% free</h3>
                     <p className="text-text-muted text-sm">No hidden fees, no premium tiers, no paywalls, no ads</p>
                   </div>
                 </div>

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -861,16 +861,16 @@ export function MockExam() {
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
               <div>
-                <p className="text-text-muted text-sm mb-1">Pass Mark</p>
+                <p className="text-text-muted text-sm mb-1">Pass mark</p>
                 <p className="font-mono text-2xl font-semibold tabular-nums text-text-primary">{cert.passingScore}/1000</p>
               </div>
               <div>
-                <p className="text-text-muted text-sm mb-1">Time Taken</p>
-                <p className="font-mono text-2xl font-semibold tabular-nums text-text-primary">{formatTotalTime(Math.round(results!.timeTaken / 60))}</p>
+                <p className="text-text-muted text-sm mb-1">Time taken</p>
+                <p className="font-mono text-2xl font-semibold tabular-nums text-text-primary">{results!.timeTaken < 60 ? '<1m' : formatTotalTime(Math.round(results!.timeTaken / 60))}</p>
               </div>
             </div>
 
-            <h3 className="text-xl font-semibold text-text-primary mb-4">Domain Breakdown</h3>
+            <h3 className="text-xl font-semibold text-text-primary mb-4">Domain breakdown</h3>
             <div className="space-y-4">
               {cert.domains.map(domain => {
                 const score = results!.domainScores[String(domain.id)] ?? 0
@@ -1253,7 +1253,7 @@ export function MockExam() {
         <Modal isOpen={showEndModal} title="Ready to submit?" onClose={() => setShowEndModal(false)}>
           <div className="space-y-4">
             <p className="text-text-primary">You have answered <span className="font-bold">{answeredCount}</span> of {questions.length} questions.</p>
-            <p className="text-text-primary"><span className="font-bold">{flaggedCount}</span> questions are flagged for review.</p>
+            <p className="text-text-primary"><span className="font-bold">{flaggedCount}</span> {flaggedCount === 1 ? 'question is' : 'questions are'} flagged for review.</p>
             {answeredCount < questions.length && (
               <p className="text-warning text-sm" role="alert">
                 <span className="font-semibold">{questions.length - answeredCount} unanswered</span> {questions.length - answeredCount === 1 ? 'question is' : 'questions are'} marked incorrect on submit.


### PR DESCRIPTION
## Summary

Pure copy quick-wins from `.kiro/ux/UI-PERFECTION-FINDINGS-2026-07-02.md` (M1, M2, X2, X3), queue item 3 in `.kiro/maintenance/IMPLEMENTATION-QUEUE-2026-07-03.md`. No logic or styling changes.

- **M1 (`_MockExam.tsx` submit modal):** fixed "1 questions are flagged for review." to switch singular/plural, mirroring the existing pattern on the adjacent unanswered-count line.
- **M2 (`_MockExam.tsx` results):** sub-minute exam times now render "<1m" instead of a misleading "0m" (`Math.round(timeTaken / 60)` rounds anything under 30s down to 0).
- **X2 (sentence case):** normalized Title Case -> sentence case:
  - `_MockExam.tsx` results trio: "Domain Breakdown" -> "Domain breakdown", "Pass Mark" -> "Pass mark", "Time Taken" -> "Time taken"
  - `_Login.tsx` benefit headings: "Full-Length Practice Exams" -> "Full-length practice exams", "Domain Practice" -> "Domain practice", "Progress Tracking" -> "Progress tracking", "100% Free" -> "100% free", "{N}+ Practice Questions" -> "{N}+ practice questions"
  - `_DomainPractice.tsx`: "Number of Questions:" -> "Number of questions:"
- **X3 (naming, owner-decided 2026-07-02: "practice exam"):** renamed the dashboard's "mock exam" strings in `CertDashboardIsland.tsx` to the "practice exam" family: the stat tile label, the best-score baseline hint, the practice-exam card heading, and the recent-attempts empty state (hint + button). Updated the literal-text assertion in `e2e/weakest-domain-next-action.spec.ts` in the same commit since it was checking the old copy.

### "mock exam" hits deliberately left (grepped the whole repo)

Per the task scope (product UI only, not marketing/SEO/locked content/blog):
- `README.md`, `CONTRIBUTING.md`, `public/manifest.json` (generated by `scripts/generate-seo-assets.mjs`), `src/components/landing/AboutCard.astro`, `src/components/landing/CertTile.astro`, `src/components/ExamRealismTable.astro`, `src/pages/index.astro`, `src/pages/aws/[cert]/[domain].astro` - marketing/SEO/indexable pages.
- `src/lib/citation-content.ts`, `src/lib/seo-data.ts`, `src/lib/base-graph.ts`, `src/pages/about.astro` (HowTo JSON-LD), `src/layouts/BaseLayout.astro` (no-JS fallback content) - locked SEO / JSON-LD surfaces.
- `src/content/blog/*.md` - blog content.
- `src/pages/_MockExam.tsx:206,216` - the noindex practice-exam route's `<title>`/meta description (out of the explicit copy-string scope for this file, to stay clear of a parallel session's event-call-site work in the same file).
- Various code comments (not rendered UI text): `PassFailBanner.tsx`, `FooterIsland.tsx`, `useExamActive.ts`, `pendingAttempt.ts`, `scoring.ts`, `analytics.ts`, `_DomainPractice.tsx`, `certifications.ts`, `scoring.test.ts`, `e2e/conversion-events.spec.ts`, `supabase/README.md`.

### Deviations from the task prompt

- Applied sentence case to all 5 login benefit headings for consistency (task named 2 explicitly + "etc."), matching the site's existing sentence-case pattern on the home page's equivalent feature grid (`AboutCard.astro`).

## Verification

- `npm run check` (astro check + eslint + vitest): 0 errors, 263/263 tests pass.
- `npm run build`: all guards green (`check:citation`, `check:graph`, `check:person-graph`, `csp:hash`).
- `npm run e2e`: 68 passed (9 skipped - real-creds tests, expected without local secrets), including all `weakest-domain-next-action` assertions against the updated copy. One pre-existing flake (`github_click`, unrelated file, passes in isolation) and the `ux-audit-a11y`/`ux-audit-practice-menu` specs are excluded - both fail on a clean `origin/main` checkout too (missing `axe-core`, never a committed dependency; confirmed pre-existing, not caused by this change).
- Screenshots (light + dark, Playwright harness) of the submit modal with 1 flagged question, the results header (showing "<1m", sentence case), and the dashboard tiles/recent-attempts empty state, saved under `.kiro/maintenance/wave1-2026-07-02/quick-wins/` (gitignored, not part of this PR).

## Test plan

- [x] `npm run check`
- [x] `npm run build` (guards)
- [x] `npm run e2e`
- [x] Visual screenshot pass, light + dark