### PR TITLE
feat(seo): fix RSS canonical links, allow 2026 AI crawlers, add RSL license

### DIFF
--- a/public/license.xml
+++ b/public/license.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsl xmlns="https://rslstandard.org/rsl">
+  <content url="https://www.cloudcertprep.io/">
+    <license>
+      <permits type="usage">all</permits>
+      <payment type="free">
+        <standard>https://github.com/nastaso/cloudcertprep/blob/main/LICENSE</standard>
+      </payment>
+      <legal type="contact">https://www.cloudcertprep.io/about</legal>
+    </license>
+  </content>
+</rsl>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,14 @@
+License: https://www.cloudcertprep.io/license.xml
+
 User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
-# Auth and transient pages also have <meta name="robots" content="noindex">
-# but listing them here saves crawl budget.
-Disallow: /login
-Disallow: /reset-password
-Disallow: /history
-# Block query-string variants. Social trackers (?fbclid, ?utm_*, ?gclid) can
-# create duplicate crawls of canonical URLs. We have canonical tags as the
-# primary defence; this is belt-and-braces.
-Disallow: /*?
+# /login, /reset-password, /history, and query-string variants (?fbclid,
+# ?utm_*, ?gclid) used to be Disallowed here for crawl-budget reasons. But
+# /login, /reset-password, and /history already carry <meta name="robots"
+# content="noindex">, and a Disallow stops a crawler from ever reaching that
+# tag - it hides the noindex signal instead of letting it be honored. Crawl
+# access is intentionally left open here so crawlers can read and honor it.
 
 # --- AI crawler preferences (R23.8) ---
 # Preference-signaling only, NOT an enforcement boundary. The interactive
@@ -22,6 +22,19 @@ Allow: /
 User-agent: PerplexityBot
 Allow: /
 User-agent: Google-Extended
+Allow: /
+
+# 2026 citation/answer-engine crawlers: search-index and user-triggered fetch
+# bots for AI answer engines, same citation flywheel as above.
+User-agent: OAI-SearchBot
+Allow: /
+User-agent: ClaudeBot
+Allow: /
+User-agent: Claude-SearchBot
+Allow: /
+User-agent: Perplexity-User
+Allow: /
+User-agent: Applebot
 Allow: /
 
 # Training-ingestion crawlers may read the marketing/landing surface but we

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,13 @@
-License: https://www.cloudcertprep.io/license.xml
+# NOTE: An RSL license doc ships at /license.xml (open, attribution-friendly,
+# consistent with the repo's MIT license) and a Content-Signal stance would be
+# "search/ai-input/ai-train all welcome". Neither is advertised here yet: the
+# RSL `License:` directive and the `Content-Signal:` line are non-standard
+# robots.txt lines that Lighthouse's robots.txt validator rejects, which drops
+# the SEO audit below 100 (a hard project constraint). Discovery of both is
+# deferred until a Lighthouse-compatible mechanism (e.g. an HTTP Link header)
+# is chosen.
 
 User-agent: *
-Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 # /login, /reset-password, /history, and query-string variants (?fbclid,
 # ?utm_*, ?gclid) used to be Disallowed here for crawl-budget reasons. But
@@ -16,7 +22,7 @@ Allow: /
 # is never in the prerendered HTML a crawler sees regardless of these rules.
 #
 # Browse-mode citation crawlers (answer a user's live query, then cite us) are
-# welcome on the full indexable surface — this is the LLM-citation flywheel.
+# welcome on the full indexable surface (the LLM-citation flywheel).
 User-agent: ChatGPT-User
 Allow: /
 User-agent: PerplexityBot

--- a/src/pages/blog/rss.xml.ts
+++ b/src/pages/blog/rss.xml.ts
@@ -17,12 +17,19 @@ export async function GET(context: APIContext) {
     (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
       b.data.date.getTime() - a.data.date.getTime(),
   )
+  const site = context.site ?? new URL('https://www.cloudcertprep.io')
+  const selfHref = new URL('/blog/rss.xml', site).href
 
   return rss({
     title: 'CloudCertPrep Blog',
     description:
       'Guides, exam-format breakdowns, and study strategy for AWS certification exams from the CloudCertPrep team.',
-    site: context.site ?? 'https://www.cloudcertprep.io',
+    site,
+    // `format: 'file'` serves posts at /blog/slug with no trailing slash, so
+    // item links must match (issue #71) or they 404 via the canonical redirect.
+    trailingSlash: false,
+    xmlns: { atom: 'http://www.w3.org/2005/Atom' },
+    customData: `<atom:link href="${selfHref}" rel="self" type="application/rss+xml"/>`,
     items: sorted.map((post: CollectionEntry<'blog'>) => ({
       title: post.data.title,
       description: post.data.description,


### PR DESCRIPTION
## Summary

Two independent, low-risk static/edge-endpoint fixes bundled together:

1. **RSS canonical fix (issue #71)** - `src/pages/blog/rss.xml.ts`
2. **robots.txt AI-crawler allow bundle + RSL license file** - `public/robots.txt` + new `public/license.xml`

Both are static output / a single Astro endpoint; no guard-relevant SEO surface (sitemap, canonical H1, JSON-LD, internal link graph) is touched.

## Update: Lighthouse SEO fix (second commit)

CI flagged a Lighthouse regression: `categories.seo` fell below `minScore 1.0` on all 5 URLs because Lighthouse's robots.txt validator rejects two **non-standard** directives as invalid lines - the RSL `License:` directive and the `Content-Signal:` line. Lighthouse 100/100/100/100 on indexable pages is a hard AGENTS.md constraint, so both lines were removed in a follow-up commit.

- `License:` and `Content-Signal:` are **removed** from `public/robots.txt`.
- `public/license.xml` **still ships** as a standalone static asset (harmless, still fetchable at `/license.xml`); only its robots.txt-based discovery (`License:`) is gone.
- A comment in robots.txt records that RSL / Content-Signal discovery is **deferred** until a Lighthouse-compatible mechanism (e.g. an HTTP `Link` header) is chosen. No such header is added in this PR.
- Everything else is unchanged: the 4 removed over-blocking Disallows, the 5 crawler Allow groups, and the RSS fix.

Re-verified locally: `npm run build` then `npm run check:lighthouse` (`lhci autorun`, 3 runs x 5 URLs = 15 runs) passes all assertions including `categories:seo` `minScore 1.0`. Exit code 0, "All results processed!", no assertion failures.

## 1. RSS canonical fix

`src/pages/blog/rss.xml.ts`:
- Added `trailingSlash: false` to the `rss()` call so item links match the site's `format: 'file'` no-trailing-slash canonical URLs (`/blog/slug`, not `/blog/slug/`).
- Added a channel self-reference via `xmlns: { atom: '...' }` + `customData: '<atom:link href="..." rel="self" .../>'`, built from `context.site` (falls back to the same literal already used elsewhere in the file), not a separate hardcoded string.

Built `dist/blog/rss.xml` channel head + first item (truncated):

```xml
<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>CloudCertPrep Blog</title><description>Guides, exam-format breakdowns, and study strategy for AWS certification exams from the CloudCertPrep team.</description><link>https://www.cloudcertprep.io</link><atom:link href="https://www.cloudcertprep.io/blog/rss.xml" rel="self" type="application/rss+xml"/><item><title>AIF-C01 vs CLF-C02: Which AWS Cert to Take First</title><link>https://www.cloudcertprep.io/blog/aif-c01-vs-clf-c02</link><guid isPermaLink="true">https://www.cloudcertprep.io/blog/aif-c01-vs-clf-c02</guid>...
```

Item link has no trailing slash (`/blog/aif-c01-vs-clf-c02`), `atom:link rel="self"` present, and the file parses as well-formed XML.

## 2. robots.txt bundle

Confirmed `public/robots.txt` is a static file, not generated (`grep -rin "robots.txt" scripts/` only turns up a comment in `ping-indexnow.mjs` referring to it as a static asset it discovers; nothing writes it).

**Removed** from the `User-agent: *` group only (these routes already carry `<meta name="robots" content="noindex">`, so a Disallow just hides that signal from crawlers instead of letting them see and honor it):
- `Disallow: /login`
- `Disallow: /reset-password`
- `Disallow: /history`
- `Disallow: /*?`

**Added:** new `Allow: /` groups for 2026 citation/answer-engine bots: `OAI-SearchBot`, `ClaudeBot`, `Claude-SearchBot`, `Perplexity-User`, `Applebot`.

**Removed after CI (Lighthouse):** `Content-Signal:` on the wildcard group and the top-of-file `License:` directive (see Lighthouse fix above).

Final crawler section of `public/robots.txt`:

```
User-agent: *
Allow: /
# /login, /reset-password, /history, and query-string variants (?fbclid,
# ?utm_*, ?gclid) used to be Disallowed here for crawl-budget reasons. But
# /login, /reset-password, and /history already carry <meta name="robots"
# content="noindex">, and a Disallow stops a crawler from ever reaching that
# tag - it hides the noindex signal instead of letting it be honored. Crawl
# access is intentionally left open here so crawlers can read and honor it.

# --- AI crawler preferences (R23.8) ---
# Preference-signaling only, NOT an enforcement boundary. The interactive
# practice flows are client-rendered React islands, so their question content
# is never in the prerendered HTML a crawler sees regardless of these rules.
#
# Browse-mode citation crawlers (answer a user's live query, then cite us) are
# welcome on the full indexable surface (the LLM-citation flywheel).
User-agent: ChatGPT-User
Allow: /
User-agent: PerplexityBot
Allow: /
User-agent: Google-Extended
Allow: /

# 2026 citation/answer-engine crawlers: search-index and user-triggered fetch
# bots for AI answer engines, same citation flywheel as above.
User-agent: OAI-SearchBot
Allow: /
User-agent: ClaudeBot
Allow: /
User-agent: Claude-SearchBot
Allow: /
User-agent: Perplexity-User
Allow: /
User-agent: Applebot
Allow: /

# Training-ingestion crawlers may read the marketing/landing surface but we
# prefer they skip the interactive practice/auth shells (no useful prerendered
# content there anyway).
User-agent: GPTBot
Allow: /
Disallow: /login
Disallow: /reset-password
Disallow: /history
Disallow: /*/practice-exam
Disallow: /*/domain-practice

User-agent: CCBot
Allow: /
Disallow: /login
Disallow: /reset-password
Disallow: /history
Disallow: /*/practice-exam
Disallow: /*/domain-practice

Sitemap: https://www.cloudcertprep.io/sitemap.xml
```

(The top of the file additionally carries a comment block explaining the deferred RSL/Content-Signal discovery.)

Left `GPTBot`/`CCBot`'s existing per-path disallows untouched - the task scoped Disallow removal to the wildcard group only.

## RSL license file

New file: **`public/license.xml`** (site-root location, the convention shown in the RSL guide's own examples). Still ships; just no longer advertised via robots.txt.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<rsl xmlns="https://rslstandard.org/rsl">
  <content url="https://www.cloudcertprep.io/">
    <license>
      <permits type="usage">all</permits>
      <payment type="free">
        <standard>https://github.com/nastaso/cloudcertprep/blob/main/LICENSE</standard>
      </payment>
      <legal type="contact">https://www.cloudcertprep.io/about</legal>
    </license>
  </content>
</rsl>
```

Permits all usage types (`search`, `ai-input`, `ai-train`) for free, referencing the repo's actual MIT `LICENSE` on GitHub as the governing terms (the site is already MIT-licensed and markets itself as "free to read, reuse, and improve" on `/about`).

## Owner-confirmation flags

- **RSL / Content-Signal discovery is deferred** (see Lighthouse fix). If you want AI-usage/licensing signals advertised, the Lighthouse-safe path is an HTTP `Link: <https://www.cloudcertprep.io/license.xml>; rel="license"` response header (via `public/_headers` / the Cloudflare Pages Function), which robots.txt validators never see. I did not add it in this PR since it touches the CSP/headers generation pipeline and warrants its own review.
- **RSL `<payment type="free"><standard>...`**: RSL's `<standard>` URL is normally meant to point at a recognized license framework (e.g. a Creative Commons URL). I pointed it at the repo's own MIT `LICENSE` file since that is the site's actual, already-public license, rather than attaching a CC license the project does not use. Confirm this pairing or swap in a CC BY link if preferred.

## Verification

- `npm run build` - green, all guards pass unchanged (citation, internal-graph, person-graph, seo-head snapshot, csp:hash, cf:headers). `public/sitemap.xml` and `functions/_csp.generated.js` were touched by the build's own prebuild/postbuild steps and were `git restore`d before committing - not part of this PR.
- `npm run check:lighthouse` (`lhci autorun`) - all assertions pass, including `categories:seo` `minScore 1.0` on all 5 URLs.
- `npm run lint` - clean, 0 issues.
- `npm run test` - 273/273 passed.
- `npx astro check` - 0 errors (34 pre-existing hints unrelated to this change).
- `PW_PORT=4405 PW_REUSE_SERVER=0 npm run e2e` - 94 passed, 20 skipped (env-gated), 14 failed. All 14 failures are in seeded-session specs requiring a Supabase service-role key / seeded test project not present in a bare worktree, by design. Pre-existing gap, not caused by this change.

## Files touched

- `src/pages/blog/rss.xml.ts`
- `public/robots.txt`
- `public/license.xml` (new)

Model: ran on Sonnet.
