### PR TITLE
fix(stats,history): cert ordering, error-state chips, single loader, shift-free stats swap (S1/S2/H2 + FLASH F2/F3)

### DIFF
--- a/src/components/StatsIsland.tsx
+++ b/src/components/StatsIsland.tsx
@@ -16,6 +16,12 @@ import { ErrorBoundary } from './ErrorBoundary'
 
 const SNAPSHOT_SELECTOR = '[data-stats-snapshot]'
 
+// The swap itself is kept shift-free by the Astro shell, not by JS: the
+// snapshot and this island share a min-height wrapper in stats.astro that
+// keeps the footer at/below the fold before, during, and after the swap
+// (FLASH F3), and the wrapper's min-height means a shorter live grid never
+// pulls the footer back up either. Hiding the snapshot here is then a pure
+// in-place replacement.
 function hideSnapshot() {
   if (typeof document === 'undefined') return
   const el = document.querySelector<HTMLElement>(SNAPSHOT_SELECTOR)

--- a/src/pages/_History.tsx
+++ b/src/pages/_History.tsx
@@ -490,8 +490,11 @@ export function History() {
           {/* Cert filter row (logged-in only, shown whenever the user has any
               attempts). With a single cert it reads "All certs (N) · CLF-C02 (N)",
               signalling that history is cert-aware; the control stays put as
-              attempt distribution changes rather than appearing only at 2+ certs. */}
-          {user && certsWithAttempts.length >= 1 && (
+              attempt distribution changes rather than appearing only at 2+ certs.
+              Hidden on a load error (H2): with no data loaded there is nothing
+              to filter, and a zero-count chip row above the error band read as
+              "0 attempts" contradicting "couldn't load". */}
+          {!loadError && user && certsWithAttempts.length >= 1 && (
             <div className="flex flex-wrap items-center gap-2 mb-3">
               <span className="text-text-muted text-xs md:text-sm font-medium mr-1">
                 Certification:
@@ -519,8 +522,11 @@ export function History() {
             </div>
           )}
 
-          {/* Pass/fail filter and items-per-page (logged-in only). */}
-          {user && (
+          {/* Pass/fail filter and items-per-page (logged-in only). Hidden on
+              a load error (H2), same reasoning as the cert filter row above:
+              the "Show" select and All(0)/Passed(0)/Failed(0) chips otherwise
+              stay visible above the error band and retry button. */}
+          {!loadError && user && (
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
               <div className="flex gap-2">
                 <button

--- a/src/pages/_Stats.tsx
+++ b/src/pages/_Stats.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useLayoutEffect } from 'react'
 import { Skeleton } from '../components/Skeleton'
 import { Card } from '../components/Card'
 import { Alert } from '../components/Alert'
 import { getSupabase } from '../lib/supabase'
 import { formatRelativeDate } from '../lib/formatting'
 import { formatTime } from '../lib/scoring'
-import { CERTIFICATION_LIST, getCertTotalQuestions, getCertDomains } from '../data/certifications'
+import { getSortedCerts, getCertTotalQuestions, getCertDomains, DEFAULT_CERT_ID } from '../data/certifications'
 import { Trophy, TrendingUp, Clock, Check, RotateCw } from 'lucide-react'
 import { logError } from '../lib/logger'
 
@@ -114,10 +114,11 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
       setLoading(false)
       // Hide the prerendered snapshot ONLY on a successful load (a single
       // forward swap to live numbers). On an errored first load we keep it, so
-      // the real cached numbers stay on screen behind a compact retry.
+      // the real cached numbers stay on screen behind a compact retry. The
+      // actual hide happens in the layout effect below, not here directly
+      // (FLASH F3).
       if (ok) {
         setLiveLoaded(true)
-        onLoaded?.()
       }
     }
   }
@@ -125,8 +126,19 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadStats()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Calling onLoaded() (which hides the prerendered snapshot) directly inside
+  // loadStats raced React's own commit: the snapshot's <h1> could be hidden
+  // before the live view's <h1> had actually painted, producing a one-frame
+  // gap where no heading was visible (FLASH F3). useLayoutEffect runs
+  // synchronously after the DOM has been updated with the live content but
+  // before the browser paints, so the snapshot-hide and the live-content-show
+  // land in the same frame - there is never a frame with zero (or two) <h1>s.
+  useLayoutEffect(() => {
+    if (liveLoaded) onLoaded?.()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [liveLoaded])
 
   // First-load phase: the prerendered snapshot is still standing in (it is
   // hidden only on a SUCCESSFUL load). Never replace it with a skeleton or the
@@ -225,8 +237,16 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
             </Alert>
           )}
 
-          {/* Certification Sections */}
-          {CERTIFICATION_LIST.map(cert => {
+          {/* Certification Sections. Same ordering as the home grid
+              (UI-PERFECTION S1): getSortedCerts() puts active certs before
+              coming-soon ones, then the flagship cert (DEFAULT_CERT_ID) leads
+              the actives. This also matches the prerendered snapshot's cert
+              order (stats.astro renders CERTIFICATIONS insertion order:
+              CLF -> AIF), so the snapshot -> live swap never visibly reorders
+              the certs. */}
+          {[...getSortedCerts()].sort((a, b) =>
+            a.code === DEFAULT_CERT_ID ? -1 : b.code === DEFAULT_CERT_ID ? 1 : 0,
+          ).map(cert => {
             const cs = certStats[cert.code]
 
             if (cert.status === 'coming-soon') {
@@ -245,10 +265,10 @@ export function Stats({ hideInitialSkeleton = false, onLoaded }: StatsProps = {}
                     <TrendingUp className="w-5 h-5 text-text-muted flex-shrink-0 mt-0.5" aria-hidden="true" />
                     <div>
                       <p className="text-text-primary text-sm md:text-base mb-1">
-                        {getCertTotalQuestions(cert.code).toLocaleString('en-US')} practice questions available
+                        {getCertTotalQuestions(cert.code).toLocaleString('en-US')} questions authored so far
                       </p>
                       <p className="text-text-muted text-xs md:text-sm">
-                        Community stats will appear here once users start taking exams.
+                        Question bank in development. Community stats will appear here once users start taking exams.
                       </p>
                     </div>
                   </div>

--- a/src/pages/account.astro
+++ b/src/pages/account.astro
@@ -15,11 +15,18 @@ import AppIsland from '../components/AppIsland.tsx'
   noscriptDirectory={true}
 >
   {/* Static island shell: reserves the body height + a spinner so the page is
-      never an empty, footer-only frame before the client:only island hydrates
-      (parity with login / practice-exam). AppIsland removes #cc-island-fallback
-      on mount; the spinner mirrors LoadingSpinner.tsx. */}
+      never an empty, footer-only frame before the client:only island hydrates.
+      AppIsland removes #cc-island-fallback on mount; the spinner mirrors
+      LoadingSpinner.tsx.
+      Top-aligned (not vertically centered like login / practice-exam) so the
+      handoff to Account's own near-top loading state (_Account.tsx's
+      authLoading spinner, positioned via p-4 md:p-8 rather than centered in
+      the viewport) is in place rather than a center-to-top jump (FLASH F2).
+      This is a deliberate divergence from the login/practice-exam spinner
+      position, scoped to the two routes whose component renders its own
+      near-top loading state next. */}
   <div class="relative flex-1 flex flex-col min-h-[70vh]">
-    <div id="cc-island-fallback" class="absolute inset-0 flex items-center justify-center" role="status" aria-label="Loading">
+    <div id="cc-island-fallback" class="absolute inset-0 flex items-start justify-center pt-8 sm:pt-12 md:pt-16" role="status" aria-label="Loading">
       <div class="w-12 h-12 relative">
         <div class="absolute inset-0 border-[3px] border-text-muted/20 rounded-full"></div>
         <div class="absolute inset-0 border-[3px] border-transparent border-t-text-primary/80 rounded-full animate-spin"></div>

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -15,11 +15,16 @@ import AppIsland from '../components/AppIsland.tsx'
   noscriptDirectory={true}
 >
   {/* Static island shell: reserves the body height + a spinner so the page is
-      never an empty, footer-only frame before the client:only island hydrates
-      (parity with login / practice-exam). AppIsland removes #cc-island-fallback
-      on mount; the spinner mirrors LoadingSpinner.tsx. */}
+      never an empty, footer-only frame before the client:only island hydrates.
+      AppIsland removes #cc-island-fallback on mount; the spinner mirrors
+      LoadingSpinner.tsx.
+      Top-aligned (not vertically centered like login / practice-exam) so the
+      handoff to History's own top-aligned skeleton (_History.tsx) is in
+      place rather than a center-to-top jump (FLASH F2). This is a deliberate
+      divergence from the login/practice-exam spinner position, scoped to the
+      two routes whose component renders a top-aligned skeleton next. */}
   <div class="relative flex-1 flex flex-col min-h-[70vh]">
-    <div id="cc-island-fallback" class="absolute inset-0 flex items-center justify-center" role="status" aria-label="Loading">
+    <div id="cc-island-fallback" class="absolute inset-0 flex items-start justify-center pt-8 sm:pt-12 md:pt-16" role="status" aria-label="Loading">
       <div class="w-12 h-12 relative">
         <div class="absolute inset-0 border-[3px] border-text-muted/20 rounded-full"></div>
         <div class="absolute inset-0 border-[3px] border-transparent border-t-text-primary/80 rounded-full animate-spin"></div>

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -83,6 +83,19 @@ const datasetJsonLd = serializeJsonLd({
   jsonLd={[datasetJsonLd]}
 >
   {/*
+    Shared wrapper for the snapshot -> live swap (FLASH F3). The live grid is
+    a differently-sized layout than the snapshot, so without a reserved
+    height the swap yanks the footer up or down in one frame (measured CLS up
+    to ~0.31 with the footer starting well inside a 900px viewport). The
+    min-height (viewport minus the md header, h-14 = 3.5rem) keeps the footer
+    at/below the fold before the swap, and, being a minimum, the region never
+    shrinks below it afterwards - so neither a taller nor a shorter live grid
+    moves anything visible. Costs a band of whitespace above the footer on
+    no-JS/crawler views of a short snapshot; same tradeoff as the app shells'
+    min-h-[70vh].
+  */}
+  <div class="min-h-[calc(100vh-3.5rem)]">
+  {/*
     Prerendered snapshot — the crawler-visible, citable surface. The React
     island below replaces these figures with live numbers after hydration.
     Both this block and the Dataset JSON-LD read the same snapshot file, so
@@ -143,4 +156,5 @@ const datasetJsonLd = serializeJsonLd({
   </section>
 
   <StatsIsland client:only="react" />
+  </div>
 </BaseLayout>


### PR DESCRIPTION
Queue item 7 (`.kiro/maintenance/IMPLEMENTATION-QUEUE-2026-07-03.md`): UIPF S1/S2/H2 (L25) + FLASH F2/F3 (L26).

## What changed

**S1 - /stats cert ordering.** The live grid mapped `CERTIFICATION_LIST` raw, sandwiching coming-soon SAA-C03 between the two active certs. It now uses `getSortedCerts()` + the home grid's flagship-first tweak, so the order is CLF-C02 -> AIF-C01 -> SAA-C03 - identical to the home grid AND to the prerendered snapshot's order (the swap never visibly reorders certs).

**S2 - SAA coming-soon copy.** "20 practice questions available" (nothing is practicable) -> "20 questions authored so far" + "Question bank in development." - consistent with the home tile.

**H2 - /history error state.** The load-error state kept the "All (0) / Passed (0) / Failed (0)" chips, the cert filter row, and the Show select above the error band - simultaneously claiming "0 attempts" and "couldn't load". All three are now hidden while `loadError` is set; they return after a successful retry. (Does not touch the Show select's label attributes - that belongs to the parallel a11y PR.)

**FLASH F2 - history/account double loader.** Chosen option: **top-align the `#cc-island-fallback` spinner** (not drop it - the fallback exists to cover paint->hydration; dropping it would leave a blank 70vh for ~1.6s, per the corrected analysis in `.kiro/ux/impl-2026-06-28/FLASH-F2F3-loader-cls-PROMPT.md`). The spinner now sits in the top band (~129px in a 900px viewport, was ~350px) where the component skeleton lands next, so the handoff is in place instead of a center->top jump.
> **Owner flag:** this deliberately diverges from the login/practice-exam centered-spinner parity, scoped to the two routes whose component renders a top-aligned loading state next. Comments in both shells say so.

**FLASH F3 - /stats swap CLS + h1 blink.** Two-part fix:
1. The snapshot and the island now share a `min-h-[calc(100vh-3.5rem)]` wrapper in `stats.astro`: the footer starts at/below the fold and the region never shrinks, so neither a taller nor a shorter live grid moves anything visible. This zeroes the swap CLS in *both* directions (the audit's empty-stub shrink case and the real-data growth case).
2. The snapshot-hide (`onLoaded`) moved from the fetch callback into a `useLayoutEffect` keyed on the first successful load, so the hide and the live paint land in the same frame - a per-frame sampler confirms exactly one visible h1 at every moment (before: it hit 0 for at least one frame).

**Not weakened:** #133's error semantics - an errored /stats load still keeps the prerendered snapshot behind the compact "Showing the latest saved figures" retry alert (re-verified). The Dataset JSON-LD, snapshot values, and snapshot h1 are untouched.

## CLS before -> after (buffered layout-shift observer, 1280x900, RPC/fetch delayed ~1.2-1.5s, mocked data - the flash audit's method)

| Surface / scenario | before (main) | after (branch) |
|---|---|---|
| /stats cold load, empty-stub RPC (audit-comparable) | 0.1417 | **0.0000** |
| /stats cold load, representative data | 0.3067 | **0.0000** |
| /history cold load, empty attempts | 0.0094 | 0.0094 |
| /history cold load, 3 representative attempts | 0.3482 | 0.3482 |

/history is unchanged by design: the fallback spinner is `absolute inset-0` (out of flow) so F2 was always perceptual, and the "rich" number is inherent below-the-fold content growth when data arrives (identical before/after).

## Verification

- `npm run check`: astro check 0 errors + lint clean + 263/263 unit tests
- `npm run build`: all guards green (citation, internal graph, person-graph, CSP hash)
- `npm run e2e`: 112 passed, 9 skipped (standing credless/owner-gated skips), 0 failed
- Playwright functional pass on the preview build (all backend traffic mocked): 32/32 checks - S1 order + S2 copy light/dark, H2 error state light/dark (forced via blocked attempts fetch) + retry recovery, F3 h1 min/max 1/1 per frame, #133 snapshot-kept-on-error, F2 spinner position on /history + /account
- Evidence (screenshots, before/after JSON, harness script): `.kiro/maintenance/wave1-2026-07-02/stats-history-polish/` (gitignored, local)

Baseline for before-numbers: origin/main @ 679981e.