### PR TITLE
fix(a11y): collapse blog TOC aside+nav into one top-level nav landmark

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -233,27 +233,32 @@ const updatedDisplay = data.updated
           <div class={`blog-content max-w-[68ch] mx-auto${showToc ? ' lg:mx-0 [&_:is(h2,h3)]:scroll-mt-24' : ''}`}>
             <slot />
           </div>
+          {/* A single <nav> landmark, not <aside>-wrapping-<nav>: the outer
+              <aside> duplicated the inner nav's role/label, and axe's
+              landmark-complementary-is-top-level flags a complementary
+              region nested inside <article> anyway. A table of contents is
+              navigation, so <nav> is the correct (and now top-level-safe)
+              role; merging the two elements avoids trading that flag for a
+              landmark-unique violation (two nested navs sharing one name). */}
           {showToc && (
-            <aside class="hidden lg:block" aria-label="Table of contents">
-              <nav class="sticky top-24" aria-label="Table of contents">
-                <p class="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted mb-3">
-                  On this page
-                </p>
-                <ul class="space-y-1 list-none p-0 m-0 border-l border-border-hairline">
-                  {toc.map((h) => (
-                    <li>
-                      <a
-                        href={`#${h.slug}`}
-                        data-toc-link
-                        class={`-ml-px block border-l border-transparent py-1 text-sm leading-snug text-text-muted transition-colors duration-200 hover:border-text-muted hover:text-text-primary focus-visible:outline-none focus-visible:border-text-muted focus-visible:text-text-primary [&[data-active=true]]:border-text-primary [&[data-active=true]]:text-text-primary [&[data-active=true]]:font-medium ${h.depth === 3 ? 'pl-6' : 'pl-3'}`}
-                      >
-                        {h.text}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </nav>
-            </aside>
+            <nav class="hidden lg:block sticky top-24" aria-label="Table of contents">
+              <p class="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted mb-3">
+                On this page
+              </p>
+              <ul class="space-y-1 list-none p-0 m-0 border-l border-border-hairline">
+                {toc.map((h) => (
+                  <li>
+                    <a
+                      href={`#${h.slug}`}
+                      data-toc-link
+                      class={`-ml-px block border-l border-transparent py-1 text-sm leading-snug text-text-muted transition-colors duration-200 hover:border-text-muted hover:text-text-primary focus-visible:outline-none focus-visible:border-text-muted focus-visible:text-text-primary [&[data-active=true]]:border-text-primary [&[data-active=true]]:text-text-primary [&[data-active=true]]:font-medium ${h.depth === 3 ? 'pl-6' : 'pl-3'}`}
+                    >
+                      {h.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

- Ledger L74: axe's `landmark-complementary-is-top-level` best-practice rule flags the wide-screen blog "On this page" TOC because it is an `<aside aria-label="Table of contents">` nested inside `<article>` in `src/layouts/BlogLayout.astro`.
- Same class of issue as the end-of-post CTA aside fixed in PR #151 (that one became a plain `<div>`).

## What I found (deviates slightly from the literal "rename aside to nav" instruction, with reasoning)

The actual markup was **not** a bare `<aside>` wrapping plain content - it was an `<aside aria-label="Table of contents">` wrapping an **inner** `<nav aria-label="Table of contents">` with the identical accessible name:

```astro
<aside class="hidden lg:block" aria-label="Table of contents">
  <nav class="sticky top-24" aria-label="Table of contents">
    ...
  </nav>
</aside>
```

A literal `aside` -> `nav` rename would have left **two nested `<nav>` landmarks sharing the same accessible name**, which trades the `landmark-complementary-is-top-level` flag for a `landmark-unique` violation instead (axe requires unique role+name combos across landmarks on a page). So instead I merged the two elements into a single `<nav>` that carries both elements' classes (`hidden lg:block` + `sticky top-24`):

```astro
<nav class="hidden lg:block sticky top-24" aria-label="Table of contents">
  ...
</nav>
```

This is a strict subset of the original DOM (one fewer wrapper element), same classes, same label, same content and links. Only `src/layouts/BlogLayout.astro` changed; no other `<aside>` usage in the codebase was touched (`DomainProgressStrip.tsx`, `GitHubPermalinkCallout.astro` are unrelated components, out of scope).

## Verification

1. **CSS-selector check** - grepped `src/index.css` (the only global stylesheet) and the whole codebase for `aside` used as a CSS element selector: none found. The TOC is styled purely with Tailwind utility classes (`hidden lg:block`, `sticky top-24`, etc.), so the tag change has no styling impact. The only other `<aside>` elements in the codebase (`DomainProgressStrip.tsx`, `GitHubPermalinkCallout.astro`) are unrelated components and were left untouched.
2. **Guards** - `npm run check` (astro check + lint + full vitest suite) and `npm run build` both green:
   - `astro check`: 0 errors, 0 warnings, 34 hints (pre-existing, unrelated)
   - `eslint`: clean
   - `vitest`: 22/22 test files, 273/273 tests passed
   - `npm run build` postbuild guards all passed: `check:citation`, `check:graph`, `check:person-graph`, `check:seo-head`, `csp:hash`, `cf:headers`
   - (Auto-generated build artifacts `functions/_csp.generated.js` and `public/sitemap.xml` were regenerated by the local build but reverted before committing since they're unrelated to this change and would just be noise/timestamp churn in the diff.)
3. **Screenshots** - built + previewed the real live post `/blog/aif-c01-vs-clf-c02` at 1280x1000 (lg+ breakpoint where the TOC rail renders) with Playwright, `reducedMotion: 'reduce'`, before and after the fix. Saved to `.kiro/ux/blog-toc-landmark-2026-07-03/before-wide.png` and `after-wide.png` (gitignored, local-only per repo convention - not part of this diff). The two PNGs are byte-identical (420,917 bytes each) - the TOC rail renders pixel-for-pixel the same.
4. **axe** - not run (no new npm dependency added, per hard constraint); relied on markup reasoning above (which specific rules would/wouldn't fire) plus the screenshots confirming zero visual regression.

## Test plan

- [x] `npm run check` green (astro check + lint + vitest, 273/273 tests)
- [x] `npm run build` green (all prebuild/postbuild guards passed)
- [x] Before/after screenshots at 1280px confirm pixel-identical rendering
- [x] Grepped for `aside` CSS-element selectors - none found
- [ ] Owner to eyeball the deployed preview once merged (not merging this PR myself)