### PR TITLE
a11y(Modal): derive a unique title id with useId to avoid duplicate ids

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { X } from 'lucide-react'
 import { useFocusTrap } from '../hooks/useFocusTrap'
 
@@ -15,6 +15,7 @@ const EXIT_MS = 180
 
 export function Modal({ isOpen, title, children, onClose }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
+  const titleId = useId()
   // Keep the modal mounted through its exit animation: a hard cut on close reads
   // abrupt. `render` stays true until the exit completes. Opening is a derived
   // state-during-render adjustment (React's "adjust state when a prop changes"
@@ -56,13 +57,13 @@ export function Modal({ isOpen, title, children, onClose }: ModalProps) {
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby="modal-title"
+        aria-labelledby={titleId}
         tabIndex={-1}
         className={`relative bg-bg-card rounded-2xl border border-border-hairline shadow-overlay max-w-2xl w-full max-h-[90vh] overflow-y-auto ${closing ? 'animate-scale-out pointer-events-none' : 'animate-scale-in'}`}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-border-hairline">
-          <h2 id="modal-title" className="text-xl md:text-2xl font-semibold tracking-[-0.01em] text-text-primary">{title}</h2>
+          <h2 id={titleId} className="text-xl md:text-2xl font-semibold tracking-[-0.01em] text-text-primary">{title}</h2>
           <button
             onClick={onClose}
             aria-label="Close dialog"


### PR DESCRIPTION
## Summary

Fixes #76.

`Modal.tsx` hardcoded `aria-labelledby="modal-title"` and `id="modal-title"` as static literals, a latent duplicate-id bug (WCAG 4.1.1 / 1.3.1) since `_MockExam.tsx` mounts up to four Modal instances in one tree.

## Changes

- Generate the title id with React `useId()` and wire both `aria-labelledby` on the dialog and `id` on the `<h2>` heading to it.
- No visual or behavioral change.

## Verification

- `npm run lint` passes.
- `npm run test` passes (273 tests, 22 files).
- Pre-push `npm run check` (astro check + lint + test) passes.
- No other references to the old `modal-title` id remain in the repo.