### PR TITLE
feat(blog): scale pre-flight - figure/svg CSS, tag taxonomy, gated llms Articles section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,51 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import rehypeRaw from 'rehype-raw';
+
+// Minimal SVG presentation attributes needed for hand-authored inline
+// diagrams (G5 content-scale pre-flight). Deliberately excludes anything
+// that can reach outside the element (no href/xlink:href, no `<use>`/
+// `<foreignObject>`/`<script>` tags), so diagrams stay self-contained shapes
+// and text only.
+const svgPresentationAttrs = [
+  'viewBox', 'width', 'height', 'x', 'y', 'cx', 'cy', 'r', 'rx', 'ry', 'd',
+  'points', 'x1', 'y1', 'x2', 'y2', 'fill', 'stroke', 'strokeWidth',
+  'strokeLinecap', 'strokeLinejoin', 'strokeDasharray', 'transform',
+  'opacity', 'role', 'ariaLabel', 'ariaHidden', 'focusable',
+  'preserveAspectRatio',
+];
+
+// Extends rehype-sanitize's default (GitHub-flavoured) schema with
+// <figure>/<figcaption> and a minimal safe SVG element set, so a blog post
+// can hand-author an inline diagram. Everything else (script, style,
+// event-handler attributes, <use>, <foreignObject>) stays disallowed.
+const blogContentSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...defaultSchema.tagNames,
+    'figure', 'figcaption',
+    'svg', 'g', 'path', 'circle', 'rect', 'line', 'polyline', 'polygon',
+    'ellipse', 'text', 'tspan', 'defs', 'linearGradient', 'stop',
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    svg: svgPresentationAttrs,
+    g: svgPresentationAttrs,
+    path: svgPresentationAttrs,
+    circle: svgPresentationAttrs,
+    rect: svgPresentationAttrs,
+    line: svgPresentationAttrs,
+    polyline: svgPresentationAttrs,
+    polygon: svgPresentationAttrs,
+    ellipse: svgPresentationAttrs,
+    text: svgPresentationAttrs,
+    tspan: svgPresentationAttrs,
+    defs: svgPresentationAttrs,
+    linearGradient: [...svgPresentationAttrs, 'gradientUnits', 'gradientTransform'],
+    stop: [...svgPresentationAttrs, 'offset', 'stopColor', 'stopOpacity'],
+  },
+};
 
 // output: 'static' — no adapter needed. Every route is enumerable at build time
 // (home, about, blog, cert/domain landings, legal, 404). SSR is unnecessary
