### PR TITLE
content(blog): P24 ESL +30 minutes draft (draft:true, do not merge)

### DIFF
--- a/src/content/blog/aws-exam-extra-time-esl.md
+++ b/src/content/blog/aws-exam-extra-time-esl.md
@@ -1,0 +1,105 @@
+---
+title: 'How to Get 30 Extra Minutes on Any AWS Exam (ESL +30)'
+slug: aws-exam-extra-time-esl
+description: 'Non-native English speakers get 30 extra minutes on any English AWS exam. Request the free ESL +30 accommodation once, before booking. Exact steps inside.'
+date: 2026-07-04
+tags: ['clf-c02', 'aif-c01', 'exam-format']
+ogImage: /og/og-blog.png
+draft: true
+faq:
+  - q: "How do I get 30 extra minutes on an AWS certification exam?"
+    a: "Request the ESL +30 MINUTES accommodation in your AWS Certification account before you register: sign in at aws.training, open Certification, select Go to your Account, then Request Exam Accommodations, choose ESL +30 MINUTES, and select Create. It is free and applies to all future English exam registrations."
+  - q: "Who qualifies for the AWS ESL +30 accommodation?"
+    a: "Any non-native English speaker taking an AWS certification exam delivered in English qualifies. AWS asks for no documentation or proof. If you sit the exam in another offered language instead of English, the ESL extension does not apply."
+  - q: "Do I need to send proof or documentation for the ESL +30 request?"
+    a: "No. Unlike disability accommodations, the ESL +30 MINUTES accommodation requires no documentation. You select it from a dropdown in your AWS Certification account and create the request; there is nothing to upload."
+  - q: "Do I have to request ESL +30 before every AWS exam?"
+    a: "No. You request it once, before registering, and it then applies automatically to all of your future English-delivered exam registrations with all test delivery providers. You never repeat the request for later exams."
+  - q: "Can I add the ESL +30 accommodation after booking my exam?"
+    a: "The accommodation attaches to registrations made after it is granted, so request it before you book. If you already scheduled an exam without it, create the request first, then reschedule; AWS lets you reschedule for free up to 24 hours before your appointment."
+  - q: "Does the ESL +30 accommodation cost anything or change the exam?"
+    a: "No. It is free, the questions and the 700 out of 1000 passing score are identical, and the certification you earn is the same. The only thing that changes is the clock: a 90-minute foundational exam becomes 120 minutes."
+---
+
+To get 30 extra minutes on any AWS certification exam, request the free **ESL +30 MINUTES** accommodation in your AWS Certification account before you register: sign in at aws.training, open the Certification section, select **Go to your Account**, then **Request Exam Accommodations**, then **Request Accommodation**, pick **ESL +30 MINUTES** from the Accommodation Type dropdown, and select **Create**. AWS asks for no documentation, and once granted the extension applies automatically to every future exam you register for in English.
+
+That is the entire process, and it is one of the most under-used advantages in AWS certification, largely because most advice about it is wrong. The extra time is not added automatically when you book, and it is not an option you pick at checkout with the test provider. This guide walks through the exact request flow, who qualifies, and what the extra 30 minutes changes on exam day for the Cloud Practitioner (CLF-C02) and AI Practitioner (AIF-C01) exams.
+
+_Last reviewed: July 2026._
+
+## How to request the ESL +30 accommodation (step by step)
+
+You request the accommodation once, in your AWS Certification account, before registering for any exam. The request is a dropdown selection, not an application: there is no essay, no document upload, no fee, and no waiting on a case review. The steps below come from AWS's official [exam accommodations policy](https://aws.amazon.com/certification/policies/before-testing/).
+
+1. Sign in at aws.training and open the **Certification** section.
+2. Select the **Go to your Account** button.
+3. Select **Request Exam Accommodations**, then **Request Accommodation**.
+4. In the **Accommodation Type** dropdown, select **ESL +30 MINUTES**.
+5. Select the **Create** button.
+
+That is it. Book your exam as you normally would afterward, and the extra time attaches to the registration on its own. In AWS's own words, once granted "it will apply to all future exam registrations with all test delivery providers," so you never repeat this for a later exam.
+
+## Who qualifies, and what it costs
+
+Every non-native English speaker taking an AWS exam delivered in English qualifies, and the accommodation is free. The [before-testing policy](https://aws.amazon.com/certification/policies/before-testing/) states that a 30-minute exam extension is available upon request to non-native English speakers taking an exam in English. There is no test of your English level and no proof to submit.
+
+Two boundaries are worth knowing. First, the extension applies to exams delivered in English; if you sit the exam in another offered language, the ESL accommodation is not the mechanism for extra time. Second, this is separate from disability accommodations, which have their own request flow and do require documentation. ESL +30 is the simple case: one dropdown, one click, done.
+
+<!-- OWNER (rule 2): optional first-person ESL line here -->
+
+## It is not automatic: the misconception vs the real process
+
+The most common mistake is assuming the extra time is granted automatically at booking, or that you choose it during checkout with the test delivery provider. Neither is true. The request lives in your AWS Certification account and must exist before you register, or your exam is booked at the standard time.
+
+| What people assume | What actually happens |
+| --- | --- |
+| The extra time is added automatically when you book | You must request it yourself in your AWS Certification account |
+| You select it at checkout with the test delivery provider | There is no such checkout option; the request happens before registration |
+| You repeat the request for every exam | You request it once and it applies to all future English exam registrations |
+| You need documents proving English is not your first language | AWS asks for no documentation at all |
+| It costs extra or needs special approval | It is free and created from a simple dropdown request |
+
+If you have already booked an exam without the accommodation, the fix is straightforward: create the ESL +30 request first, then reschedule the exam so the registration picks up the extension. AWS lets you reschedule at no cost up to 24 hours before your appointment.
+
+## What 30 extra minutes changes on exam day
+
+The accommodation adds a flat 30 minutes to the exam clock and changes nothing else: same questions, same 700 out of 1000 passing score, same certification at the end. On the foundational exams that means 120 minutes instead of 90, a 33% increase in thinking time.
+
+| Exam | Standard time | With ESL +30 |
+| --- | --- | --- |
+| [Cloud Practitioner (CLF-C02)](/aws/clf-c02) | 90 minutes (about 83 seconds per question) | 120 minutes (about 110 seconds per question) |
+| [AI Practitioner (AIF-C01)](/aws/aif-c01) | 90 minutes (about 83 seconds per question) | 120 minutes (about 110 seconds per question) |
+
+Both foundational exams run 65 questions in 90 minutes, per the official [CLF-C02 exam guide](https://docs.aws.amazon.com/aws-certification/latest/cloud-practitioner-02/cloud-practitioner-02.html) and [AIF-C01 exam guide](https://docs.aws.amazon.com/aws-certification/latest/ai-practitioner-01/ai-practitioner-01.html). Because the accommodation attaches to your account rather than to one exam, the same flat 30 minutes applies to any English-delivered AWS exam at any level, from foundational through professional.
+
+For non-native speakers the value is concentrated in question reading: long scenario stems and near-identical answer options are exactly where translation overhead eats the clock. The extra half hour is what lets you re-read a twisted stem twice without falling behind. Rehearse your pacing at the standard 90 minutes with a full-length [CLF-C02 practice exam](/aws/clf-c02/practice-exam) or [AIF-C01 practice exam](/aws/aif-c01/practice-exam); if the standard clock already feels comfortable, the extra 30 minutes on the real exam becomes pure review buffer.
+
+## Bottom line
+
+If English is not your first language, request the ESL +30 MINUTES accommodation before you book anything: aws.training, Certification, **Go to your Account**, **Request Exam Accommodations**, **ESL +30 MINUTES**, **Create**. It is free, needs no proof, takes about a minute, and covers every future English AWS exam you sit. Then prepare as normal with free [CLF-C02 practice questions](/aws/clf-c02) or [AIF-C01 practice questions](/aws/aif-c01), and if you are still deciding between the two foundational exams, see [AIF-C01 vs CLF-C02: which to take first](/blog/aif-c01-vs-clf-c02).
+
+## Frequently asked questions
+
+### How do I get 30 extra minutes on an AWS certification exam?
+
+Request the ESL +30 MINUTES accommodation in your AWS Certification account before you register: sign in at aws.training, open Certification, select Go to your Account, then Request Exam Accommodations, choose ESL +30 MINUTES, and select Create. It is free and applies to all future English exam registrations.
+
+### Who qualifies for the AWS ESL +30 accommodation?
+
+Any non-native English speaker taking an AWS certification exam delivered in English qualifies. AWS asks for no documentation or proof. If you sit the exam in another offered language instead of English, the ESL extension does not apply.
+
+### Do I need to send proof or documentation for the ESL +30 request?
+
+No. Unlike disability accommodations, the ESL +30 MINUTES accommodation requires no documentation. You select it from a dropdown in your AWS Certification account and create the request; there is nothing to upload.
+
+### Do I have to request ESL +30 before every AWS exam?
+
+No. You request it once, before registering, and it then applies automatically to all of your future English-delivered exam registrations with all test delivery providers. You never repeat the request for later exams.
+
+### Can I add the ESL +30 accommodation after booking my exam?
+
+The accommodation attaches to registrations made after it is granted, so request it before you book. If you already scheduled an exam without it, create the request first, then reschedule; AWS lets you reschedule for free up to 24 hours before your appointment.
+
+### Does the ESL +30 accommodation cost anything or change the exam?
+
+No. It is free, the questions and the 700 out of 1000 passing score are identical, and the certification you earn is the same. The only thing that changes is the clock: a 90-minute foundational exam becomes 120 minutes.


### PR DESCRIPTION
## DRAFT ONLY

This is a new blog **draft** (`draft: true`). Publishing is owner-consent-gated (hard rule): do NOT merge, do NOT flip `draft:false`. The post is excluded from indexable output while draft.

- **File:** `src/content/blog/aws-exam-extra-time-esl.md`
- **Slug:** `aws-exam-extra-time-esl`
- **Post:** P24 "How to Get 30 Extra Minutes on Any AWS Exam (ESL +30)"

## Corrected process (the main content point)

The post is written as the CORRECTED, accurate flow and explicitly debunks the common misconception. The ESL +30 minutes accommodation is:

- **Requested ONCE, BEFORE registering** for any exam, in the AWS training/Certification account: aws.training -> Certification -> **Go to your Account** -> **Request Exam Accommodations** -> **Request Accommodation** -> Accommodation Type dropdown -> **ESL +30 MINUTES** -> **Create**.
- **Granted WITHOUT documentation** (no proof of English level required).
- **Auto-applies to ALL future English-delivered exam registrations** with all test delivery providers, once granted.
- NOT "automatic at Pearson booking" and NOT selected per-exam at checkout. A "misconception vs real process" comparison table makes this explicit.

## Citations used (N1, >=2 outbound authority links in body)

1. AWS "before-testing" exam accommodations policy: https://aws.amazon.com/certification/policies/before-testing/ (cited twice; source of the exact menu path, "requested once prior to registering", no-documentation, and "applies to all future exam registrations with all test delivery providers"). Verified via WebFetch 2026-07-04.
2. Official CLF-C02 exam guide: https://docs.aws.amazon.com/aws-certification/latest/cloud-practitioner-02/cloud-practitioner-02.html (65 Q / 90 min).
3. Official AIF-C01 exam guide: https://docs.aws.amazon.com/aws-certification/latest/ai-practitioner-01/ai-practitioner-01.html (65 Q / 90 min).

**Owner-verify URL flags:** None fabricated. The `before-testing` policy URL was fetched and confirmed to contain the ESL +30 language and the exact aws.training menu path, so no owner verification flag is required. All three URLs are official `aws.amazon.com` / `docs.aws.amazon.com` pages already in `blog-sources.md` or verified live this session.

## OWNER marker

Exactly ONE first-person marker, placed where an optional ESL first-person line belongs (after the "Who qualifies" section):

`<!-- OWNER (rule 2): optional first-person ESL line here -->`

No first-person experience was written by the agent.

## Verification results

- **`npm run build`:** GREEN. All guards passed (validate-blog-frontmatter, generate-seo-assets, validate-internal-links, check:citation, check:graph, check:person-graph, check:seo-head byte-identical, csp:hash, cf:headers). Build regenerations (`functions/_csp.generated.js`, `public/sitemap.xml`) were `git restore`d; only the new markdown file is staged.
- **`validate-blog-frontmatter`:** PASS. Tags `['clf-c02', 'aif-c01', 'exam-format']` include recognized cert-code tags (exam logistics applies to both foundational exams). Title 53 chars, description 154 chars (both in range).
- **`npm run check` (astro check + lint + unit tests):** GREEN. Type-check clean, ESLint clean, 273/273 unit tests pass.
- **Dash check:** `grep -nP '[\x{2013}\x{2014}]'` on the post = EMPTY (no em/en-dashes). US English confirmed (no en-GB slips).
- **e2e (`PW_PORT=4410 PW_REUSE_SERVER=0 npm run e2e`):** 94 passed, 20 skipped, 14 failed. The 14 failures are the known env-gated seeded-session baseline (crash-safety, delete-modal-exit-signals x6, mock-exam-hardening, pending-attempt-owner-binding, ux-audit-seeded, weakest-domain-next-action x4); none relate to this markdown-only content change.

## Structure notes

- Answer-first lede (N14): opens by stating the exact request path before any preamble.
- Number in title (T3): "30 Extra Minutes" / "ESL +30".
- Real `<ol>`/`<table>` structures (T1); descriptive internal-link anchors up to `/aws/clf-c02`, `/aws/aif-c01`, their practice exams, and the live `aif-c01-vs-clf-c02` post (T2).
- `faq` frontmatter mirrored verbatim in a visible FAQ section.
