### PR TITLE
security: add security.txt, CodeQL paths-ignore, GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,6 @@
 # Sponsor button shown at the top of the GitHub repo page.
-# Single entry: Ko-fi (one-off and monthly support, no platform cut).
+# Ko-fi (one-off and monthly support, no platform cut) plus GitHub Sponsors
+# (0% platform fee, keeps support inside GitHub). GitHub Sponsors must be
+# enabled on the account for this entry to activate the button.
 ko_fi: alexsantonastaso
+github: [nastaso]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,13 @@ jobs:
         uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
         with:
           languages: javascript-typescript
+          # scripts/ holds build-time generator/validator scripts (regex over
+          # local JSON, self-generated HTML for SEO assets) that CodeQL
+          # repeatedly flags as false positives - they never touch untrusted
+          # user input. Excluded from analysis to cut noise in the Security tab.
+          config: |
+            paths-ignore:
+              - scripts/
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -3,4 +3,5 @@
 Contact: mailto:alex@cloudcertprep.io
 Policy: https://github.com/nastaso/cloudcertprep/blob/main/SECURITY.md
 Preferred-Languages: en
+Canonical: https://www.cloudcertprep.io/.well-known/security.txt
 Expires: 2027-07-04T00:00:00.000Z

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+# CloudCertPrep security disclosure policy (RFC 9116).
+# Full policy, scope, and PII/auth-provider details: see SECURITY.md in the repo.
+Contact: mailto:alex@cloudcertprep.io
+Policy: https://github.com/nastaso/cloudcertprep/blob/main/SECURITY.md
+Preferred-Languages: en
+Expires: 2027-07-04T00:00:00.000Z


### PR DESCRIPTION
## Summary

Three small, low-risk security/compliance pieces bundled together, all config/static files:

1. **`public/.well-known/security.txt`** (RFC 9116) - mirrors the disclosure contact and policy already in `SECURITY.md`:
   - `Contact: mailto:alex@cloudcertprep.io`
   - `Policy: https://github.com/nastaso/cloudcertprep/blob/main/SECURITY.md`
   - `Preferred-Languages: en`
   - `Expires: 2027-07-04T00:00:00.000Z`
   - **Flag:** RFC 9116 requires `Expires`; this is set roughly a year out and needs periodic renewal (candidate for a scheduled reminder, e.g. a yearly calendar note or a cron-based check).
   - Confirmed present in `dist/.well-known/security.txt` after `npm run build`.

2. **`.github/workflows/codeql.yml`** - added `paths-ignore: scripts/` via the `init` step's inline `config` input (confirmed `github/codeql-action/init@411c4c9...` / v3.36.3, the SHA already pinned in this workflow, supports the `config` input for inline YAML). `scripts/` holds build-time generator/validator scripts (regex over local JSON, self-generated HTML for SEO assets) that never touch untrusted input - 6 of the current 10 CodeQL alerts are false positives from this directory.
   - **Note:** CodeQL cannot be run locally; the alert-count reduction is only observable on the next scheduled/triggered CodeQL run on this branch or `main`.

3. **`.github/FUNDING.yml`** - added `github: [nastaso]` alongside the existing `ko_fi` entry.
   - **Flag:** GitHub Sponsors must be **enabled on the account** for this button to activate. Until then the entry is harmless but inert (brand-consistent: 0% platform fee, keeps support inside GitHub, not a premium tier).

## Owner-only follow-up (not code, noted here only)

The 4 `src/` localStorage CodeQL alerts are false positives (non-secret UI state, e.g. exam progress/theme prefs) - dismissing them is a GitHub Security dashboard action, not a code change, so it's left for the owner to do directly on the Security tab.

## Verification

- `npm run build` - green. All postbuild guards unchanged: `check:citation`, `check:graph`, `check:person-graph`, `check:seo-head`, `csp:hash`, `cf:headers` all pass with no drift (config/static files only, no locked SEO surface touched).
- Confirmed `dist/.well-known/security.txt` exists and matches source after build.
- `npm run lint` - clean (0 errors).
- `npm run test` - 273/273 passing (22 test files).
- `astro check` - 0 errors, 0 warnings (34 pre-existing hints in unrelated files, e.g. deprecated `z` re-exports and `is:inline` script hints - not touched by this change).
- `PW_PORT=4407 PW_REUSE_SERVER=0 npm run e2e` - 94 passed, 20 skipped, 14 failed. Reproduced the identical 14 failures (same specs, same assertions) against unmodified `main` in the same worktree (`git stash` then rerun, then restored) - these are the seeded-session specs that need a service-key test project, absent by design in a bare worktree. Pre-existing, unrelated to this change.
- YAML validated with `js-yaml` (Node): both `codeql.yml` and `FUNDING.yml` parse cleanly; the `config` block resolves to `paths-ignore: [scripts/]` as inline YAML, and `FUNDING.yml` resolves to `{ ko_fi: ..., github: [nastaso] }`.

Model: ran on Sonnet.