### PR TITLE
feat(account): optional exit-reason chips + export pointer in the delete modal (M1)

### DIFF
--- a/e2e/delete-modal-exit-signals.spec.ts
+++ b/e2e/delete-modal-exit-signals.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect, type Page } from '@playwright/test'
+import { seedSession, getSeedRef } from './seededSession'
+
+/**
+ * Delete-modal exit signals (GROW M1): optional reason chips + export pointer.
+ *
+ * Everything here runs against the seeded-session harness with the
+ * `delete-account` Edge Function route STUBBED, so no real backend (and no
+ * real deletion) is ever touched - safe in CI with the placeholder Supabase
+ * URL and locally against a live project.
+ *
+ * The binding anti-dark-pattern contract under test:
+ *  - the reason is optional and skippable (never gates the Delete button),
+ *  - deletion stays exactly one click after DELETE is typed,
+ *  - the `account_delete_reason` event fires ONLY when a chip was selected.
+ * Plus the #138 behaviors these additions must not break: retry-first error
+ * copy on failure, and cross-tab session death auto-closing the modal.
+ */
+
+interface CapturedEvent {
+  name: string
+  params?: Record<string, unknown>
+}
+
+declare global {
+  interface Window {
+    __events: CapturedEvent[]
+  }
+}
+
+/** Stub window.umami so every trackEvent lands in window.__events. */
+async function installEventCapture(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const sink: CapturedEvent[] = []
+    ;(window as unknown as { __events: CapturedEvent[] }).__events = sink
+    ;(window as unknown as { umami: unknown }).umami = {
+      track: (name: string, params?: Record<string, unknown>) => {
+        sink.push({ name, params })
+      },
+    }
+  })
+}
+
+/**
+ * Stub the delete-account Edge Function. `delayMs` holds the response open so
+ * assertions can read window.__events BEFORE the success path redirects away
+ * (trackEvent fires synchronously before the invoke).
+ */
+async function stubDeleteFunction(page: Page, opts: { status: number; delayMs?: number }): Promise<void> {
+  await page.route('**/functions/v1/delete-account', async route => {
+    if (opts.delayMs) await new Promise(r => setTimeout(r, opts.delayMs))
+    await route.fulfill({
+      status: opts.status,
+      contentType: 'application/json',
+      body: opts.status === 200 ? '{"ok":true}' : '{"error":"boom"}',
+    })
+  })
+}
+
+async function openDeleteModal(page: Page): Promise<void> {
+  await page.goto('/account')
+  await page.getByRole('button', { name: 'Delete my account' }).click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+}
+
+test('chips are optional and toggleable; Delete enables on typed DELETE alone', async ({ page }) => {
+  await seedSession(page)
+  await openDeleteModal(page)
+
+  const chip = page.getByRole('button', { name: 'Passed my exam' })
+  await chip.click()
+  await expect(chip).toHaveAttribute('aria-pressed', 'true')
+  await chip.click()
+  await expect(chip).toHaveAttribute('aria-pressed', 'false')
+
+  // One click after DELETE is typed, no chip required.
+  const deleteBtn = page.getByRole('button', { name: 'Delete account' })
+  await expect(deleteBtn).toBeDisabled()
+  await page.getByPlaceholder('DELETE').fill('DELETE')
+  await expect(deleteBtn).toBeEnabled()
+})
+
+test('no chip selected: deletion proceeds and account_delete_reason does NOT fire', async ({ page }) => {
+  await installEventCapture(page)
+  await seedSession(page)
+  await stubDeleteFunction(page, { status: 200, delayMs: 1200 })
+  await openDeleteModal(page)
+
+  await page.getByPlaceholder('DELETE').fill('DELETE')
+  await page.getByRole('button', { name: 'Delete account' }).click()
+
+  // Read events while the stub holds the response open (pre-redirect).
+  await expect(page.getByText('Deleting your account...')).toBeVisible()
+  const events = await page.evaluate(() => window.__events)
+  expect(events.filter(e => e.name === 'account_delete_reason')).toHaveLength(0)
+
+  await page.waitForURL('**/?account_deleted=1')
+})
+
+test('chip selected: account_delete_reason fires once, anonymously, at deletion time', async ({ page }) => {
+  await installEventCapture(page)
+  await seedSession(page)
+  await stubDeleteFunction(page, { status: 200, delayMs: 1200 })
+  await openDeleteModal(page)
+
+  await page.getByRole('button', { name: 'Found a better tool' }).click()
+  await page.getByPlaceholder('DELETE').fill('DELETE')
+  await page.getByRole('button', { name: 'Delete account' }).click()
+
+  await expect(page.getByText('Deleting your account...')).toBeVisible()
+  const events = await page.evaluate(() => window.__events)
+  const reasonEvents = events.filter(e => e.name === 'account_delete_reason')
+  expect(reasonEvents).toHaveLength(1)
+  // Anonymous: the payload is the reason slug and nothing else.
+  expect(reasonEvents[0].params).toEqual({ reason: 'better_tool' })
+
+  await page.waitForURL('**/?account_deleted=1')
+})
+
+test('export pointer closes the modal and runs the existing export', async ({ page }) => {
+  await seedSession(page)
+  await openDeleteModal(page)
+
+  await page.getByRole('button', { name: 'Download your data' }).click()
+  await expect(page.getByRole('dialog')).toBeHidden()
+  // handleExport runs against the seeded REST stub and saves the JSON file.
+  await expect(page.getByText('Your data has been downloaded.')).toBeVisible()
+})
+
+test('#138 regression: failed delete keeps retry-first copy; chip + typed confirm survive', async ({ page }) => {
+  await installEventCapture(page)
+  await seedSession(page)
+  await stubDeleteFunction(page, { status: 500 })
+  await openDeleteModal(page)
+
+  await page.getByRole('button', { name: 'Privacy' }).click()
+  await page.getByPlaceholder('DELETE').fill('DELETE')
+  await page.getByRole('button', { name: 'Delete account' }).click()
+
+  await expect(page.getByRole('alert')).toContainText(/could not delete your account/i)
+  await expect(page.getByRole('dialog')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Privacy' })).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByPlaceholder('DELETE')).toHaveValue('DELETE')
+})
+
+test('#138 regression: cross-tab sign-out still auto-closes the modal', async ({ page }) => {
+  await seedSession(page)
+  await openDeleteModal(page)
+
+  // auth-js delivers cross-tab auth events over a BroadcastChannel named
+  // after the storage key; a SIGNED_OUT message is exactly what signOut in
+  // another tab broadcasts. Post it from a second page (a channel never
+  // delivers to its own context).
+  const tabB = await page.context().newPage()
+  await tabB.goto('/404')
+  await tabB.evaluate(ref => {
+    new BroadcastChannel(`sb-${ref}-auth-token`).postMessage({ event: 'SIGNED_OUT', session: null })
+  }, getSeedRef())
+  await tabB.close()
+
+  await expect(page.getByRole('dialog')).toBeHidden()
+})

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -56,6 +56,7 @@ export const KNOWN_EVENTS = [
   'sign_in_initiated',  // OAuth button clicked (method: github | google)
   'sign_in',            // unauth -> auth transition (fired once, any method)
   'sign_out',           // sign-out
+  'account_delete_reason', // optional exit-reason chip in the delete modal (anonymous; params: reason)
   // Mock exam flow
   'exam_started',
   'exam_abandoned',     // beforeunload during an active exam

--- a/src/pages/_Account.tsx
+++ b/src/pages/_Account.tsx
@@ -6,15 +6,27 @@ import { useSEO } from '../hooks/useSEO'
 import { getSupabase } from '../lib/supabase'
 import { sweepAuthTokens, eraseLocalTraces } from '../lib/authCleanup'
 import { logError } from '../lib/logger'
+import { trackEvent } from '../lib/analytics'
 import { Button } from '../components/Button'
 import { Card } from '../components/Card'
 import { Alert } from '../components/Alert'
 import { Modal } from '../components/Modal'
 import { Input } from '../components/Input'
 import { LoadingSpinner } from '../components/LoadingSpinner'
+import { filterChipClass } from '../lib/buttonStyles'
 import { Download, Trash2, UserCircle } from 'lucide-react'
 
 const SUPPORT_EMAIL = 'alex@cloudcertprep.io'
+
+// Optional, skippable exit-reason chips shown in the delete-confirmation
+// modal (GROW M1). Purely a success/churn signal for retention analysis -
+// never gates the Delete button, and only ever sent if the user opts in.
+const DELETE_REASONS = [
+  { value: 'passed_exam', label: 'Passed my exam' },
+  { value: 'better_tool', label: 'Found a better tool' },
+  { value: 'privacy', label: 'Privacy' },
+  { value: 'other', label: 'Other' },
+] as const
 
 /**
  * Account settings (signed-in only, noindex app route).
@@ -47,6 +59,7 @@ export function Account() {
 
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [confirmText, setConfirmText] = useState('')
+  const [deleteReason, setDeleteReason] = useState<string | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
   // Synchronous re-entrancy guard (note 1): setDeleting is async, so a
@@ -141,6 +154,11 @@ export function Account() {
     setDeleteError(null)
     try {
       const supabase = await getSupabase()
+      // Optional exit-reason signal (GROW M1): anonymous, opt-in only - never
+      // gates deletion, and only sent if the user tapped a chip.
+      if (deleteReason) {
+        trackEvent('account_delete_reason', { reason: deleteReason })
+      }
       // 30s race (note 3): functions.invoke never times out on its own, and
       // the modal is deliberately unclosable mid-delete - a hung request would
       // lock the user on the spinner forever. The deletion itself is
@@ -252,7 +270,7 @@ export function Account() {
                 Permanently delete your account and all your data: exam attempts, domain progress, and your sign-in. This cannot be undone.
               </p>
               <Button
-                onClick={() => { setConfirmText(''); setDeleteError(null); setShowDeleteModal(true) }}
+                onClick={() => { setConfirmText(''); setDeleteError(null); setDeleteReason(null); setShowDeleteModal(true) }}
                 variant="danger"
                 leftIcon={<Trash2 className="w-4 h-4" aria-hidden="true" />}
               >
@@ -272,6 +290,34 @@ export function Account() {
           <p className="text-text-primary">
             This permanently erases your account, exam history, and progress. It cannot be undone.
           </p>
+          <p className="text-sm text-text-muted">
+            Want a copy first?{' '}
+            <button
+              type="button"
+              onClick={() => { setShowDeleteModal(false); handleExport() }}
+              disabled={deleting}
+              className="text-text-primary underline underline-offset-2 hover:text-text-primary/70 transition-colors"
+            >
+              Download your data
+            </button>
+          </p>
+          <div>
+            <p className="text-sm text-text-muted mb-2">Mind sharing why? (optional)</p>
+            <div className="flex flex-wrap gap-2">
+              {DELETE_REASONS.map(r => (
+                <button
+                  key={r.value}
+                  type="button"
+                  onClick={() => setDeleteReason(prev => (prev === r.value ? null : r.value))}
+                  aria-pressed={deleteReason === r.value}
+                  disabled={deleting}
+                  className={filterChipClass({ active: deleteReason === r.value, size: 'sm' })}
+                >
+                  {r.label}
+                </button>
+              ))}
+            </div>
+          </div>
           <p className="text-sm text-text-muted">
             Type <span className="font-mono font-semibold text-text-primary">DELETE</span> to confirm.
           </p>


### PR DESCRIPTION
Implements queue item 4 (GROW M1): the delete flow now captures an optional exit signal and points at the export, without touching the deletion contract #138 shipped.

## Changes

- **`src/pages/_Account.tsx`**
  - Four optional reason chips in the delete-confirmation modal: "Passed my exam" / "Found a better tool" / "Privacy" / "Other". One tap selects, a second tap deselects (`aria-pressed` reflects state). Styled with the house `filterChipClass` idiom (same as the History/MockExam review filters), correct in dark + light.
  - `trackEvent('account_delete_reason', { reason })` fires inside `handleDelete`, before the edge-function invoke, ONLY if a chip was selected. Payload is the reason slug and nothing else (anonymous, no user id).
  - Export pointer line: "Want a copy first? Download your data".
  - Chip state resets each time the modal opens; chips disable while deleting.
- **`src/lib/analytics.ts`**: one registry line adding `account_delete_reason` to `KNOWN_EVENTS` (nothing else touched; trivially rebases against the parallel analytics-integrity branch).
- **`e2e/delete-modal-exit-signals.spec.ts`** (new, CI-safe, all network stubbed): chips optional/toggleable, Delete enables on typed DELETE alone, event fires only on opt-in (exactly once, anonymous payload), no-chip deletion fires nothing, export pointer works, plus #138 regressions (retry-first error copy with chip + typed confirm surviving a failed attempt; cross-tab sign-out auto-close via the auth-js BroadcastChannel).

## Export-pointer option chosen

**Close the modal + reuse the existing `handleExport`** (the least-stateful option). No new state, no scroll/focus management: the click closes the modal and invokes the same function the export card's button calls; the card behind the modal shows the in-progress and "Your data has been downloaded." states. Deliberately NOT `deleting`-flow-adjacent: the button is disabled while a delete is in flight.

## Anti-dark-pattern contract (binding, verified by the new spec)

- Reason is optional and skippable; it never gates the Delete button.
- Deletion stays exactly one click after DELETE is typed.
- No guilt copy, no retention offers, no extra confirmation steps.

## #138 interplay (verified untouched)

Typed-DELETE gate, `deletingRef` re-entrancy guard, 30s invoke timeout, session-death auto-close, retry-first error copy: all preserved. The event fires before the invoke, so a timed-out-but-actually-completed deletion still carries its signal; a failed attempt keeps the chip selected so a retry re-sends the same reason (idempotent-enough for an anonymous counter).

## Verification

- `npm run check`: green (astro check 0 errors, eslint clean, 263/263 unit tests).
- `npm run build`: green, all prebuild + postbuild guards pass (citation, graph, person-graph, CSP hash).
- Playwright full suite: **123 passed, 9 skipped** (112 on an isolated-port run + the 2 specs that hardcode `localhost:4321` re-run against the same build with the URL temporarily pointed at the isolated port, then reverted). Note for reviewers: verification ran on an isolated preview port because a concurrent session was serving a different build on 4321.
- New spec: 6/6 green.
- Manual Playwright pass on `npm run preview` (seeded session): chips select/deselect, Delete works with NO chip selected, event fires only when a chip is chosen (verified via umami stub capture pre-redirect), export pointer downloads + shows the success alert, cross-tab close and error-retry copy still hold.
- Screenshots (light + dark + mobile 375px) in `.kiro/maintenance/wave1-2026-07-02/delete-chips/` (gitignored, local).

Source finding: `.kiro/ux/GROWTH-RETENTION-FINDINGS-2026-07-02.md` section 2 M1. Queue: `.kiro/maintenance/IMPLEMENTATION-QUEUE-2026-07-03.md` item 4.