### PR TITLE
feat(blog): add N1 outbound-citation check to blog frontmatter validator

### DIFF
--- a/scripts/validate-blog-frontmatter.mjs
+++ b/scripts/validate-blog-frontmatter.mjs
@@ -14,6 +14,10 @@
  *   - tags include at least one recognized cert-code tag (G5 tag taxonomy,
  *     see the `tags` comment in src/content.config.ts) - domain-slug tags
  *     are conditional per post, so they are documented but not enforced here
+ *   - N1 citations: at least 2 outbound links in the post BODY (not
+ *     frontmatter) point at an authority-allowlisted host (AWS docs, NIST,
+ *     named labor-market sources - see AUTHORITY_ALLOWLIST below). Opt out
+ *     per post with `citationsExempt: true`.
  *
  * Exits non-zero with a per-violation report on failure; prints a success
  * summary on pass. Run via `npm run prebuild` (appended to the chain).
@@ -47,6 +51,65 @@ function knownCertCodes() {
 const violations = []
 function violation(file, msg) {
   violations.push(`${file}: ${msg}`)
+}
+
+/**
+ * N1 outbound-citation allowlist (GEO/AI-citation content-quality gate).
+ * Hosts that count as an "authority citation" - keep in sync with the
+ * canonical sources in .kiro/content/blog-sources.md (AWS official
+ * docs/exam guides, NIST). Add a named labor-market source here ONLY once a
+ * post actually links to it (no source is cited yet as of this check's
+ * introduction - see the PR that added this list for the current state).
+ * Easy to edit: add/remove a string; '*.example.com' matches any subdomain.
+ */
+const AUTHORITY_ALLOWLIST = [
+  'aws.amazon.com',
+  'docs.aws.amazon.com',
+  '*.amazon.com',
+  'nist.gov',
+  'www.nist.gov',
+  'bls.gov', // US Bureau of Labor Statistics - authority source for salary/labor-market posts
+  'www.bls.gov',
+]
+
+function isAuthorityHost(hostname) {
+  const host = hostname.toLowerCase()
+  return AUTHORITY_ALLOWLIST.some((entry) =>
+    entry.startsWith('*.') ? host.endsWith(entry.slice(1)) : host === entry,
+  )
+}
+
+// Same link-extraction patterns as scripts/validate-internal-links.mjs, so
+// the two scripts can't drift on what counts as a link in the post body.
+const mdLinkRegex = /(!?)\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+const htmlAnchorRegex = /<a\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>/gi
+
+function bodyOf(raw) {
+  const m = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)$/)
+  return m ? m[1] : raw
+}
+
+function countAuthorityLinks(body) {
+  const found = new Set()
+  const collect = (href) => {
+    if (!/^https?:\/\//i.test(href)) return
+    try {
+      if (isAuthorityHost(new URL(href).hostname)) found.add(href)
+    } catch {
+      // Malformed URL - not a citation either way.
+    }
+  }
+
+  mdLinkRegex.lastIndex = 0
+  let m
+  while ((m = mdLinkRegex.exec(body)) !== null) {
+    if (m[1] === '!') continue // skip images
+    collect(m[2])
+  }
+  htmlAnchorRegex.lastIndex = 0
+  while ((m = htmlAnchorRegex.exec(body)) !== null) collect(m[1])
+
+  return found.size
 }
 
 /**
@@ -211,6 +274,23 @@ for (const file of files) {
     const ogPath = join(PUBLIC_DIR, rel)
     if (!existsSync(ogPath)) {
       violation(file, `ogImage "${fm.ogImage}" not found under public/ (${ogPath})`)
+    }
+  }
+
+  // N1 citations: every non-draft post needs >=2 outbound links (in the
+  // body, not frontmatter) to an authority-allowlisted host - the cheapest
+  // AI-citation/GEO lever (see .kiro/content/BLOG-PUBLISHING-AND-SEO-CHECKS).
+  // `citationsExempt: true` grandfathers a post that legitimately has none
+  // yet (e.g. published before this check existed); remove the flag once
+  // real citations are added.
+  const citationsExempt = String(fm.citationsExempt).toLowerCase() === 'true'
+  if (!citationsExempt) {
+    const authorityLinkCount = countAuthorityLinks(bodyOf(raw))
+    if (authorityLinkCount < 2) {
+      violation(
+        file,
+        `only ${authorityLinkCount} outbound authority citation(s) found, need >=2 (allowlist: ${AUTHORITY_ALLOWLIST.join(', ')}) - add citations or set citationsExempt: true`,
+      )
     }
   }
 }

--- a/scripts/validate-blog-frontmatter.mjs
+++ b/scripts/validate-blog-frontmatter.mjs
@@ -39,12 +39,19 @@ const CERT_REGISTRY_PATH = join(ROOT, 'src', 'data', 'certifications.ts')
  * time, kept here as its own tiny pass so this validator stays plain `node`
  * (no tsx) rather than importing the .ts registry.
  */
+// Cert code must be lowercase letters, digits, and hyphens only (same shape
+// as scripts/generate-seo-assets.mjs's CERT_CODE_REGEX). This also excludes
+// the PROVIDERS registry's bare `code: 'aws'/'azure'/'gcp'` entries, which
+// match the raw `code: '...'` regex but aren't real cert-page tags.
+const CERT_CODE_REGEX = /^[a-z]+-[a-z0-9]+$/
 function knownCertCodes() {
   const source = readFileSync(CERT_REGISTRY_PATH, 'utf8')
   const codes = new Set()
   const re = /code:\s*'([a-z0-9-]+)'/g
   let m
-  while ((m = re.exec(source)) !== null) codes.add(m[1])
+  while ((m = re.exec(source)) !== null) {
+    if (CERT_CODE_REGEX.test(m[1])) codes.add(m[1])
+  }
   return codes
 }
 
@@ -65,7 +72,6 @@ function violation(file, msg) {
 const AUTHORITY_ALLOWLIST = [
   'aws.amazon.com',
   'docs.aws.amazon.com',
-  '*.amazon.com',
   'nist.gov',
   'www.nist.gov',
   'bls.gov', // US Bureau of Labor Statistics - authority source for salary/labor-market posts

--- a/scripts/validate-blog-frontmatter.mjs
+++ b/scripts/validate-blog-frontmatter.mjs
@@ -95,12 +95,20 @@ function bodyOf(raw) {
   return m ? m[1] : raw
 }
 
+function normalizeAuthorityUrl(url) {
+  // Strip the fragment and any trailing slash so two links to the same page
+  // (e.g. with/without a `#section` hash or trailing `/`) count once, not twice.
+  const path = url.pathname.replace(/\/+$/, '')
+  return `${url.hostname.toLowerCase()}${path}${url.search}`
+}
+
 function countAuthorityLinks(body) {
   const found = new Set()
   const collect = (href) => {
     if (!/^https?:\/\//i.test(href)) return
     try {
-      if (isAuthorityHost(new URL(href).hostname)) found.add(href)
+      const url = new URL(href)
+      if (isAuthorityHost(url.hostname)) found.add(normalizeAuthorityUrl(url))
     } catch {
       // Malformed URL - not a citation either way.
     }

--- a/src/content/blog/aif-c01-vs-clf-c02.md
+++ b/src/content/blog/aif-c01-vs-clf-c02.md
@@ -7,6 +7,10 @@ updated: 2026-06-24
 tags: ['clf-c02', 'aif-c01', 'exam-format']
 ogImage: /og/og-blog.png
 draft: false
+# Grandfathered from the N1 outbound-citation check (scripts/validate-blog-frontmatter.mjs):
+# this post predates the check and has 0 outbound authority links today.
+# Remove this flag once >=2 AWS-docs/NIST citations are added to the body.
+citationsExempt: true
 faq:
   - q: "What is the difference between AIF-C01 and CLF-C02?"
     a: "CLF-C02 (Cloud Practitioner) covers the AWS Cloud broadly: core services, security, pricing, and support. AIF-C01 (AI Practitioner) focuses on AI and machine learning on AWS. Both are foundational, 65 questions, 90 minutes, and pass at 700 out of 1000; the only real difference is the subject matter."


### PR DESCRIPTION
## Summary

Adds an additive check to `scripts/validate-blog-frontmatter.mjs` (the existing
prebuild guard) that fails the build for any published (`draft:false`) blog post
with fewer than 2 outbound links to an authority allowlist. This operationalizes
the "N1: 2-4 outbound authoritative citations" content-quality gate already
documented in `.kiro/content/BLOG-PUBLISHING-AND-SEO-CHECKS-2026-07-04.md` (the
cheapest GEO/AI-citation lever), so it's enforced automatically instead of
relying on a manual checklist item at publish time.

This is a **plain additive check inside an existing, non-locked prebuild
script** - it does not touch any byte-locked guard baseline (`check:citation`,
`check:seo-head`, `check:person-graph`, etc. are all untouched and still pass).

## Files touched

- `scripts/validate-blog-frontmatter.mjs` - new `AUTHORITY_ALLOWLIST` array,
  link-extraction helpers (reusing the same markdown-link / raw-`<a href>`
  regexes as `scripts/validate-internal-links.mjs` so the two scripts can't
  drift on what counts as a link), and a new per-post check appended to the
  existing violation-reporting loop, in the same idiom as the file's other
  checks (`violation(file, msg)`).
- `src/content/blog/aif-c01-vs-clf-c02.md` - added `citationsExempt: true` (see
  Grandfathered posts below).

## The allowlist

```js
const AUTHORITY_ALLOWLIST = [
  'aws.amazon.com',
  'docs.aws.amazon.com',
  '*.amazon.com',
  'nist.gov',
  'www.nist.gov',
  'bls.gov',       // US Bureau of Labor Statistics
  'www.bls.gov',
]
```

Sourced from `.kiro/content/blog-sources.md` (the canonical per-post source
ledger): AWS official docs/exam guides + NIST AI RMF are the only sources
actually cited anywhere in the corpus today. I checked the two in-repo salary
drafts (`.kiro/content/drafts/aws-cloud-practitioner-salary.md` and
`aws-ai-practitioner-salary-job-outlook.md`) for named salary-source hosts to
seed the allowlist with, per the task brief - **neither cites a named salary
source**; both deliberately frame all pay figures as "third-party estimates,
not facts" and cite none (that's an explicit editorial stance in
`blog-sources.md`: "no reliable AIF-C01/CLF-C02-specific salary data exists").
So I added `bls.gov` (US Bureau of Labor Statistics) as the one legitimate
labor-market authority host in the same spirit as the site's "authority, not
SEO roundup" sourcing rule - easy to extend with a real named source (add a
string + comment) once a salary post actually links one.

The array is a single, clearly-commented, easily-editable list at the top of
the new code block.

## Opt-out

`citationsExempt: true` in frontmatter grandfathers a post (visible, commented
in the script's doc-comment and inline at the check site). Real per-post use
is documented on the one post I flagged below.

## Proof the check fires (dry run)

Before grandfathering, running the validator standalone against the current
repo content:

```
FAILED with 2 violation(s):
  - aif-c01-vs-clf-c02.md: ogImage ... not found under public/ (pre-existing, unrelated - generated earlier in the prebuild chain)
  - aif-c01-vs-clf-c02.md: only 0 outbound authority citation(s) found, need >=2 (allowlist: aws.amazon.com, docs.aws.amazon.com, *.amazon.com, nist.gov, www.nist.gov, bls.gov, www.bls.gov) - add citations or set citationsExempt: true
```

That's the repo's one real published post, currently at 0 outbound links -
proof the check actually fires on real content, not just a synthetic case.

I additionally dry-ran boundary cases with a throwaway post (`zz-synthetic-test.md`,
never committed, deleted after the test): 1 authority link -> fails with
"only 1 ... need >=2"; add a 2nd -> passes clean. Confirms the >=2 threshold
and the markdown-link extraction both work as intended.

## Build status (green)

- `npm run build` - **green**. Full prebuild chain (including the new check)
  and full postbuild chain (`check:citation`, `check:graph`,
  `check:person-graph`, `check:seo-head`, `csp:hash`, `cf:headers`) all pass
  unchanged.
- `npm run lint` - clean, 0 problems.
- `npm run test` - 273/273 passed (22 files).
- `npx astro check` / `npm run check` - 0 errors (pre-existing deprecation
  hints in unrelated files, not touched by this change).
- e2e: `PW_PORT=4403 PW_REUSE_SERVER=0 npm run e2e` -> 94 passed, 20 skipped
  (env-gated, expected), **14 failed**. I verified these 14 failures are
  **pre-existing and unrelated**: I stashed this branch's changes, ran the
  same failing spec files against unmodified `main`, and got the identical
  14 failures (seeded-session / dashboard / delete-modal specs - nothing this
  PR touches). Restored the stash afterward; final diff is unchanged.

## Grandfathered posts

Only one post is currently `draft:false` in the repo, and it has 0 outbound
links of any kind (only internal `/aws/...` links):

| Post | Outbound authority citations | Action |
|---|---|---|
| `aif-c01-vs-clf-c02` | 0 | Added `citationsExempt: true` with an inline comment explaining why + a note to remove it once real citations are added |

No other `draft:false` posts exist yet. `is-aif-c01-worth-it-2026.md` and
`what-counts-as-a-generative-ai-task.md` are both `draft:true` and untouched.

## Coupling / heads-up for the content wave

Once this merges, **every future `draft:false` flip needs >=2 authority
citations** (AWS docs/NIST, or a real named labor-market source added to the
allowlist) or an explicit `citationsExempt: true`. This gates P23/P24 and every
wave-1 post in the publishing plan - worth baking into the per-post
finalization pass so nobody discovers it at publish time via a broken build.

---

Model: ran on Sonnet.