### PR TITLE
feat(footer): link the community stats page (M2 step 1)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -58,6 +58,7 @@ export function Footer() {
               <li><a href="/about" className={navLink}>About</a></li>
               <li><a href="/blog" className={navLink}>Blog</a></li>
               <li><a href="/contribute" className={navLink}>Contribute</a></li>
+              <li><a href="/stats" className={navLink}>Community stats</a></li>
               <li>
                 <a
                   href={KOFI_URL}


### PR DESCRIPTION
## Summary
- Adds a "Community stats" link to the footer's Project column (between Contribute and Support this project) so visitors can discover `/stats`.
- `/stats` itself is untouched: still `robots="noindex"`, still excluded from the sitemap. Only the entry point changes.

## Why this column
Project groups the site's other content/about pages (About, Blog, Contribute) plus the donate CTA. Community stats is a content page like those, so it slots in before the CTA rather than crowding Practice (exam-taking links) or Legal (policy docs).

## Test plan
- [x] `npm run check` (astro check + eslint + vitest) - 0 errors, 263 tests passed
- [x] `npm run build` - prebuild/postbuild guards all green, including `check:graph` (0 violations) and `check:citation`/`check:person-graph`
- [x] `npm run e2e` - 118 passed, 9 skipped, 0 failed
- [x] Playwright screenshot of the footer, light + dark, on an isolated preview port (4399) - link renders identically styled to neighbors
- [x] Click-through verified: footer link resolves to `/stats` (h1 "Community statistics")