### PR TITLE
test(locationChange): cover subscribeLocationChange push/replace/popstate, unsubscribe, and SSR guard

### DIFF
--- a/src/lib/locationChange.test.ts
+++ b/src/lib/locationChange.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
+import { subscribeLocationChange, LOCATION_CHANGE_EVENT } from './locationChange'
+
+/**
+ * These tests run in the `node` vitest environment (no jsdom), so there is no
+ * real `window`/`history`. We stub the minimum surface `locationChange.ts`
+ * touches:
+ *  - `globalThis.window` as a real `EventTarget` so `addEventListener` /
+ *    `removeEventListener` / `dispatchEvent` behave for real.
+ *  - `globalThis.history` as a plain object with `pushState`/`replaceState`
+ *    spies, matching the module's own `typeof history === 'undefined'` guard.
+ *
+ * The module patches `history` (installing its notifier) only ONCE per
+ * process, guarded by an internal `installed` flag - so the stubs are set up
+ * a single time for the whole suite and the module is imported once. Do not
+ * swap `globalThis.history` out mid-suite expecting a re-patch.
+ */
+
+let origPushSpy: ReturnType<typeof vi.fn>
+let origReplaceSpy: ReturnType<typeof vi.fn>
+let fakeWindow: EventTarget
+
+beforeAll(() => {
+  fakeWindow = new EventTarget()
+  origPushSpy = vi.fn()
+  origReplaceSpy = vi.fn()
+
+  Object.defineProperty(globalThis, 'window', {
+    value: fakeWindow,
+    writable: true,
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, 'history', {
+    value: { pushState: origPushSpy, replaceState: origReplaceSpy },
+    writable: true,
+    configurable: true,
+  })
+})
+
+afterAll(() => {
+  Object.defineProperty(globalThis, 'window', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, 'history', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  origPushSpy.mockClear()
+  origReplaceSpy.mockClear()
+})
+
+describe('subscribeLocationChange', () => {
+  it('fires cb when history.pushState is called (M3 fix: script-driven navigation bypasses popstate)', () => {
+    const cb = vi.fn()
+    const rawEvents: Event[] = []
+    const rawListener = (e: Event) => rawEvents.push(e)
+    window.addEventListener(LOCATION_CHANGE_EVENT, rawListener)
+
+    const unsubscribe = subscribeLocationChange(cb)
+    history.pushState({ a: 1 }, '', '/foo')
+
+    expect(cb).toHaveBeenCalledTimes(1)
+    // the notifier dispatches the named custom event, not just "something"
+    expect(rawEvents).toHaveLength(1)
+    expect(rawEvents[0]?.type).toBe(LOCATION_CHANGE_EVENT)
+
+    unsubscribe()
+    window.removeEventListener(LOCATION_CHANGE_EVENT, rawListener)
+  })
+
+  it('still invokes the ORIGINAL history.pushState with the original args (navigation is not swallowed)', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribeLocationChange(cb)
+
+    history.pushState({ a: 1 }, '', '/foo')
+
+    expect(origPushSpy).toHaveBeenCalledTimes(1)
+    expect(origPushSpy).toHaveBeenCalledWith({ a: 1 }, '', '/foo')
+
+    unsubscribe()
+  })
+
+  it('fires cb when history.replaceState is called', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribeLocationChange(cb)
+
+    history.replaceState({ b: 2 }, '', '/bar')
+
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+  })
+
+  it('still invokes the ORIGINAL history.replaceState with the original args', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribeLocationChange(cb)
+
+    history.replaceState({ b: 2 }, '', '/bar')
+
+    expect(origReplaceSpy).toHaveBeenCalledTimes(1)
+    expect(origReplaceSpy).toHaveBeenCalledWith({ b: 2 }, '', '/bar')
+
+    unsubscribe()
+  })
+
+  it('fires cb on a popstate event (browser back/forward)', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribeLocationChange(cb)
+
+    window.dispatchEvent(new Event('popstate'))
+
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+  })
+
+  it('returns an unsubscribe fn; after calling it, pushState and popstate no longer fire cb', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribeLocationChange(cb)
+
+    unsubscribe()
+
+    history.pushState({}, '', '/baz')
+    window.dispatchEvent(new Event('popstate'))
+
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('fires cb exactly once per pushState call (patch is not double-applied)', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribeLocationChange(cb)
+
+    history.pushState({}, '', '/once')
+
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+  })
+
+  it('re-subscribing a fresh cb after unsubscribe still fires exactly once (no accumulated double-patch)', () => {
+    const cbA = vi.fn()
+    const unsubA = subscribeLocationChange(cbA)
+    unsubA()
+
+    const cbB = vi.fn()
+    const unsubB = subscribeLocationChange(cbB)
+
+    history.pushState({}, '', '/fresh')
+
+    expect(cbB).toHaveBeenCalledTimes(1)
+    expect(cbA).not.toHaveBeenCalled()
+
+    unsubB()
+  })
+
+  it('is SSR-safe: returns a no-op unsubscribe and never registers cb when window is undefined', () => {
+    const previousWindow = globalThis.window
+
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    })
+
+    const cb = vi.fn()
+    let unsubscribe: () => void = () => {
+      throw new Error('should have been reassigned')
+    }
+
+    expect(() => {
+      unsubscribe = subscribeLocationChange(cb)
+    }).not.toThrow()
+    expect(() => unsubscribe()).not.toThrow()
+
+    // restore the real window and confirm cb was never wired up against it
+    Object.defineProperty(globalThis, 'window', {
+      value: previousWindow,
+      writable: true,
+      configurable: true,
+    })
+
+    history.pushState({}, '', '/after-ssr-check')
+    expect(cb).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What this covers

