### PR TITLE
docs(readme): document get_public_totals RPC and e2e/Lighthouse CI jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ surface to static HTML at build time, and the interactive flows hydrate as
 |    platform_stats       aggregate counters                  |
 |    question_mastery     view, SECURITY INVOKER, RLS         |
 |                                                             |
-|  RPC: get_public_exam_stats() returns aggregates only       |
+|  RPCs (aggregates only, no user rows):                      |
+|    get_public_exam_stats()   get_public_totals()            |
 |                                                             |
 |  Security: RLS on every user-data table                     |
 |            policy: auth.uid() = user_id                     |
@@ -153,7 +154,7 @@ surface to static HTML at build time, and the interactive flows hydrate as
 | Hosting | Cloudflare Pages (auto-deploy from `main`) |
 | Email | Brevo SMTP via Supabase Auth |
 | Analytics | Umami (cookieless, always on) |
-| CI | GitHub Actions: validate, lint, astro check, test, build, citation guard |
+| CI | GitHub Actions: validate, lint, astro check, test, build, citation guard, Playwright e2e, Lighthouse |
 
 The marketing surface is prerendered static HTML, so crawlers and LLM browse-mode read full content with no JavaScript. Interactive islands are code-split and hydrate on demand. See `npm run build` output for exact sizes against your local build.
 


### PR DESCRIPTION
## Summary

Two demonstrably stale README lines, corrected against source:

1. **Architecture diagram - Supabase RPC list.** The diagram listed only `get_public_exam_stats()`, but the app also calls `get_public_totals()` (see `src/pages/_Stats.tsx` line 72: `supabase.rpc('get_public_totals')`, returning `total_users` and `total_questions_answered` as platform-wide aggregates across all certs). The diagram now lists both RPCs under a shared "aggregates only, no user rows" heading.

2. **Tech-stack table - CI row.** The row previously listed `validate, lint, astro check, test, build, citation guard`, omitting two jobs that actually run in `.github/workflows/ci.yml`: the `e2e` job ("Playwright e2e (logged-out + seeded)") and the `lighthouse` job ("Lighthouse CI"), alongside the existing `build` job ("Build and validate"). The row now lists both.

## Verification

Diff is surgical: only `README.md` changed (confirmed via `git diff --stat` and `git status --porcelain` before commit).

Architecture-diagram box alignment check (every box line must stay 63 chars so the trailing `|` column lines up):

```
$ awk 'NR>=97 && NR<=137 {printf "%d len=%d\n", NR, length($0)}' README.md
```
All 41 lines (borders and content rows) report `len=63`. The two new RPC lines were length-verified before editing:
- `|  RPCs (aggregates only, no user rows):                      |` -> 63 chars
- `|    get_public_exam_stats()   get_public_totals()            |` -> 63 chars

## Gate

- `npm run build` - green. All guards passed (prebuild validate/seo-assets, postbuild citation/graph/person-graph/seo-head/csp/cf-headers). The build-regenerated `functions/_csp.generated.js` and `public/sitemap.xml` were reverted before committing so the pushed diff is README-only.
- `npm run check` (astro check + eslint + vitest) - green, 0 errors, 273/273 tests passed, including the pre-push hook's own run.

No new npm dependencies. No em-dashes or en-dashes in the README lines, commit message, or this PR body.

## Test plan

- [x] `npm run build` green
- [x] `npm run check` green (also re-ran automatically via pre-push hook)
- [x] Box alignment check: all diagram lines report `len=63`
- [x] `git status --porcelain` shows only `README.md` changed before commit