### PR TITLE
feat(blog): add author bio box + rel=author to blog post byline

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -182,7 +182,7 @@ const updatedDisplay = data.updated
           <h1 class="font-display mt-3 text-[1.75rem] leading-[1.12] md:text-[2.5rem] font-bold tracking-[-0.025em] text-[#F4F6F8]">{data.title}</h1>
 
           <p class="mt-4 text-sm text-[#9AA6B2]">
-            By <a href="https://santonastaso.me" class="text-[#C9D2DC] underline underline-offset-2 hover:text-white transition-colors">Alex Santonastaso</a>
+            By <a href="https://santonastaso.me" rel="author" class="text-[#C9D2DC] underline underline-offset-2 hover:text-white transition-colors">Alex Santonastaso</a>
             {readingMinutes && <span>{' · '}{readingMinutes} min read</span>}
           </p>
 
@@ -260,6 +260,19 @@ const updatedDisplay = data.updated
               </ul>
             </nav>
           )}
+        </div>
+
+        {/* Author bio (N6): a small, factual "about the author" box at the end
+            of every post's body, distinct from the <head> article:author meta
+            and the Person JSON-LD node above (both untouched) - this is the
+            reader-facing E-E-A-T surface, not a crawler-facing one. */}
+        <div class={`mt-10 max-w-[68ch] mx-auto${showToc ? ' lg:mx-0' : ''}`}>
+          <div class="rounded-xl border border-border-hairline bg-bg-card/70 p-5 md:p-6">
+            <p class="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">About the author</p>
+            <p class="text-sm text-text-muted leading-relaxed">
+              <a href="https://santonastaso.me" class="font-semibold text-text-primary hover:underline underline-offset-2">Alex Santonastaso</a> is a software engineer who built CloudCertPrep to prepare for the AWS Certified Cloud Practitioner exam, then passed it. He maintains the platform and its open-source question banks, which are validated by an automated checker and publicly auditable on GitHub.
+            </p>
+          </div>
         </div>
 
         {/* Quiet share/copy-link row (GROW M3 rider): sits between the post


### PR DESCRIPTION
## Summary

- Adds a small, factual "About the author" bio box to the footer region of every blog post body (an E-E-A-T surface for readers, distinct from the crawler-facing signals already in place: the `article:author` meta and the Person JSON-LD node).
- Adds `rel="author"` to the existing visible byline link ("By Alex Santonastaso").
- Body-only change: nothing in `<head>` (title, meta, canonical, JSON-LD) was touched, so the byte-locked SEO guards do not need re-blessing.

Copy is factual and matches wording already asserted on `/about` and in `src/lib/base-graph.ts` (the Person JSON-LD source of truth): "a software engineer who built CloudCertPrep to prepare for the AWS Certified Cloud Practitioner exam, then passed it," plus a second sentence on maintaining the open-source, publicly-auditable question banks. No new external URLs are introduced; the bio links to the same `https://santonastaso.me` already used elsewhere.

## Files changed

- `src/layouts/BlogLayout.astro` - added the bio box (mirrors the existing card idiom: `rounded-xl border border-border-hairline bg-bg-card/70`) and `rel="author"` on the byline link.

## Verification

- `npm run build` - green, including the two locked-SEO guards this change is designed not to trip:
  - `check:person-graph` - PASSED, byte-identical to snapshot across all 29 prerendered pages.
  - `check:seo-head` - PASSED, byte-identical to baseline across all 18 indexable pages (no `--update` needed).
  - `check:citation`, `check:graph`, `csp:hash`, `cf:headers` - all green.
- `npm run lint` - clean.
- `npm run test` - 273/273 passed (22 test files).
- `astro check` - 0 errors, 0 warnings (pre-existing hints only, unrelated to this change).
- `PW_PORT=4402 PW_REUSE_SERVER=0 npm run e2e` - 94 passed, 20 skipped, 14 failed. All 14 failures are in specs that depend on `e2e/seededSession.ts` / a service-role-backed test project (`crash-safety`, `delete-modal-exit-signals`, `mock-exam-hardening`, `pending-attempt-owner-binding`, `ux-audit-seeded`, `weakest-domain-next-action`), which is unavailable in this worktree. Confirmed pre-existing/environment-gated by running the same specs against `main` (pre-change): the identical failures reproduce there too. No blog-layout-related failures.
- Lighthouse (via the `lighthouse` CLI already in `node_modules`, run headless against the built blog post page `/blog/aif-c01-vs-clf-c02` on `astro preview`): **performance 100, accessibility 100, best-practices 100, seo 100.**

## Screenshots

Captured with Playwright (`reducedMotion: 'reduce'`), logged-out, on the one published post (`/blog/aif-c01-vs-clf-c02`), saved under `.pr-shots/` (not committed):

- `blog-post-{light,dark}-{mobile,wide}-full.png` - full-page shots showing the bio box's placement in context: after the post body/FAQ, before the share row and the end-of-post CTA card.
- `author-bio-{light,dark}-{mobile,wide}.png` - close-up crops of just the new box.

Logged-in shots were not captured - no seeded session is available in this worktree (same gating as the e2e failures above).

## Notes

- PR-1 (entity bundle, per the maintainer's plan) also touches `BlogLayout.astro` / head-adjacent regions. This PR is strictly body-only and should rebase cleanly on top of it.
- No new npm dependencies. No em-dashes/en-dashes. System fonts only (no new font usage).

Model: ran on Sonnet.