### PR TITLE
docs(analytics): document donate_click location values

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -90,7 +90,8 @@ export const KNOWN_EVENTS = [
   'share_result',            // results-screen share, pass-only (method: web_share | clipboard; params: cert, authed)
   'post_share_clicked',      // blog post share/copy-link row (method: web_share | clipboard)
   'report_question_clicked',
-  'donate_click',
+  'donate_click',            // Ko-fi link activated (params: location: footer | mobile_drawer |
+                              // floating | results - the four independent donate surfaces)
   'github_click',
   'affiliate_click',    // reserved for the deferred affiliate iteration
 ] as const


### PR DESCRIPTION
## Summary

Implementation-queue item F.8 step 1 ("measure first, tiny analytics rider"): add a `location` param to `donate_click` so we can tell which placement drives donations, before any placement change.

**Finding:** every `donate_click` call site already fires a `location` param today (added across earlier PRs, back to 2026-06-11 / 2026-06-28). There was nothing left to add in the call sites themselves. The one real gap: the `KNOWN_EVENTS` registry entry for `donate_click` in `src/lib/analytics.ts` never documented the param inline, unlike its neighbors (`unlock_cta_clicked`, `weakest_domain_cta_clicked`). This PR closes that gap with a comment-only change, matching the existing convention.

### Call sites found (grep for `donate_click` across `src/`) and their existing `location` values

| File | Placement | `location` value |
|---|---|---|
| `src/pages/_MockExam.tsx:988` | Results-screen donate card | `results` |
| `src/components/DonateButton.tsx:75` | Floating donate/Ko-fi pill | `floating` |
| `src/components/Footer.tsx:67` | Footer "Support this project" link | `footer` |
| `src/components/HeaderInteractive.tsx:329` | Mobile header drawer donate link | `mobile_drawer` |

(Four distinct placements, not three — the mobile drawer link was missed in the original scoping but was already instrumented.)

Note: `src/pages/about.astro:197` also links to Ko-fi but does not fire `donate_click` at all (no `onClick`/`trackEvent`). Out of scope per the task's hard boundary against adding/moving placements — flagging for a separate owner decision if that surface should be measured too.

### Diff

Comment-only change to the `donate_click` entry in `KNOWN_EVENTS`:
```
-  'donate_click',
+  'donate_click',            // Ko-fi link activated (params: location: footer | mobile_drawer |
+                              // floating | results - the four independent donate surfaces)
```

### e2e

`e2e/conversion-events.spec.ts` does not currently cover `donate_click` at all. Per the task instructions ("if an existing e2e spec covers donate_click, update it... do NOT add brand-new e2e infrastructure"), no e2e changes were made since there's nothing existing to update.

## Test plan

- [x] `npm run check` (astro check + eslint + vitest) - green, 0 errors/warnings, 273 tests passed
- [x] `npm run build` - green, all prebuild/postbuild guards passed (citation, internal-graph, person-graph, seo-head snapshot, csp:hash)
- [x] Pre-push hook (same `npm run check`) - green
- [ ] No e2e spec changes made (nothing existing covers `donate_click` to update)

No behavior change: this is a documentation-only diff to the analytics event registry.