### PR TITLE
content(blog): add P23 free-CLF-via-promo draft (draft:true)

### DIFF
--- a/src/content/blog/how-to-get-aws-cloud-practitioner-exam-free-2026.md
+++ b/src/content/blog/how-to-get-aws-cloud-practitioner-exam-free-2026.md
@@ -1,0 +1,124 @@
+---
+title: 'How to Get the AWS Cloud Practitioner Exam Free (2026)'
+slug: how-to-get-aws-cloud-practitioner-exam-free-2026
+description: 'How to take the AWS Cloud Practitioner exam free in 2026: the official AIF-C01 promo path, its deadlines, and evergreen voucher options that outlast it.'
+date: 2026-07-04
+tags: ['clf-c02', 'aif-c01', 'study-tips']
+ogImage: /og/og-blog.png
+draft: true
+faq:
+  - q: "Can you take the AWS Cloud Practitioner exam for free in 2026?"
+    a: "Yes. Through an official AWS promotion on Pearson VUE, you register for the AWS Certified AI Practitioner (AIF-C01) exam with a promo code for 50% off, and if you pass by September 30, 2026, you get a free AWS Certified Cloud Practitioner (CLF-C02) exam to complete by November 30, 2026."
+  - q: "What are the conditions of the free CLF-C02 promotion?"
+    a: "You must be 18 or older, schedule through Pearson VUE, register and take AIF-C01 with the promo code between May 26 and September 30, 2026, and pass it. If you fail AIF-C01, you do not get the free Cloud Practitioner exam. The free CLF-C02 exam must be completed by November 30, 2026."
+  - q: "Is there a free AWS Cloud Practitioner voucher without taking AIF-C01?"
+    a: "Not as a standing offer. Outside time-limited promotions, the reliable paths are the 50% discount voucher you earn by holding any AWS certification, exam vouchers some employers and training programs provide, and occasional AWS or Pearson VUE offers. There is no permanent public free voucher."
+  - q: "What happens to this offer after November 30, 2026?"
+    a: "The promotion ends. After that date the evergreen options remain: the 50% discount voucher for existing certification holders, employer-sponsored vouchers, and whatever new promotions AWS runs. This post will be updated when the promo closes."
+---
+
+There is one official way to take the AWS Certified Cloud Practitioner (CLF-C02) exam completely free in 2026: AWS's AI and cloud foundational certification promotion, run through Pearson VUE. You register for the AWS Certified AI Practitioner (AIF-C01) exam with a promo code for 50% off (about USD 50 instead of USD 100), take and pass it by September 30, 2026, and that pass unlocks a free CLF-C02 exam you must complete by November 30, 2026. Every other path on this page is a discount or a sponsored voucher, not a standing freebie.
+
+This guide walks through exactly how the promotion works, every condition that can disqualify you, and the evergreen voucher and discount options that will still exist after the promo ends. If you are weighing the two foundational exams themselves, see [AIF-C01 vs CLF-C02: which to take first](/blog/aif-c01-vs-clf-c02).
+
+_Last reviewed: July 2026._
+
+**Time-sensitive:** the free-exam path below closes after November 30, 2026. If you are reading this later, skip to the [evergreen ways to save](#evergreen-ways-to-save-on-aws-exams-after-the-promo-ends); this post will be reframed once the promotion expires.
+
+## How the free Cloud Practitioner promotion works
+
+Pass the AWS Certified AI Practitioner exam at half price by September 30, 2026, and AWS gives you the Cloud Practitioner exam free, to be completed by November 30, 2026. The promo code is published on the official [Pearson VUE AWS AI and Cloud offer page](https://www.pearsonvue.com/us/en/aws/aif2cloud.html), which also lists the full terms. Do not trust third-party coupon sites; the code and conditions live on that one page.
+
+The conditions that matter, all of them:
+
+- **Register and take AIF-C01 through Pearson VUE between May 26 and September 30, 2026**, applying the promo code from the official offer page at checkout for 50% off.
+- **Pass AIF-C01 by September 30, 2026.** The discount and the pass are both required; if you fail AIF-C01, you are not eligible for the free CLF-C02 exam.
+- **Complete the free CLF-C02 exam by November 30, 2026.** Book it early enough to leave a buffer.
+- **You must be 18 or older**, and the code only applies to exams scheduled through Pearson VUE.
+- **The offer cannot be combined with other offers** and is non-transferable.
+
+| Detail | The 2026 offer |
+| --- | --- |
+| What you pay | About USD 50 for AIF-C01 (50% off), then CLF-C02 free |
+| Registration window | May 26 to September 30, 2026, via Pearson VUE |
+| Must pass AIF-C01 by | September 30, 2026 |
+| Free CLF-C02 completed by | November 30, 2026 |
+| Age requirement | 18 or older |
+| If you fail AIF-C01 | No free CLF-C02 |
+
+The math is simple: two foundational certifications for about USD 50 total, against a list price of USD 200. That is a 75% saving, and the only catch is that the free exam depends on you passing the first one.
+
+## Step by step: from promo code to free CLF-C02
+
+The whole path is four steps, and the only risky one is the exam you have to pass. Start from the official page so you get the real code and the current terms, then treat the AIF-C01 pass as the gate everything else hangs on.
+
+1. **Get the code from the official source.** Open the [Pearson VUE offer page](https://www.pearsonvue.com/us/en/aws/aif2cloud.html) and copy the promo code and terms from there.
+2. **Schedule AIF-C01 through Pearson VUE** (test center or online proctored) and apply the code at checkout. The fee drops to about USD 50.
+3. **Prepare until you are consistently passing, then sit AIF-C01 by September 30, 2026.** The free [AIF-C01 practice questions](/aws/aif-c01) cover all five exam-guide domains, and a timed [AIF-C01 mock exam](/aws/aif-c01/practice-exam) rehearses the real 65-question format.
+4. **Book the free CLF-C02 exam once you pass**, and complete it by November 30, 2026. Drill the [CLF-C02 practice questions](/aws/clf-c02) between the two exams; the overlap in AWS basics means momentum works in your favor.
+
+Do not book the AIF-C01 date until your practice scores are steady. A failed first exam costs you the discount you already spent and the free exam you were counting on.
+
+## Is the promo worth it if you only wanted Cloud Practitioner?
+
+Usually yes. Paying about USD 50 for AIF-C01 and getting CLF-C02 free costs half the USD 100 you would spend on Cloud Practitioner alone, and you finish with two certifications instead of one. The trade is real study time: AIF-C01 is a genuine exam on AI and machine learning fundamentals, not a formality.
+
+The usual advice is to take Cloud Practitioner first because it builds the AWS vocabulary that makes some AIF-C01 topics easier to place; the [AIF-C01 vs CLF-C02 comparison](/blog/aif-c01-vs-clf-c02) covers that reasoning. This promotion flips the order for purely economic reasons, and that is workable: both exams are foundational, neither has prerequisites, and if you already use AI tools at work, AIF-first may even feel more natural. Just budget honest study time for the AI exam rather than treating it as a checkbox on the way to the free one.
+
+<!-- OWNER (rule 2): first-person line here - e.g. that you booked and passed CLF-C02 directly at full price before this promotion existed, and how you would weigh the AIF-first detour. Do not imply you used the promo. -->
+
+## Evergreen ways to save on AWS exams (after the promo ends)
+
+Once the promotion expires, the reliable savings paths are the 50% discount voucher every AWS certification holder earns, vouchers from employers and training programs, and whatever time-limited offers AWS runs next. None of these make CLF-C02 free on a standing basis, but they routinely halve the fee or shift it to someone else's budget.
+
+| Path | Who it fits | What CLF-C02 costs you |
+| --- | --- | --- |
+| AIF-C01 promo (until November 30, 2026) | Anyone 18+ willing to take AIF-C01 first | Free, after about USD 50 for AIF-C01 |
+| Existing-certification 50% voucher | Anyone holding any current AWS certification | About USD 50 |
+| Employer or program vouchers | Employees, students, program members | Often nothing out of pocket |
+| Periodic AWS and Pearson VUE promotions | Varies by offer | Varies |
+| Full price | Everyone else | USD 100 plus local tax |
+
+How each one works:
+
+- **The existing-certification voucher.** Every AWS certification you earn unlocks a 50% discount voucher for your next exam, listed in the benefits section of your AWS Certification account; the [AWS Certification benefits page](https://aws.amazon.com/certification/benefits/) documents it. This is the one discount you can always count on, and it stacks across a certification path: each pass halves the next fee.
+- **Student and early-career programs.** [AWS Educate](https://aws.amazon.com/education/awseducate/) is free to join and is AWS's entry point for learners; its Emerging Talent Community has periodically offered certification exam vouchers to eligible members. Voucher availability changes, so treat it as a path to check rather than a guarantee.
+- **Employer sponsorship.** Many employers buy exam vouchers in bulk or reimburse certification fees, especially AWS partners. Asking your manager before you pay is the highest-value two-minute move on this list.
+- **Watch for the next promotion.** AWS and Pearson VUE run recurring offers, such as discounted exams or free retakes. The pattern of the 2026 AI promotion suggests more cross-certification offers are likely; the official AWS certification pages and the Pearson VUE AWS section are where they appear first.
+
+One thing that is never discounted: retakes. If you fail, you wait 14 days and pay the full fee again for each attempt, which is why being ready the first time is the biggest cost saving available.
+
+## How to prepare so the free exam counts
+
+A free exam you fail is not free, so prepare for both exams the same way you would if you were paying full price. CLF-C02 is 65 questions in 90 minutes with a passing score of 700 on a 100 to 1000 scale, per the [official CLF-C02 exam guide](https://docs.aws.amazon.com/aws-certification/latest/cloud-practitioner-02/cloud-practitioner-02.html), and AIF-C01 follows the same shape across five AI-focused domains.
+
+A sequence that fits inside the promo deadlines:
+
+- **Start with AIF-C01 practice by domain.** Work the free [AIF-C01 question bank](/aws/aif-c01) until your weak domains are obvious, then focus there.
+- **Rehearse the full format.** Sit at least one timed [AIF-C01 mock exam](/aws/aif-c01/practice-exam) before booking; only book the real exam when your scores hold comfortably above the passing line.
+- **Roll straight into CLF-C02 practice after the pass.** The [CLF-C02 question bank](/aws/clf-c02) is organized around the same four domains as the real exam, and a full [CLF-C02 mock exam](/aws/clf-c02/practice-exam) confirms you are ready before you spend the free voucher.
+- **Leave calendar buffer.** Sitting AIF-C01 by early September leaves room for a contingency; waiting until the September 30 deadline leaves none.
+
+Every question on this site is free, open-source, and paired with a written explanation, so you can run this entire preparation without spending anything beyond the discounted AIF-C01 fee.
+
+## Bottom line
+
+In 2026 the AWS Cloud Practitioner exam can be genuinely free: use the promo code from the official Pearson VUE offer page, pass AIF-C01 at 50% off by September 30, 2026, and complete the free CLF-C02 exam by November 30, 2026. After that window closes, the evergreen options are the 50% voucher every certified person holds, employer and program vouchers, and the next promotion. Whichever path you take, the fee only stays low if you pass on the first attempt, so start with the free [AIF-C01 practice questions](/aws/aif-c01) and the [CLF-C02 question bank](/aws/clf-c02) before you book anything.
+
+## Frequently asked questions
+
+### Can you take the AWS Cloud Practitioner exam for free in 2026?
+
+Yes. Through an official AWS promotion on Pearson VUE, you register for the AWS Certified AI Practitioner (AIF-C01) exam with a promo code for 50% off, and if you pass by September 30, 2026, you get a free AWS Certified Cloud Practitioner (CLF-C02) exam to complete by November 30, 2026.
+
+### What are the conditions of the free CLF-C02 promotion?
+
+You must be 18 or older, schedule through Pearson VUE, register and take AIF-C01 with the promo code between May 26 and September 30, 2026, and pass it. If you fail AIF-C01, you do not get the free Cloud Practitioner exam. The free CLF-C02 exam must be completed by November 30, 2026.
+
+### Is there a free AWS Cloud Practitioner voucher without taking AIF-C01?
+
+Not as a standing offer. Outside time-limited promotions, the reliable paths are the 50% discount voucher you earn by holding any AWS certification, exam vouchers some employers and training programs provide, and occasional AWS or Pearson VUE offers. There is no permanent public free voucher.
+
+### What happens to this offer after November 30, 2026?
+
+The promotion ends. After that date the evergreen options remain: the 50% discount voucher for existing certification holders, employer-sponsored vouchers, and whatever new promotions AWS runs. This post will be updated when the promo closes.


### PR DESCRIPTION
## DRAFT ONLY - do not publish

New blog post P23 as `draft: true`. **Publishing (flipping `draft: false`) is owner-consent-gated per the hard rule; this PR only adds the draft file.** No other files touched; build regeneration (sitemap/_csp) was restored before commit.

- **File:** `src/content/blog/how-to-get-aws-cloud-practitioner-exam-free-2026.md`
- **Slug:** `how-to-get-aws-cloud-practitioner-exam-free-2026`
- **Target:** free/voucher cluster ("cloud practitioner exam free"), distinct from P8's "exam cost" primary - the post never targets cost keywords and does not link the unpublished P8 slug.

## What the post covers

1. **Leads with the official 2026 promo** (answer-first lede, N14): promo code from the official Pearson VUE offer page gives 50% off AIF-C01 (about USD 50); pass by September 30, 2026 and the CLF-C02 exam is free, to be completed by November 30, 2026. All conditions stated: register/take via Pearson VUE between May 26 and September 30, 2026, must use the code AND pass (fail = no free exam), 18+, not combinable, non-transferable. The code itself is deliberately NOT printed - readers are pointed to the official page (per brief).
2. **Sunset note near the top**: the promo path closes after November 30, 2026; readers are routed to the evergreen section and the post will be reframed at expiry.
3. **Evergreen discount landscape** so the post survives the promo: the standing 50% voucher for existing cert holders, AWS Educate / Emerging Talent Community, employer sponsorship, recurring promotions, and the retake reality (14-day wait, full fee).
4. **Cross-cert bridge** (CLF <-> AIF): links the live comparison post and notes the promo inverts the usual CLF-first order; builder-framed, no claim the owner used the promo.

## Citations (N1: 4 outbound authority links, all fetched live 2026-07-04)

| URL | Backs | Status |
| --- | --- | --- |
| https://www.pearsonvue.com/us/en/aws/aif2cloud.html | All promo terms (dates, 50%, pass condition, 18+, Pearson VUE only) | VERIFIED live; page terms match the post verbatim (dates, failure clause, age) |
| https://aws.amazon.com/certification/benefits/ | 50% discount voucher for existing cert holders | VERIFIED live; page says "Get access to a 50% discount voucher to apply toward recertification or any other exam" |
| https://docs.aws.amazon.com/aws-certification/latest/cloud-practitioner-02/cloud-practitioner-02.html | 65 questions / 90 min / 700 of 1000 | Canonical AWS-CLF-GUIDE source already in blog-sources.md |
| https://aws.amazon.com/education/awseducate/ | AWS Educate as the student entry point | Page VERIFIED live, BUT it does not itself mention exam vouchers. The post hedges ("has periodically offered... treat it as a path to check rather than a guarantee"). **OWNER: please verify the Emerging Talent Community voucher claim or trim that clause.** |

**Owner-verification flags:** (1) the AWS Educate / Emerging Talent Community voucher sentence above; (2) sanity-check the promo terms once more on the Pearson page at the owner pass (they were fetched and matched today, but this is a live promotional page).

## Sunset date

Promo registration/pass deadline **September 30, 2026**; free CLF-C02 completion deadline **November 30, 2026**. The post carries an explicit time-sensitive note up top plus an FAQ entry on what happens after expiry.

## OWNER marker

Exactly one first-person marker, in the "Is the promo worth it if you only wanted Cloud Practitioner?" section: `<!-- OWNER (rule 2): first-person line here ... -->` (hint: owner passed CLF-C02 directly at full price; do not imply promo use).

## Verification

- `npm run build` GREEN (exit 0): prebuild `validate-blog-frontmatter` passed ("4 post file(s), 1 non-draft; All non-draft posts valid" - slug unique); postbuild `check:citation`, `check:graph`, `check:person-graph`, `check:seo-head` all byte-identical/passing (draft:true is excluded from indexable output as expected); `csp:hash` + `cf:headers` regenerated then `git restore`d.
- `npm run lint` clean.
- `npm run test` 273/273 passed (22 files).
- `astro check` 0 errors, 0 warnings.
- Dash check: `grep -nP '[\x{2013}\x{2014}]'` on the post = EMPTY (no em/en dashes anywhere).
- e2e on isolated port: `PW_PORT=4409 PW_REUSE_SERVER=0 npm run e2e` = **94 passed, 20 skipped (env-gated realcreds/seeded baseline), 0 failed**, exit 0.
- Frontmatter matches the collection schema: title 54 chars, description 152 chars, cert-code tags `clf-c02` + `aif-c01`, `ogImage` exists, FAQ frontmatter mirrored verbatim in a visible FAQ section (FAQPage JSON-LD parity).

Do not merge without owner review. Do not flip `draft: false`.
