### PR TITLE
docs: fix two stale build-pipeline descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,9 @@ opening PRs, see `CONTRIBUTING.md`; for a project overview, see `README.md`.
   `check:seo-head` (full `<head>` SEO surface - title/description/canonical/robots/og/twitter/
   per-page JSON-LD - snapshotted against `scripts/seo-head-baseline.json` for the 18 indexable
   pages; re-bless intentional changes with `node scripts/check-seo-head.mjs --update`),
-  `csp:hash` (rewrites `dist/_headers` to a hash-based CSP over every inline script/style).
+  `csp:hash` (rewrites `dist/_headers` to a hash-based CSP over every inline script/style),
+  `cf:headers` (propagates that CSP into `functions/_csp.generated.js` for the Cloudflare
+  Pages Function).
 
 A failing guard means your change moved locked output. Treat it as a real failure.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ src/
 
 scripts/          Build/prebuild + CI checks:
   validate-questions.mjs    Question-bank validator (`npm run validate`)
-  generate-seo-assets.mjs   Sitemap + question-counts.ts + llms.txt + _redirects
+  generate-seo-assets.mjs   Sitemap + question-counts.ts + llms.txt + _redirects + manifest.json
   generate-og-images.mjs    Per-cert / per-domain / blog OG composites
   generate-stats-snapshot.mjs   Build-time /stats snapshot
   validate-blog-frontmatter.mjs, validate-internal-links.mjs,


### PR DESCRIPTION
## What

A conservative documentation-accuracy pass (queue F.2) over the user-facing / legal / contributor docs (`privacy.astro`, `terms.astro`, `README.md`, `CONTRIBUTING.md`, `AGENTS.md`). Result: the docs are in good shape. The stated priority item (a privacy page describing an OLD email/mailto-only deletion flow) was **already fixed** on `main` when self-service deletion shipped, so nothing to change there. Only two small, verifiable factual staleness items remained, both in build-pipeline descriptions.

## Fixed

- **README.md:183** - the `generate-seo-assets.mjs` output list omitted `public/manifest.json`. The script writes it (verified `scripts/generate-seo-assets.mjs:1-2,31`), and `CONTRIBUTING.md:140` already lists it, so README was the inconsistent doc. Appended `+ manifest.json`.
- **AGENTS.md:56** - the postbuild guard chain enumeration stopped at `csp:hash` and omitted the final step `cf:headers` (`scripts/generate-cf-headers.mjs`, which writes `functions/_csp.generated.js` for the Cloudflare Pages Function). Matches `package.json` `postbuild`. Documenting it also explains why `functions/_csp.generated.js` shows up as build-regenerated.

Body/prose only. No SEO `<head>`, no policy, no legal terms touched.

## Flagged for the owner (NOT edited - policy / legal / owner call)

- **Privacy policy does not disclose GitHub OAuth data collection.** It documents Google OAuth data fields (`privacy.astro:74-79`) but has no equivalent section for GitHub, which is a shipped sign-in method (`_Login.tsx:221-231`). Adding a disclosure section is legal-drafting = owner decision.
- **Terms "no paid tiers ... ever"** (`terms.astro:52-54`) is a policy commitment with a noted future-pro-tier conflict. Pure policy, left untouched.
- **README architecture diagram (`README.md:132`)** lists only `get_public_exam_stats()`; the newer `get_public_totals()` RPC (used by /stats, documented in `supabase/README.md:139`) is not shown. Statement is not false, so left as-is.
- **README CI summary (`README.md:156`)** omits the e2e (Playwright) and Lighthouse CI jobs. Everything listed still runs; incomplete not false, so left as-is.

## Verified accurate, no change needed

Account deletion copy (privacy self-service already correct), analytics/Umami description, "Mock exam" vs "practice exam" naming (consistent with the shipped UI label), sign-in options, question counts, and terms' "Azure and GCP planned" (consistent with `certifications.ts:44,47`).

## Gate

- `npm run check` (astro check + eslint + 273 unit tests): green
- `npm run build` (prebuild + build + postbuild guards: citation / internal-graph / person-graph / seo-head / csp / cf:headers): green

Build-regenerated artifacts (sitemap, `_csp.generated.js`, og images, stats snapshot) were intentionally NOT committed; only the two doc files are in this diff.