### PR TITLE
fix(auth): stop token-refresh loop that 429'd /history and logged users out (#159)

### DIFF
--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { isRedundantTokenRefresh } from './useAuth'
+import type { User } from '@supabase/supabase-js'
+
+// The predicate only reads `id`; a minimal stub is enough. `userAAgain` is a
+// DIFFERENT object with the SAME id - exactly what supabase-js hands us on a
+// token refresh, and the reference churn that caused issue #159.
+const userA = { id: 'user-a' } as User
+const userAAgain = { id: 'user-a' } as User
+const userB = { id: 'user-b' } as User
+
+describe('isRedundantTokenRefresh (issue #159 auth-refresh loop guard)', () => {
+  it('is TRUE for a same-user TOKEN_REFRESHED, so useAuth keeps the reference stable', () => {
+    // This is the case that must NOT publish a new `user` object: doing so
+    // re-runs every consumer effect keyed on `user` and re-issues a query,
+    // which looped against the auth /token endpoint until a 429.
+    expect(isRedundantTokenRefresh('TOKEN_REFRESHED', userAAgain, userA)).toBe(true)
+  })
+
+  it('is FALSE for a TOKEN_REFRESHED that changes the user id (must publish)', () => {
+    expect(isRedundantTokenRefresh('TOKEN_REFRESHED', userB, userA)).toBe(false)
+  })
+
+  it('is FALSE for identity-changing events so they still publish normally', () => {
+    for (const event of ['SIGNED_IN', 'INITIAL_SESSION', 'USER_UPDATED', 'SIGNED_OUT']) {
+      expect(isRedundantTokenRefresh(event, userAAgain, userA)).toBe(false)
+    }
+  })
+
+  it('is FALSE before a user is established or when the session dropped', () => {
+    expect(isRedundantTokenRefresh('TOKEN_REFRESHED', userA, null)).toBe(false)
+    expect(isRedundantTokenRefresh('TOKEN_REFRESHED', null, userA)).toBe(false)
+    expect(isRedundantTokenRefresh('TOKEN_REFRESHED', null, null)).toBe(false)
+  })
+})

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -46,6 +46,39 @@ function setState(next: AuthState) {
   listeners.forEach(cb => cb())
 }
 
+/**
+ * True when an onAuthStateChange event is a bare token refresh for the SAME
+ * user that is already published - i.e. nothing a React consumer needs to see.
+ *
+ * A TOKEN_REFRESHED event rotates the JWT but does not change who is signed in;
+ * supabase-js holds the new access token internally. Publishing a fresh `user`
+ * object for it would change the object's identity on every refresh, re-running
+ * every consumer effect keyed on `user` (History, CertDashboard, Account,
+ * DomainProgressStrip, DomainPractice) and re-issuing an authenticated query.
+ * Combined with supabase-js refreshing again around that query, that spun an
+ * infinite refetch/refresh loop that hammered the auth /token endpoint until
+ * Supabase returned 429 and the session died - reported as "logged out after
+ * 50+ requests on /history" (issue #159). When this returns true the caller
+ * keeps the existing reference (no setState), so no consumer effect re-fires.
+ *
+ * Returns false for every identity-changing event (SIGNED_IN, USER_UPDATED,
+ * SIGNED_OUT, INITIAL_SESSION) and for a refresh that somehow changes the user
+ * id or arrives before any user is established, so those still publish normally.
+ * Exported for unit testing (see useAuth.test.ts).
+ */
+export function isRedundantTokenRefresh(
+  event: string,
+  newUser: User | null,
+  currentUser: User | null,
+): boolean {
+  return (
+    event === 'TOKEN_REFRESHED'
+    && newUser !== null
+    && currentUser !== null
+    && newUser.id === currentUser.id
+  )
+}
+
 // Best-effort sync check for a persisted Supabase session token.
 //
 // SYNC: same scan also lives at window.__ccHasSession (BaseLayout.astro
@@ -218,6 +251,15 @@ function init() {
       // is tracked again instead of staying silently suppressed.
       if (event === 'SIGNED_OUT') {
         try { sessionStorage.removeItem(SIGN_IN_TRACKED_KEY) } catch { /* private mode */ }
+      }
+
+      // Skip the state publish on a bare same-user token refresh so the `user`
+      // reference stays stable and no consumer effect re-fires (see
+      // isRedundantTokenRefresh for the full rationale / issue #159). prevUser
+      // still advances so downstream identity checks stay correct.
+      if (isRedundantTokenRefresh(event, newUser, state.user)) {
+        prevUser = newUser
+        return
       }
 
       prevUser = newUser


### PR DESCRIPTION
## The bug (issue #159, reported by @vancore295)
Signed-in users clicking into exam history got **logged out with a 429**. The network tab showed **50+ requests** before the failure: a tight alternating loop of `GET exam_attempts` / `POST /token?grant_type=refresh_token` against prod, until Supabase rate-limited the auth `/token` endpoint and the session died.

## Root cause
`useAuth` publishes a **new `user` object on every `onAuthStateChange` event, including `TOKEN_REFRESHED`**. Every user-scoped island keys its data-fetch effect on the `user` object:
- `_History.tsx`, `CertDashboardIsland.tsx`, `_Account.tsx`, `DomainProgressStrip.tsx`, `_DomainPractice.tsx`

So a token refresh -> new `user` reference -> effect re-runs -> authenticated query -> supabase-js refreshes again -> ... an infinite refetch/refresh loop that hammers the **shared** auth rate limit (can affect other users' logins too). Tests never caught it because they run with fresh tokens, so no refresh fires during the short test window, and nothing asserts a request budget.

## The fix (surgical, at the source)
On a **bare same-user `TOKEN_REFRESHED`**, keep the existing `user` reference stable instead of publishing a new object (`isRedundantTokenRefresh`). No consumer effect re-fires, so the loop cannot start - for all five islands and any future one. A refresh only rotates the JWT (held internally by supabase-js); no React consumer needs a new user object for it.

Identity-changing events (`SIGNED_IN` / `USER_UPDATED` / `SIGNED_OUT` / `INITIAL_SESSION`) still publish normally, so every existing auth-flow invariant (OAuth `?code=`, bfcache F8 downgrade, sign_in tab-dedupe, pending-attempt flush, email-unverified guard) is untouched.

## Verification
- New unit regression test `useAuth.test.ts` guards the predicate (same-user refresh -> stabilize; identity change / id change / null -> publish).
- `npm run check` green (267 tests incl. the 4 new, astro check + eslint clean).
- `npm run build` green (all guards incl. the #155 SEO head snapshot).
- Diff is 2 files: `src/hooks/useAuth.ts` + its test. No build artifacts.

## Deploy / rollout
- Merging + deploying (main = prod) ships the fixed bundle. Affected users just revisit /history (normal navigation pulls the new hashed JS).
- **No Supabase change needed** - not on prod (`gegbjeluttwwiccyukka`) or test (`lqnchqfltmognaoudoqc`). This is purely client-side. Any current 429 clears on Supabase's own rate-limit cooldown.

Addresses #159.