### PR TITLE
ci: add CodeQL code-scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+# GitHub's default CodeQL code-scanning template, scoped to this repo's single
+# language (JavaScript/TypeScript covers the Astro + React source). Findings
+# appear in the Security tab and as informational PR checks - this workflow
+# does not gate merges.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, Sunday 03:00 UTC.
+    - cron: '0 3 * * 0'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/codeql.yml`, GitHub's standard CodeQL code-scanning
template scoped to this repo's single language, `javascript-typescript`
(covers the Astro + React + TS source). CodeQL is free for public repos and
scans for common JS/TS security vulnerabilities (injection, unsafe regex,
prototype pollution, etc.) on every push/PR to `main` plus a weekly schedule.

- Triggers: `push` to `main`, `pull_request` to `main`, weekly `schedule`
  (Sunday 03:00 UTC).
- Permissions: minimal - `contents: read`, `security-events: write`,
  `actions: read`.
- Steps: `actions/checkout` (same pinned version already used in
  `ci.yml`/`monitor-production.yml`/`indexnow.yml`), then
  `github/codeql-action/init` and `github/codeql-action/analyze` (both pinned
  to `v3.36.3` by commit SHA, matching this repo's convention of pinning
  third-party actions to a full SHA). No autobuild step - a JS/TS codebase
  needs no compile step for CodeQL to analyze it.
- No new npm dependencies; this is CI config only and does not touch
  `package.json`, app code, or any Supabase project.

Verification performed (CodeQL itself only runs inside GitHub Actions, so it
cannot be executed locally):

- Parsed the new YAML with `js-yaml` to confirm it is well-formed and
  structurally matches GitHub's documented default CodeQL template.
- Checked for em-dashes/en-dashes in the new file (none).
- Ran `npm run check` (astro check + eslint + vitest) and `npm run build`
  (full prebuild/postbuild guard chain: citation, internal-link graph,
  person-graph, SEO-head snapshot, CSP hash) - both green, confirming this
  change has no effect on the app itself.

## Owner follow-up

The workflow file alone is sufficient for CodeQL to start running on the next
push/PR to this branch or `main`. You may still want to confirm "Code
scanning" is enabled under **Settings > Code security** so results surface in
the Security tab as expected (for most public repos this is on by default
once a CodeQL workflow exists).

Results (if any) will show up in the **Security** tab and as a PR check
labeled for the `javascript-typescript` analysis - this is informational and
is not wired up as a required/blocking check.

## Test plan

- [x] `npm run check` green
- [x] `npm run build` green (all guards pass)
- [x] YAML parses cleanly via `js-yaml`
- [x] No new npm dependencies added
- [x] No em/en-dashes in the new file
- [ ] Owner: confirm Code scanning is enabled under Settings > Code security
      after merge (optional - workflow alone is enough to trigger a run)