### PR TITLE
test(citation-content): cover the home page citation string builders

### DIFF
--- a/src/lib/citation-content.test.ts
+++ b/src/lib/citation-content.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildHomeFirstParagraph,
+  buildHomeMetaDescription,
+  LOCKED_CITATION_REGEXES,
+} from './citation-content'
+
+describe('buildHomeFirstParagraph', () => {
+  const text = buildHomeFirstParagraph(1000, 1234)
+
+  it('matches both locked citation count regexes', () => {
+    for (const regex of LOCKED_CITATION_REGEXES) {
+      expect(text).toMatch(regex)
+    }
+  })
+
+  it('contains the phrases the citation guard locks for this builder', () => {
+    expect(text).toContain('spaced repetition')
+    expect(text).toContain('MIT licensed')
+    expect(text).toContain('publicly auditable on GitHub')
+  })
+
+  it('formats counts with en-US thousands separators', () => {
+    expect(text).toContain('1,000+')
+    expect(text).toContain('1,234+')
+  })
+})
+
+describe('buildHomeMetaDescription', () => {
+  const text = buildHomeMetaDescription(1000, 1234)
+
+  it('contains the verbatim locked citation phrase', () => {
+    expect(text).toContain('Free open-source AWS certification practice exams')
+  })
+
+  it('formats counts with en-US thousands separators', () => {
+    expect(text).toContain('1,000+')
+    expect(text).toContain('1,234+')
+  })
+
+  it('stays within the SERP snippet length budget', () => {
+    expect(text.length).toBeLessThanOrEqual(160)
+    expect(text.length).toBeGreaterThan(80)
+  })
+})


### PR DESCRIPTION
## What

Adds `src/lib/citation-content.test.ts` with unit tests for the two pure string builders in `src/lib/citation-content.ts`: `buildHomeFirstParagraph` and `buildHomeMetaDescription`. No source file was touched.

## Why

The postbuild `Build_Time_Citation_Guard` (`scripts/check-citation-phrases.mjs`) asserts the locked phrases appear in the built `dist/index.html`, but that's slow, end-to-end feedback. The builder functions themselves had no unit test. These tests lock the exact composition each builder is responsible for, and give fast pre-build feedback if a future edit drifts from what the guard expects.

## Covered (asserting the right invariant per function, not a blanket check)

`buildHomeFirstParagraph(clfCount, aifCount)`:
- Matches both `LOCKED_CITATION_REGEXES` (imported from the module, not hardcoded).
- Contains the three locked phrases this builder actually produces: `spaced repetition`, `MIT licensed`, `publicly auditable on GitHub`.
- `buildHomeFirstParagraph(1000, 1234)` formats counts with en-US thousands separators (`1,000+`, `1,234+`) - guards against a future refactor swapping `toLocaleString('en-US')` for `String(n)`, which would silently break comma grouping.

`buildHomeMetaDescription(clfCount, aifCount)`:
- Contains the verbatim locked phrase `Free open-source AWS certification practice exams`.
- Same en-US thousands-separator formatting check.
- Output length stays within a SERP-safe budget: `<= 160` and `> 80` characters (code comment targets ~150).

Deliberately does *not* assert `LOCKED_CITATION_REGEXES` against the meta description (it omits the "AWS " prefix before "Cloud Practitioner", so the regexes don't match it), and does not assert the H1 phrase, `CloudCertPrep`, or `Alex Santonastaso` against the first paragraph, since those aren't produced by that builder.

## Gate results (all green)

`npx vitest run src/lib/citation-content.test.ts`:
```
 RUN  v3.2.6

 ✓ src/lib/citation-content.test.ts (6 tests) 3ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

`npm run check` (astro check + eslint + full vitest suite):
```
Result (138 files):
- 0 errors
- 0 warnings
- 34 hints

 Test Files  23 passed (23)
      Tests  279 passed (279)
```

`npm run build`: build succeeded, all postbuild guards passed (`check:citation`, `check:graph`, `check:person-graph`, `check:seo-head`, `csp:hash`, `cf:headers`). Regenerated `functions/_csp.generated.js` and `public/sitemap.xml` were reverted afterward so the pushed diff is exactly the one new test file.

## Test plan

- [x] `npx vitest run src/lib/citation-content.test.ts` green
- [x] `npm run check` green
- [x] `npm run build` green, guards unmoved
- [x] Diff contains only `src/lib/citation-content.test.ts`