@@ -21,10 +66,27 @@ export default defineConfig({
   site: 'https://www.cloudcertprep.io',
   trailingSlash: 'never',
   // Sanitize HTML in blog markdown so a contributor PR cannot land raw
-  // <script>/onerror= handlers (stored-XSS via the content pipeline). Uses
-  // rehype-sanitize's default GitHub-flavoured allowlist. (security V7)
+  // <script>/onerror= handlers (stored-XSS via the content pipeline).
+  // (security V7)
+  //
+  // ORDERING NOTE (G5 content-scale pre-flight): Astro's own markdown
+  // pipeline appends its OWN `rehypeRaw` + `rehypeStringify` AFTER these
+  // user rehypePlugins (see @astrojs/markdown-remark). That means raw HTML
+  // written directly into a .md file is still an opaque, un-parsed `raw`
+  // hast node at the point a rehypePlugins-only `rehypeSanitize` step would
+  // run: hast-util-sanitize does not recognise that node type and silently
+  // drops the entire node. Verified: with `rehypePlugins: [rehypeSanitize]`
+  // alone, a raw <figure>/<svg>/<img> written in a post body rendered as
+  // nothing at all, regardless of the schema passed in, meaning every
+  // wave-1 diagram would have silently vanished at build time. Running
+  // `rehypeRaw` here FIRST turns the raw HTML into real element nodes
+  // before `rehypeSanitize` inspects them, so sanitization actually filters
+  // tags/attributes instead of no-op'ing on an opaque node. Astro's own
+  // trailing `rehypeRaw` call becomes a harmless no-op (nothing is left of
+  // type `raw` by then). `blogContentSanitizeSchema` (above) is the default
+  // GitHub-flavoured allowlist plus <figure>/<figcaption>/inline SVG.
   markdown: {
-    rehypePlugins: [rehypeSanitize],
+    rehypePlugins: [rehypeRaw, [rehypeSanitize, blogContentSanitizeSchema]],
   },
   // Prefetch on hover/touch so the island route chunks (login, practice-exam,
   // domain-practice, history) and prerendered pages begin loading before the

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^16.5.0",
         "postcss": "^8.5.16",
+        "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "satori": "^0.26.0",
         "tailwindcss": "^3.4.1",
@@ -440,6 +441,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3335,6 +3337,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3344,6 +3347,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3410,6 +3414,7 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -3936,6 +3941,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4706,6 +4712,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5808,7 +5815,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -6307,6 +6315,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8561,6 +8570,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -11036,6 +11046,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -11195,6 +11206,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11428,6 +11440,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11437,6 +11450,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11932,6 +11946,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -13102,6 +13117,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13275,6 +13291,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -13423,6 +13440,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13967,6 +13985,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -14081,6 +14100,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14880,6 +14900,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15126,6 +15147,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^16.5.0",
     "postcss": "^8.5.16",
+    "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "satori": "^0.26.0",
     "tailwindcss": "^3.4.1",

--- a/scripts/generate-seo-assets.mjs
+++ b/scripts/generate-seo-assets.mjs
@@ -309,25 +309,31 @@ function parseBlogFrontmatter(raw) {
   const get = (key) => body.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))?.[1]?.trim().replace(/^['"]|['"]$/g, '')
   return {
     slug: get('slug'),
+    title: get('title'),
+    description: get('description'),
     date: get('date'),
     updated: get('updated'),
     draft: /^draft:\s*true\s*$/m.test(body),
   }
 }
 
+// `livePosts` is reused below to build the llms.txt "## Articles" section
+// (G5 content-scale pre-flight); kept outside the try block so it survives
+// past the sitemap-routes computation.
 let blogRoutes = []
+let livePosts = []
 try {
   const files = readdirSync(BLOG_DIR).filter(f => f.endsWith('.md'))
-  blogRoutes = files
+  livePosts = files
     .map(f => parseBlogFrontmatter(readFileSync(resolve(BLOG_DIR, f), 'utf8')))
     .filter(p => p && p.slug && !p.draft)
-    .map(p => ({
-      path: `/blog/${p.slug}`,
-      changefreq: 'monthly',
-      priority: '0.6',
-      lastmod: (p.updated ?? p.date ?? today).slice(0, 10),
-      image: '/og/og-blog.png',
-    }))
+  blogRoutes = livePosts.map(p => ({
+    path: `/blog/${p.slug}`,
+    changefreq: 'monthly',
+    priority: '0.6',
+    lastmod: (p.updated ?? p.date ?? today).slice(0, 10),
+    image: '/og/og-blog.png',
+  }))
   if (blogRoutes.length > 0) {
     ROUTES.push({ path: '/blog', changefreq: 'weekly', priority: '0.7' })
     ROUTES.push(...blogRoutes)
@@ -450,6 +456,24 @@ const faqSection = faqEntries.length > 0
       .join('\n\n')
   : ''
 
+// Build the "## Articles" section (G5 content-scale pre-flight): canonical
+// URL + one-line description per live (non-draft) post, newest first (same
+// order as the /blog index). Gated at 3+ live posts, since below that
+// threshold a 1-2 entry list reads as noise rather than a genuine article
+// index; the section is entirely absent from llms.txt rather than emitted
+// half-empty. No further code change is needed as posts ship: this
+// activates itself the moment the 3rd post flips to draft:false.
+const articlePosts = livePosts
+  .filter(p => p.title && p.description)
+  .slice()
+  .sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''))
+const articlesSection = articlePosts.length >= 3
+  ? '\n\n## Articles\n\n' +
+    articlePosts
+      .map(p => `- [${p.title}](${SITE_URL}/blog/${p.slug}): ${p.description}`)
+      .join('\n')
+  : ''
+
 // Top-level `/` description block. Sourced from src/lib/citation-content.ts
 // (the SAME module the rendered home page uses) so the Locked_Citation_Phrases
 // can never drift between the home page and llms.txt (R7.3, R16.14). We build
@@ -494,7 +518,7 @@ ${providerSections}- [Blog](${SITE_URL}/blog): AWS certification study guides, e
 
 ## Certifications
 
-${certLevelSections}${comingSoonSection}${faqSection}
+${certLevelSections}${comingSoonSection}${faqSection}${articlesSection}
 
 ## Resources
 
@@ -503,7 +527,7 @@ ${certLevelSections}${comingSoonSection}${faqSection}
 - [Author portfolio](https://santonastaso.me)
 `
 writeFileSync(LLMS_TXT_PATH, llmsTxt)
-console.log(`✓ llms.txt rewritten (${activeCerts.length} active, ${comingSoonCerts.length} coming-soon, ${faqEntries.length} FAQ entries)`)
+console.log(`✓ llms.txt rewritten (${activeCerts.length} active, ${comingSoonCerts.length} coming-soon, ${faqEntries.length} FAQ entries, ${articlePosts.length} live post(s)${articlesSection ? '' : ', Articles section gated until 3'})`)
 
 // --- Rewrite public/_redirects ---
 // Legacy single-cert URLs map to the *current default cert's* practice flows.

--- a/scripts/validate-blog-frontmatter.mjs
+++ b/scripts/validate-blog-frontmatter.mjs
@@ -11,6 +11,9 @@
  *   - description length is 50-160
  *   - title length is 10-80
  *   - if ogImage is set, the referenced file exists under public/
+ *   - tags include at least one recognized cert-code tag (G5 tag taxonomy,
+ *     see the `tags` comment in src/content.config.ts) - domain-slug tags
+ *     are conditional per post, so they are documented but not enforced here
  *
  * Exits non-zero with a per-violation report on failure; prints a success
  * summary on pass. Run via `npm run prebuild` (appended to the chain).
@@ -23,6 +26,23 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 const BLOG_DIR = join(ROOT, 'src', 'content', 'blog')
 const PUBLIC_DIR = join(ROOT, 'public')
+const CERT_REGISTRY_PATH = join(ROOT, 'src', 'data', 'certifications.ts')
+
+/**
+ * Known cert codes (e.g. 'clf-c02', 'aif-c01'), parsed out of the registry's
+ * `code: '...'` fields with a small regex - same lightweight-parse approach
+ * scripts/generate-seo-assets.mjs already uses to read this file at build
+ * time, kept here as its own tiny pass so this validator stays plain `node`
+ * (no tsx) rather than importing the .ts registry.
+ */
+function knownCertCodes() {
+  const source = readFileSync(CERT_REGISTRY_PATH, 'utf8')
+  const codes = new Set()
+  const re = /code:\s*'([a-z0-9-]+)'/g
+  let m
+  while ((m = re.exec(source)) !== null) codes.add(m[1])
+  return codes
+}
 
 const violations = []
 function violation(file, msg) {
@@ -102,6 +122,7 @@ if (!existsSync(BLOG_DIR)) {
 
 const files = readdirSync(BLOG_DIR).filter((f) => f.endsWith('.md'))
 const seenSlugs = new Map()
+const CERT_CODES = knownCertCodes()
 let nonDraftCount = 0
 
 for (const file of files) {
@@ -171,6 +192,18 @@ for (const file of files) {
         violation(file, `tag "${tag}" contains disallowed characters (< or >)`)
       }
     }
+  }
+
+  // Tag taxonomy (G5 content-scale pre-flight): every non-draft post must
+  // carry at least one recognized cert-code tag (see the `tags` comment in
+  // src/content.config.ts) so it always surfaces on that cert's domain
+  // landings, even before a domain-slug tag is added. Domain-slug tags are
+  // conditional per post, so they are documented but not enforced here.
+  if (!Array.isArray(fm.tags) || !fm.tags.some((tag) => CERT_CODES.has(tag))) {
+    violation(
+      file,
+      `tags [${Array.isArray(fm.tags) ? fm.tags.join(', ') : ''}] do not include a recognized cert-code tag (one of: ${[...CERT_CODES].join(', ')})`,
+    )
   }
 
   if (fm.ogImage) {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -19,6 +19,18 @@ const blog = defineCollection({
     description: z.string().min(50).max(160),
     date: z.coerce.date(),
     updated: z.coerce.date().optional(),
+    // Tag taxonomy (G5 content-scale pre-flight): every non-draft post MUST
+    // include at least one cert-code tag (e.g. 'clf-c02', 'aif-c01' - matches
+    // `certifications.ts`'s `code` field; enforced by
+    // scripts/validate-blog-frontmatter.mjs), so the post always shows up in
+    // that cert's domain-landing "latest posts" fallback
+    // (src/pages/aws/[cert]/[domain].astro's certTaggedPosts). Add a
+    // domain-slug tag too (e.g. 'cloud-concepts', 'security-and-compliance' -
+    // matches the domain landing's URL segment) ONLY when the post is
+    // genuinely about that one domain, not a broad/comparison post - a
+    // domain-slug tag promotes the post to the front of that domain's own
+    // landing page. Additional free-form topical tags (e.g. 'exam-format',
+    // 'career', 'study-tips') are fine alongside the required cert-code tag.
     tags: z.array(z.string()).default([]),
     ogImage: z.string().optional(),
     draft: z.boolean().default(false),

--- a/src/index.css
+++ b/src/index.css
@@ -710,3 +710,32 @@ body {
 .blog-content tbody tr:last-child td {
   border-bottom: 0;
 }
+
+/* Blog media - images, figures, and inline SVG diagrams (G5 content-scale
+   pre-flight, ahead of the first diagram-bearing post). Plain images shrink
+   to fit the column; figures centre their content and get the same
+   overflow-x scroll containment as the table above so a wide diagram never
+   blows out the page on a narrow screen. Diagrams should be authored with
+   fill="currentColor" / stroke="currentColor" instead of a hard-coded
+   colour, since the rule below is exactly what currentColor resolves to
+   inside .blog-content, so one inline <svg> renders correctly in both
+   themes. */
+.blog-content img,
+.blog-content svg {
+  max-width: 100%;
+  height: auto;
+}
+.blog-content svg {
+  color: rgb(var(--color-text-primary));
+}
+.blog-content figure {
+  margin: 0;
+  overflow-x: auto;
+  text-align: center;
+}
+.blog-content figcaption {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: rgb(var(--color-text-muted));
+}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -18,6 +18,9 @@ import PostCard from '../../components/PostCard.astro'
 import { SITE_URL } from '../../lib/seo-data'
 import { includeDrafts } from '../../lib/posts'
 
+// G5 content-scale pre-flight: pagination is consciously deferred until the
+// catalogue actually passes this trigger (see the file docblock above for
+// where `blog/page/[page].astro` would go). Do not build it early.
 const PAGE_SIZE = 10
 
 const posts = await getCollection('blog', ({ data }: CollectionEntry<'blog'>) =>


### PR DESCRIPTION
## What this is

Queue item 5 (G5 content-scale pre-flight, SEO-GAP-ANALYSIS-2026-07-02 / P2-E scale pre-flight). Must land before wave-1 publishes: wave 1 carries diagram-bearing concept posts.

## Changes

1. **`.blog-content` media CSS** (`src/index.css`, after the existing table block at ~672):
   - `img`/`svg`: `max-width: 100%; height: auto` (responsive, never overflow the 68ch column)
   - `svg`: `color: rgb(var(--color-text-primary))` so `currentColor`-authored inline diagrams render correctly in BOTH themes with one markup
   - `figure`: centered, `overflow-x: auto` (same horizontal-scroll containment pattern as tables)
   - `figcaption`: muted, small, consistent with the existing blog typography tokens
2. **Markdown pipeline fix** (`astro.config.mjs`) - found while verifying the CSS end-to-end: with the previous `rehypePlugins: [rehypeSanitize]`, ANY raw HTML in a post body (`<figure>`, `<svg>`, `<img>`) was **silently dropped at build time**. Astro appends its own `rehypeRaw` AFTER user rehype plugins, so sanitize ran while raw HTML was still an opaque `raw` hast node, which `hast-util-sanitize` discards wholesale. Every wave-1 diagram would have vanished. Fix: run `rehypeRaw` first in user plugins, then `rehypeSanitize` with a schema = default GitHub allowlist + `figure`/`figcaption` + a minimal SVG element/presentation-attribute set. Script tags, event handlers (`onclick`/`onerror`), `<use>`/`<foreignObject>`, and URL-bearing SVG attrs remain stripped (verified in the built output).
3. **Tag taxonomy** - convention documented on the schema (`src/content.config.ts`): every post tags its cert code(s) (registry `code` values), domain-slug tags only when the post is genuinely about that one domain, free-form topical tags allowed. Enforced in `scripts/validate-blog-frontmatter.mjs`: non-draft posts must carry at least one recognized cert-code tag (codes parsed from `certifications.ts`, same lightweight-parse pattern as `generate-seo-assets.mjs`). The live post `aif-c01-vs-clf-c02.md` already conforms (`clf-c02`, `aif-c01`, `exam-format` - both cert codes it compares; no single domain-slug applies to a broad comparison post), so **no post file was touched** (its body is a locked SEO surface post-#143).
4. **llms.txt `## Articles` section, gated** (`scripts/generate-seo-assets.mjs`): canonical URLs + one-line descriptions of live posts, newest first, emitted only at >= 3 live posts. With 1 live post today the output is byte-identical (proof below). Activates itself when the 3rd post flips `draft:false`; zero further code changes needed.
5. **Pagination**: NOT built (consciously deferred). Comment at the `PAGE_SIZE` trigger in `src/pages/blog/index.astro` marks where `blog/page/[page].astro` takes over past ~10 posts.

## Byte-identity proof (the hard constraint)

- `npx tsx scripts/generate-seo-assets.mjs` and a full `npm run build` both regenerate `public/llms.txt` **byte-identical to git HEAD** (`git diff --exit-code public/llms.txt` passes). Re-proven after each of the #143 and #141/#142 rebases.
- `public/sitemap.xml` regeneration shows `<lastmod>` drift vs the committed artifact, but this branch's script output is **byte-identical to the pristine main script's output** (verified by running `938f168:scripts/generate-seo-assets.mjs` side by side): the drift is pre-existing committed-artifact staleness on main (git-lastmod dates moved with recent merges), not introduced here. Neither generated file is committed in this PR (per standing practice).
- Rendered-page check: the live post's `dist` HTML body under my branch is byte-identical to pristine main's; the page's inline `<style>` differs by exactly the inserted `.blog-content` media block and nothing else.

## Gates (all on the pushed SHA's base, after rebasing onto #143 + #141 + #142)

- `npm run check`: astro check 0 errors / 0 warnings, eslint clean, 263/263 unit tests
- `npm run build`: all prebuild validators + postbuild guards green (citation, internal graph, person-graph byte-identity, csp:hash, cf:headers)
- `npm run e2e` (isolated port 4399, `reuseExistingServer: false`): 101 passed / 20 skipped (creds-gated) on two consecutive full runs. One test (`conversion-events > github_click`) flaked intermittently under full 12-worker parallel load across BOTH this branch and pristine main builds - it always passes in isolation and on rerun; it waits on header-island hydration (visibility precedes handler attachment), a surface this diff does not touch.

## Visual evidence

Fixture post (never committed) rendered through the real build + preview, `.blog-content` element screenshots light + dark saved to `.kiro/maintenance/wave1-2026-07-02/blog-preflight/blog-content-{light,dark}.png` (main checkout). They show: currentColor SVG diagram correct in both themes, muted figcaption, responsive raster `<img>`, and the sanitizer stripping `<script>`/`onclick`/`onerror` while keeping the wrapping markup.

## Deviations / notes for review

- **`rehype-raw` added to `devDependencies`**: NOT a new package install - it is already in the tree (direct dependency of `@astrojs/markdown-remark`, present in the lockfile at the same `^7.0.0`); declaring it makes our direct import of it explicit instead of an undeclared transitive reach. `npm install` after the edit reported "up to date" (zero new packages). If you'd rather not declare it, the import resolves either way - say the word and I drop the manifest line.
- `package-lock.json` picked up `"peer": true` annotations on existing entries - npm 11 lockfile normalization churn from the manifest touch, no version changes.
- The pipeline fix means raw-HTML support in posts is now REAL - previously unusable (silently dropped), so no existing content changes behavior; the one live post uses no raw HTML.

DO NOT MERGE without owner review (standing rule).