### PR TITLE
fix(a11y): history select name, pill landmark, heading structure, blog table th

### DIFF
--- a/src/components/DonateButton.tsx
+++ b/src/components/DonateButton.tsx
@@ -62,6 +62,8 @@ export function DonateButton({ isExamActive, pathname }: DonateButtonProps) {
     // page. Fade it in rather than snapping into place. Reduced-motion users get
     // it instantly (global override neutralizes the animation).
     <div
+      role="complementary"
+      aria-label="Support this project"
       className={`hidden lg:block fixed bottom-6 left-6 z-40 group animate-fade-in transition-[opacity,transform] duration-gentle ease-out ${nearFooter ? 'pointer-events-none translate-y-3 opacity-0' : 'opacity-100'}`}
     >
       <a

--- a/src/content/blog/aif-c01-vs-clf-c02.md
+++ b/src/content/blog/aif-c01-vs-clf-c02.md
@@ -26,7 +26,7 @@ Both are entry-level and neither requires hands-on lab work. They follow AWS's s
 
 ## CLF-C02 vs AIF-C01 at a glance
 
-| | CLF-C02 | AIF-C01 |
+| Aspect | CLF-C02 | AIF-C01 |
 | --- | --- | --- |
 | Focus | The AWS Cloud, broadly | AI and ML on AWS |
 | Level | Foundational | Foundational |

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -234,7 +234,7 @@ const updatedDisplay = data.updated
           </div>
           {showToc && (
             <aside class="hidden lg:block" aria-label="Table of contents">
-              <nav class="sticky top-24">
+              <nav class="sticky top-24" aria-label="Table of contents">
                 <p class="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted mb-3">
                   On this page
                 </p>

--- a/src/pages/_DomainPractice.tsx
+++ b/src/pages/_DomainPractice.tsx
@@ -477,9 +477,9 @@ export function DomainPractice() {
                           {domain.id}
                         </div>
                         <div className="flex-1 min-w-0">
-                          <h3 className="text-sm md:text-base font-semibold text-text-primary [text-wrap:balance]">
+                          <h2 className="text-sm md:text-base font-semibold text-text-primary [text-wrap:balance]">
                             {domain.name}
-                          </h3>
+                          </h2>
                           <p className="text-xs md:text-sm text-text-muted">{domain.questionCount} questions</p>
                         </div>
                       </div>
@@ -639,7 +639,7 @@ export function DomainPractice() {
 
             {/* Question Number Grid */}
             <Card padding="sm" className="mb-4">
-              <h3 className="text-xs md:text-sm font-semibold text-text-muted mb-2 text-center">Questions:</h3>
+              <h2 className="text-xs md:text-sm font-semibold text-text-muted mb-2 text-center">Questions:</h2>
               <div className="grid grid-cols-[repeat(auto-fit,minmax(32px,32px))] md:grid-cols-[repeat(auto-fit,minmax(36px,36px))] gap-0.5 md:gap-1 justify-center">
                 {questionResults.map((result, idx) => {
                   const stateLabel = result.isCorrect ? 'correct' : 'incorrect'
@@ -714,9 +714,9 @@ export function DomainPractice() {
               The button is gated on >=1 answered: before that there's nothing
               to save, so Back is the exit. (M3 [B]) */}
           <div className={`flex items-center gap-3 mb-6 min-h-[2rem] ${questionResults.length > 0 ? 'justify-between' : 'justify-center'}`}>
-            <h2 className="text-base md:text-lg lg:text-xl font-semibold text-text-primary [text-wrap:balance] min-w-0">
+            <h1 className="text-base md:text-lg lg:text-xl font-semibold text-text-primary [text-wrap:balance] min-w-0">
               {domains[selectedDomain!]}
-            </h2>
+            </h1>
             {questionResults.length > 0 && (
               <button
                 type="button"
@@ -743,7 +743,7 @@ export function DomainPractice() {
 
           {/* Question */}
           <Card className="mb-3">
-            <h3 className="text-base md:text-lg text-text-primary mb-4 md:mb-5">
+            <h2 className="cc-question-stem text-base md:text-lg text-text-primary mb-4 md:mb-5">
               {currentQuestion.question}
               {currentType === 'multi' && (
                 <span className="text-text-primary font-semibold ml-2">(Select {Array.isArray(currentQuestion.answer) ? currentQuestion.answer.length : MAX_MULTI_ANSWER})</span>
@@ -754,7 +754,7 @@ export function DomainPractice() {
               {currentType === 'matching' && (
                 <span className="text-text-primary font-semibold ml-2">(Match each item)</span>
               )}
-            </h3>
+            </h2>
 
             <div className="space-y-2.5 mb-4">
               {currentType === 'ordering' ? (

--- a/src/pages/_History.tsx
+++ b/src/pages/_History.tsx
@@ -547,8 +547,9 @@ export function History() {
               </div>
 
               <div className="flex items-center gap-2">
-                <span className="text-text-muted text-sm">Show:</span>
+                <label htmlFor="history-items-per-page" className="text-text-muted text-sm">Show:</label>
                 <select
+                  id="history-items-per-page"
                   value={itemsPerPage}
                   onChange={(e) => setItemsPerPage(Number(e.target.value))}
                   className={inputClass({ surface: 'page', className: 'w-auto px-3 py-2 text-sm' })}

--- a/src/pages/_Login.tsx
+++ b/src/pages/_Login.tsx
@@ -366,7 +366,7 @@ export function Login() {
                     <BookOpen className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">{getActiveTotalQuestions().toLocaleString('en-US')}+ practice questions</h3>
+                    <h2 className="text-text-primary font-semibold mb-1">{getActiveTotalQuestions().toLocaleString('en-US')}+ practice questions</h2>
                     <p className="text-text-muted text-sm">Up to date with the latest exam guides, across multiple AWS certifications</p>
                   </div>
                 </div>
@@ -376,7 +376,7 @@ export function Login() {
                     <FileText className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">Full-length practice exams</h3>
+                    <h2 className="text-text-primary font-semibold mb-1">Full-length practice exams</h2>
                     <p className="text-text-muted text-sm">Timed exams in the same format as the real thing</p>
                   </div>
                 </div>
@@ -386,7 +386,7 @@ export function Login() {
                     <Target className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">Domain practice</h3>
+                    <h2 className="text-text-primary font-semibold mb-1">Domain practice</h2>
                     <p className="text-text-muted text-sm">Practice one domain at a time with instant feedback</p>
                   </div>
                 </div>
@@ -396,7 +396,7 @@ export function Login() {
                     <TrendingUp className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">Progress tracking</h3>
+                    <h2 className="text-text-primary font-semibold mb-1">Progress tracking</h2>
                     <p className="text-text-muted text-sm">Monitor your scores across all domains and review past attempts</p>
                   </div>
                 </div>
@@ -406,7 +406,7 @@ export function Login() {
                     <CheckCircle className="w-5 h-5 text-brand" aria-hidden="true" />
                   </div>
                   <div>
-                    <h3 className="text-text-primary font-semibold mb-1">100% free</h3>
+                    <h2 className="text-text-primary font-semibold mb-1">100% free</h2>
                     <p className="text-text-muted text-sm">No hidden fees, no premium tiers, no paywalls, no ads</p>
                   </div>
                 </div>

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -865,7 +865,7 @@ export function MockExam() {
               </div>
             </div>
 
-            <h3 className="text-xl font-semibold text-text-primary mb-4">Domain breakdown</h3>
+            <h2 className="text-xl font-semibold text-text-primary mb-4">Domain breakdown</h2>
             <div className="space-y-4">
               {cert.domains.map(domain => {
                 const score = results!.domainScores[String(domain.id)] ?? 0
@@ -1474,7 +1474,7 @@ export function MockExam() {
 
                 {/* Question Number Grid */}
                 <div>
-                  <h3 className="text-xs md:text-sm font-semibold text-text-muted mb-2 text-center">Questions:</h3>
+                  <h2 className="text-xs md:text-sm font-semibold text-text-muted mb-2 text-center">Questions:</h2>
                   <div className="grid grid-cols-[repeat(auto-fit,minmax(32px,32px))] md:grid-cols-[repeat(auto-fit,minmax(36px,36px))] gap-0.5 md:gap-1 justify-center">
                     {results.questionResults.map((result, idx) => {
                       const isCurrentQuestion = filteredQuestions[reviewQuestionIndex]?.questionId === result.questionId


### PR DESCRIPTION
## What

The a11y bundle from the 2026-07-02 UI-perfection audit (UIPF H1 + X4 + X6 + B1/B2, implementation queue item 6). Attribute/level changes only - no heading text, no styling, no behavior changed.

- **H1 (the one axe CRITICAL)**: /history's "Show:" per-page `<select>` had no accessible name. The visible "Show:" text is now a `<label htmlFor>` bound to the select (`src/pages/_History.tsx`).
- **X4**: the donate pill's fixed container sat outside all landmarks (axe `region`, fired on every page it renders). Its container is now `role="complementary"` + `aria-label="Support this project"` (`src/components/DonateButton.tsx`). It mounts outside `<main>` (BaseLayout), so the landmark is top-level - no new nesting violation.
- **X6 heading structure** (levels only, text and styling untouched - Tailwind preflight resets heading sizes, so tag swaps are invisible):
  - login benefit headings h3 -> h2 (H1 -> H3 skip)
  - practice-menu domain-card titles h3 -> h2
  - exam results "Domain breakdown" h3 -> h2 (was an h3 with no h2)
  - exam review + practice results "Questions:" h3 -> h2
  - the active domain-practice session header h2 -> h1 (the session had no H1 in question/feedback states); its question stem h3 -> h2 with `cc-question-stem` to keep greedy wrapping, matching the exam surface
- **B1**: the live post's comparison-table corner `<th>` was empty - now "Aspect" (`src/content/blog/aif-c01-vs-clf-c02.md`, re-applied against the post-#143 table; nothing else in the body touched).
- **B2**: the sticky "On this page" TOC `<nav>` in `BlogLayout.astro` now has `aria-label="Table of contents"` so duplicate navigation landmarks are distinguishable.

## Axe before/after (evidence in `.kiro/maintenance/wave1-2026-07-02/a11y/`, gitignored)

axe-core (wcag2a/2aa/21a/21aa + best-practice), chromium 1280x800, 10 surfaces incl. driven states (exam results/review, practice active/feedback/results) and a seeded-session /history. BEFORE = origin/main @ 938f168, AFTER = this branch on 58ba3ca.

| | Before | After |
|---|---|---|
| Critical | 1 (select-name, /history) | **0** |
| Moderate | 18 (region x9, heading-order x5, page-has-heading-one x2, landmark-unique x1, landmark-complementary-is-top-level x1) | **1** (see below) |
| Minor | 1 (empty-table-header) | **0** |
| New violations | - | **0** |

The one remaining moderate is pre-existing and out of the briefed scope: the END-OF-POST CTA `<aside class="mt-14...">` in BlogLayout sits inside `<main>` (`landmark-complementary-is-top-level`). One-word rider (aside -> div) if wanted later.

Heading TEXT verified identical before/after on every surface (outline diffs in before/after.json); the #142 sentence-case recases were taken from main during rebase - this branch changes tags only. Screenshots pixel-identical (ImageMagick AE=0) on practice-menu / cert-hub / history; login diff = Turnstile spinner frame; blog diff = the intended "Aspect" label only.

## Gates (on the rebased tip, post #141/#142/#143/#144)

- `npm run check`: 0 errors, 263 unit tests green
- `npm run build`: citation / internal-graph / person-graph / CSP guards all green
- `npm run e2e`: 118 passed, 0 failed, 9 skipped (realcreds-gated)
- Lighthouse on the touched indexable pages: blog post 100/100/100/100, cert hub 100/100/100/100 (practice-exam / domain-practice are `robots="noindex"` app routes, exempt per AGENTS.md)
