### PR TITLE
docs(supabase): document get_public_totals + correct stale platform_stats note

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -86,7 +86,7 @@ project, not on prod.)
 
 ### `platform_stats`
 
-Single-row singleton table with aggregate counters. Maintained by triggers on `exam_attempts` and `attempt_questions`.
+Single-row singleton table with aggregate counters. Trigger-maintained on insert only (see Triggers below), via the shared `increment_platform_stat()` function. It never decrements, so it does not correct itself when a user is deleted.
 
 | Column | Type | Notes |
 |---|---|---|
@@ -96,7 +96,14 @@ Single-row singleton table with aggregate counters. Maintained by triggers on `e
 | `total_exams_attempted` | `integer` NOT NULL | |
 | `total_exams_passed` | `integer` NOT NULL | |
 
-**RLS:** SELECT allowed for `anon` and `authenticated` (public stats page).
+**RLS:** SELECT allowed for `anon` and `authenticated`.
+
+> **Corrected 2026-07-02:** this table is the owner's private all-time cumulative
+> counter, not a page data source - no runtime code reads it. This note previously
+> said "the public stats page reads it"; that stopped being true once the Stats
+> page footer moved to `get_public_totals()` (see RPC functions below), which
+> counts live rows directly and therefore self-corrects after account deletions,
+> unlike this table.
 
 ---
 
@@ -126,6 +133,20 @@ Returns aggregated per-cert stats (pass rates, avg scores, domain difficulty, re
 - Used by the Stats page.
 
 Full source: see `src/pages/_Stats.tsx` for the call site. If you change the function signature, update the `CertStats` and `DomainStat` interfaces in that file.
+
+---
+
+### `get_public_totals()`
+
+Returns live site-wide totals as JSON: `{ total_users, total_questions_answered }`. Both fields are a plain `count(*)` on `auth.users` and `public.attempt_questions` respectively, so - unlike the `platform_stats` singleton above - the numbers self-correct after account deletions.
+
+- `SECURITY DEFINER` (the only way to read `auth.users` from the client; RLS otherwise blocks it entirely).
+- `SET search_path = ''` (empty - stricter than `get_public_exam_stats()`, which uses `public`).
+- `LANGUAGE sql`, not `plpgsql` (a single query, no procedural logic needed).
+- Granted to `anon, authenticated` only (no `service_role` grant).
+- Used by the Stats page footer, below the per-cert cards.
+
+Full source: see `src/pages/_Stats.tsx` for the call site. If you change the function signature, update the `PublicTotals` interface in that file. The client validates the returned shape before rendering it, so a missing/null field - or the function simply not existing yet on an env - hides the footer instead of breaking the page.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a `get_public_totals()` RPC section to `supabase/README.md`, matching the existing `get_public_exam_stats()` format: `SECURITY DEFINER`, `SET search_path = ''`, `LANGUAGE sql`, granted to `anon, authenticated` only, returns `{ total_users, total_questions_answered }` as live `count(*)` on `auth.users` / `public.attempt_questions`. Consumed by the `/stats` page footer (`src/pages/_Stats.tsx`).
- Corrects the `platform_stats` note, which said "the public stats page reads it" - stale since the Stats footer moved to `get_public_totals()`. `platform_stats` is now documented as the owner's private, trigger-maintained (insert-only, never decrements), all-time counter with no runtime reader.

Docs only - no other file touched. Ledger item L29 / hardening note 7 (note-7 half).

## What I verified each claim against
- `get_public_totals()` function definition (SQL text, security mode, search_path, grants): `.kiro/maintenance/STATS-LIVE-COUNTS-PROMPT-2026-07-01.md`, which contains the owner's applied-and-verified-on-prod `CREATE OR REPLACE FUNCTION` statement.
- Consumer / call site / return shape / client-side validation behavior: `src/pages/_Stats.tsx` (the `PublicTotals` interface, the `supabase.rpc('get_public_totals')` call, and the footer render).
- No runtime reader of `platform_stats` remains: grepped `src/` and `scripts/` for `platform_stats` - zero hits.
- `platform_stats` trigger-maintained, insert-only, never decrements: existing `## Triggers` section in the same README plus `.kiro/maintenance/apply-test-restore-2-2026-07-02.sql` (verbatim prod trigger/function defs for `increment_platform_stat()` and the three `on_*_created` triggers).
- That this shipped in PR #128: confirmed `1a5c1c5` ("feat(account): self-service deletion + DB cascade for user-data erasure (#128)") is on `origin/main` and its squashed history includes the `feat(stats): read live totals from get_public_totals() RPC` commit.

## Deviations
None from the brief. One addition beyond the two literal asks: I also corrected the `platform_stats` prose sentence that described it as "maintained by triggers on `exam_attempts` and `attempt_questions`" (it omitted the `auth.users` trigger for `total_users`) while writing the trigger-maintained/non-decrementing detail the brief asked for - this was a small factual gap in the same sentence I was already correcting, not a separate scope addition.

## Test plan
- [x] `npm run check` (astro check + lint + full vitest suite) green - 0 errors, 263 tests passing
- [x] Confirmed no em/en dashes in the diff
- [x] Confirmed only `supabase/README.md` changed