Adds `src/lib/locationChange.test.ts` with 9 unit tests for `src/lib/locationChange.ts`. No changes to the module itself - test-only diff.

`subscribeLocationChange(cb)` lets static-surface islands (the Header cert pill, the `useCert` resolver) react to react-router `navigate()` calls. react-router drives navigation via `history.pushState`/`replaceState`, which do NOT fire a `popstate` event, so those islands used to render a STALE path (bug M3 - e.g. the cert pill staying visible after `navigate('/login')`). The module fixes this by monkey-patching `pushState`/`replaceState` to also dispatch a `cc:locationchange` custom event, and subscribing callbacks to both that event and `popstate`.

Behaviors asserted:
1. `cb` fires when `history.pushState(...)` is called (the M3 fix itself), and the dispatched event is the named `cc:locationchange` event.
2. The original `history.pushState` is still invoked, with the original args (the notifier does not swallow the navigation).
3. `cb` fires when `history.replaceState(...)` is called.
4. The original `history.replaceState` is still invoked, with the original args.
5. `cb` fires on a `popstate` event (browser back/forward).
6. The returned unsubscribe fn stops further `pushState`- and `popstate`-driven notifications.
7. A single `pushState` call fires `cb` exactly once (guards against a double-applied monkey-patch).
8. Unsubscribing then subscribing a fresh `cb` and firing one `pushState` still fires exactly once (no accumulated double-patch from the `installed`-once guard).
9. SSR safety: when `window` is undefined, `subscribeLocationChange` returns a no-op unsubscribe, never registers `cb`, and never throws.

## Environment stubbing

Tests run in this repo's `node` vitest environment (no jsdom). `globalThis.window` is stubbed once (in `beforeAll`) as a real `EventTarget` so `addEventListener`/`dispatchEvent` behave for real, and `globalThis.history` is stubbed once as `{ pushState: vi.fn(), replaceState: vi.fn() }`. This matches the module's own one-time `installed` guard: the history patch is applied on first `subscribeLocationChange` call and never re-applied, so the fake globals are set up once for the whole suite rather than swapped per test.

A fresh worktree has no `.env`/`.env.local` (gitignored), which made two unrelated pre-existing suites (`useAuth.test.ts`, `authCleanup.test.ts`) fail with "Missing Supabase environment variables." Added a local gitignored `.env` with placeholder-shaped values only (no real or service-role creds) to unblock those, per this repo's `.env.example` shape. Not part of the pushed diff.

## Gate results

`npx vitest run src/lib/locationChange.test.ts`:
```
✓ src/lib/locationChange.test.ts (9 tests) 7ms
Test Files  1 passed (1)
     Tests  9 passed (9)
```

`npm run check` (astro check + eslint + full vitest suite) - green:
```
Result (138 files):
- 0 errors
- 0 warnings
- 34 hints

Test Files  23 passed (23)
     Tests  282 passed (282)
```

`npm run build` - green, all guards passed (question-bank validate, citation, internal-graph, person-graph, seo-head snapshot, csp:hash, cf:headers). Build-regenerated files (`functions/_csp.generated.js`, `public/sitemap.xml`) were reverted before committing so the pushed diff is exactly the one new test file.

## Test plan

- [x] `npx vitest run src/lib/locationChange.test.ts` green
- [x] `npm run check` green
- [x] `npm run build` green, no locked-SEO guard regressions