### PR TITLE
test(analytics): cover trackEvent/trackPageView dual-send and KNOWN_EVENTS registry

### DIFF
--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { trackPageView, trackEvent, KNOWN_EVENTS } from './analytics'
+
+function stubWindow(impl: Record<string, unknown>): void {
+  Object.defineProperty(globalThis, 'window', {
+    value: impl,
+    writable: true,
+    configurable: true,
+  })
+}
+
+function removeWindow(): void {
+  // Restore undefined (node default - no window)
+  Object.defineProperty(globalThis, 'window', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  })
+}
+
+afterEach(removeWindow)
+
+describe('trackPageView', () => {
+  // Regression guard for B1 (fixed 2026-07): a bare-string window.umami.track(path)
+  // call used to record a junk custom EVENT named after the route path, because
+  // Umami already auto-tracks pageviews itself via its own pushState hook.
+  // trackPageView must only ever drive the GA4 gtag page_view event.
+  it('B1 regression: fires only gtag page_view and never touches window.umami', () => {
+    const gtag = vi.fn()
+    const umamiTrack = vi.fn()
+    stubWindow({ gtag, umami: { track: umamiTrack } })
+
+    trackPageView('/some/path')
+
+    expect(gtag).toHaveBeenCalledTimes(1)
+    expect(gtag).toHaveBeenCalledWith('event', 'page_view', { page_path: '/some/path' })
+    expect(umamiTrack).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when window.gtag is absent', () => {
+    stubWindow({})
+    expect(() => trackPageView('/no-gtag')).not.toThrow()
+  })
+})
+
+describe('trackEvent', () => {
+  it('dual-sends to both gtag and umami.track with matching name and params', () => {
+    const gtag = vi.fn()
+    const umamiTrack = vi.fn()
+    stubWindow({ gtag, umami: { track: umamiTrack } })
+
+    trackEvent('share_result', { method: 'web_share', cert: 'CLF-C02' })
+
+    expect(gtag).toHaveBeenCalledWith('event', 'share_result', { method: 'web_share', cert: 'CLF-C02' })
+    expect(umamiTrack).toHaveBeenCalledWith('share_result', { method: 'web_share', cert: 'CLF-C02' })
+  })
+
+  it('is a silent no-op when both providers are absent', () => {
+    stubWindow({})
+    expect(() => trackEvent('exam_completed', { guest: false })).not.toThrow()
+  })
+
+  it('is a silent no-op when only window.gtag is present (umami missing)', () => {
+    stubWindow({ gtag: vi.fn() })
+    expect(() => trackEvent('exam_completed', { guest: false })).not.toThrow()
+  })
+
+  it('is a silent no-op when only window.umami is present (gtag missing)', () => {
+    stubWindow({ umami: { track: vi.fn() } })
+    expect(() => trackEvent('exam_completed', { guest: false })).not.toThrow()
+  })
+})
+
+describe('KNOWN_EVENTS', () => {
+  it('is non-empty and has no duplicate event names', () => {
+    expect(KNOWN_EVENTS.length).toBeGreaterThan(0)
+    expect(new Set(KNOWN_EVENTS).size).toBe(KNOWN_EVENTS.length)
+  })
+
+  it('includes the load-bearing exam_completed and share_result events', () => {
+    expect(KNOWN_EVENTS).toContain('exam_completed')
+    expect(KNOWN_EVENTS).toContain('share_result')
+  })
+})


### PR DESCRIPTION
## Summary

Adds `src/lib/analytics.test.ts` with unit tests for `src/lib/analytics.ts`. No changes to `analytics.ts` itself.

## What is covered

1. **B1 regression guard (headline test)**: `trackPageView(path)` fires only `window.gtag('event', 'page_view', { page_path: path })` exactly once, and never calls `window.umami.track(...)`. This locks in the fix for bug B1 (2026-07): Umami auto-tracks pageviews itself via its own pushState hook, so a bare-string `umami.track(path)` call used to record a junk custom EVENT named after the route path.
2. `trackEvent(name, params)` dual-sends: calls both `window.gtag('event', name, params)` and `window.umami.track(name, params)` with matching args.
3. `trackEvent` is a silent no-op (does not throw) across all three missing-provider combinations: both absent, gtag-only, umami-only.
4. `KNOWN_EVENTS` registry integrity: non-empty, no duplicate entries, and contains the load-bearing `exam_completed` / `share_result` names (not a full re-listing).

Tests run in Vitest's `node` environment (matching the existing house style in `src/lib/storage.test.ts`), stubbing `globalThis.window` via `Object.defineProperty` and restoring it to `undefined` in `afterEach` so no global state leaks into other test files.

## Test plan

- [x] `npx vitest run src/lib/analytics.test.ts` - 8/8 passed
- [x] `npm run check` (astro check + eslint + full vitest) - green, 281/281 tests passed across 23 files
- [x] `npm run build` - green, all postbuild guards passed (check:citation, check:graph, check:person-graph, check:seo-head, csp:hash, cf:headers)

```
 RUN  v3.2.6
 ✓ src/lib/analytics.test.ts (8 tests) 6ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

```
astro check: 0 errors, 0 warnings, 34 hints
 Test Files  23 passed (23)
      Tests  281 passed (281)
```

Diff is surgical: only the new test file is added; no changes to `analytics.ts` or any other source file.