### PR TITLE
fix: post-audit nits (#144 delete-reason/export, #153 gitignore, #146b figure spacing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ lerna-debug.log*
 # Local build / QA artifacts (regenerated or one-off; never source)
 .lighthouseci/
 cloudcertprep-cfg/
+
+# Local Supabase CLI state (not source; per-machine)
+supabase/.temp/

--- a/e2e/delete-modal-exit-signals.spec.ts
+++ b/e2e/delete-modal-exit-signals.spec.ts
@@ -22,29 +22,41 @@ interface CapturedEvent {
   params?: Record<string, unknown>
 }
 
-declare global {
-  interface Window {
-    __events: CapturedEvent[]
-  }
-}
-
-/** Stub window.umami so every trackEvent lands in window.__events. */
-async function installEventCapture(page: Page): Promise<void> {
+/**
+ * Stub window.umami so every trackEvent is relayed off-page via
+ * navigator.sendBeacon, and capture those beacons Node-side. A plain
+ * window.__events sink does not survive the post-delete hard navigation
+ * (window.location.assign wipes page globals); sendBeacon is designed to
+ * keep delivering during unload, and page.route observes it reliably even
+ * across that navigation.
+ */
+async function installEventCapture(page: Page): Promise<CapturedEvent[]> {
+  const events: CapturedEvent[] = []
+  await page.route('**/__evt', async route => {
+    const body = route.request().postData()
+    if (body) {
+      try {
+        events.push(JSON.parse(body) as CapturedEvent)
+      } catch {
+        // ignore malformed beacon bodies
+      }
+    }
+    await route.fulfill({ status: 204, body: '' })
+  })
   await page.addInitScript(() => {
-    const sink: CapturedEvent[] = []
-    ;(window as unknown as { __events: CapturedEvent[] }).__events = sink
     ;(window as unknown as { umami: unknown }).umami = {
       track: (name: string, params?: Record<string, unknown>) => {
-        sink.push({ name, params })
+        navigator.sendBeacon('/__evt', JSON.stringify({ name, params }))
       },
     }
   })
+  return events
 }
 
 /**
  * Stub the delete-account Edge Function. `delayMs` holds the response open so
- * assertions can read window.__events BEFORE the success path redirects away
- * (trackEvent fires synchronously before the invoke).
+ * assertions can observe the "Deleting your account..." spinner before the
+ * success path redirects away.
  */
 async function stubDeleteFunction(page: Page, opts: { status: number; delayMs?: number }): Promise<void> {
   await page.route('**/functions/v1/delete-account', async route => {
@@ -81,7 +93,7 @@ test('chips are optional and toggleable; Delete enables on typed DELETE alone', 
 })
 
 test('no chip selected: deletion proceeds and account_delete_reason does NOT fire', async ({ page }) => {
-  await installEventCapture(page)
+  const events = await installEventCapture(page)
   await seedSession(page)
   await stubDeleteFunction(page, { status: 200, delayMs: 1200 })
   await openDeleteModal(page)
@@ -89,16 +101,18 @@ test('no chip selected: deletion proceeds and account_delete_reason does NOT fir
   await page.getByPlaceholder('DELETE').fill('DELETE')
   await page.getByRole('button', { name: 'Delete account' }).click()
 
-  // Read events while the stub holds the response open (pre-redirect).
+  // The stub holds the response open long enough to observe the spinner.
   await expect(page.getByText('Deleting your account...')).toBeVisible()
-  const events = await page.evaluate(() => window.__events)
-  expect(events.filter(e => e.name === 'account_delete_reason')).toHaveLength(0)
 
+  // trackEvent (if any) fires just before the hard navigation away; assert
+  // against the Node-side capture after the redirect lands, once the
+  // beacon (if any) has had a chance to arrive.
   await page.waitForURL('**/?account_deleted=1')
+  await expect.poll(() => events.filter(e => e.name === 'account_delete_reason').length).toBe(0)
 })
 
 test('chip selected: account_delete_reason fires once, anonymously, at deletion time', async ({ page }) => {
-  await installEventCapture(page)
+  const events = await installEventCapture(page)
   await seedSession(page)
   await stubDeleteFunction(page, { status: 200, delayMs: 1200 })
   await openDeleteModal(page)
@@ -108,13 +122,15 @@ test('chip selected: account_delete_reason fires once, anonymously, at deletion 
   await page.getByRole('button', { name: 'Delete account' }).click()
 
   await expect(page.getByText('Deleting your account...')).toBeVisible()
-  const events = await page.evaluate(() => window.__events)
-  const reasonEvents = events.filter(e => e.name === 'account_delete_reason')
-  expect(reasonEvents).toHaveLength(1)
-  // Anonymous: the payload is the reason slug and nothing else.
-  expect(reasonEvents[0].params).toEqual({ reason: 'better_tool' })
 
+  // The event fires right before the success redirect; wait for the
+  // redirect, then assert against the Node-side beacon capture (which
+  // survives the navigation, unlike an in-page window.__events sink).
   await page.waitForURL('**/?account_deleted=1')
+  const reasonEvents = () => events.filter(e => e.name === 'account_delete_reason')
+  await expect.poll(() => reasonEvents().length).toBe(1)
+  // Anonymous: the payload is the reason slug and nothing else.
+  expect(reasonEvents()[0].params).toEqual({ reason: 'better_tool' })
 })
 
 test('export pointer closes the modal and runs the existing export', async ({ page }) => {

--- a/e2e/ux-audit-auth.spec.ts
+++ b/e2e/ux-audit-auth.spec.ts
@@ -2,6 +2,13 @@ import { test, expect, type Page } from '@playwright/test'
 import { createClient } from '@supabase/supabase-js'
 import { readFileSync } from 'node:fs'
 
+// Matches playwright.config.ts's own PORT/BASE_URL derivation: with PW_PORT unset
+// this is byte-identical to the old hardcoded localhost:4321, but under the
+// documented isolated-port recipe (PW_PORT=4399 ...) it follows the server this
+// spec's own baseURL actually points at, instead of racing/hanging against a
+// human's real session on 4321.
+const BASE_URL = `http://localhost:${Number(process.env.PW_PORT) || 4321}`
+
 // This spec creates and deletes REAL users via the service-role admin client, so
 // it must run serially: playwright.config sets fullyParallel:true, and the
 // afterAll cleanup below could otherwise race a sibling test that is still using
@@ -71,7 +78,7 @@ test('sign in (confirmed user) lands authenticated + dashboard renders (P1-10 ro
 
   // Sign-in success does window.location.assign(from='/'); wait for it so the
   // session is persisted before we navigate on (fixes the earlier race).
-  await page.waitForURL('http://localhost:4321/', { timeout: 20000 })
+  await page.waitForURL(`${BASE_URL}/`, { timeout: 20000 })
   // Signed-in indicator is now the account/user menu avatar (Sign out moved
   // inside it).
   await expect(page.getByRole('button', { name: 'Account menu' }).first()).toBeVisible({ timeout: 15000 })
@@ -131,7 +138,7 @@ test('P0-2: confirming the signup link redirects to /?verified=1 welcome card', 
     type: 'signup',
     email,
     password: PW,
-    options: { redirectTo: 'http://localhost:4321/?verified=1' },
+    options: { redirectTo: `${BASE_URL}/?verified=1` },
   })
   expect(error).toBeFalsy()
   const link = data.properties?.action_link
@@ -152,7 +159,7 @@ test('P1-7: in-exam Sign out routes through the leave modal, then completes', as
   await page.locator('#email').fill(email)
   await page.locator('#password').fill(PW)
   await submitForm(page)
-  await page.waitForURL('http://localhost:4321/', { timeout: 20000 })
+  await page.waitForURL(`${BASE_URL}/`, { timeout: 20000 })
 
   await page.goto('/aws/clf-c02/practice-exam')
   await page.getByRole('button', { name: 'Start exam', exact: true }).click()
@@ -181,7 +188,7 @@ test('P1-7: in-exam Sign out routes through the leave modal, then completes', as
   await page.getByRole('button', { name: 'Sign out' }).click()
   await expect(signOutDialog).toBeVisible()
   await signOutDialog.getByRole('button', { name: 'Sign out' }).click()
-  await page.waitForURL('http://localhost:4321/', { timeout: 20000 })
+  await page.waitForURL(`${BASE_URL}/`, { timeout: 20000 })
   await expect(page.getByRole('button', { name: 'Sign in' }).first()).toBeVisible({ timeout: 15000 })
 })
 
@@ -192,7 +199,7 @@ test('Practice menu (signed in): includes a Dashboard link per active cert', asy
   await page.locator('#email').fill(email)
   await page.locator('#password').fill(PW)
   await submitForm(page)
-  await page.waitForURL('http://localhost:4321/', { timeout: 20000 })
+  await page.waitForURL(`${BASE_URL}/`, { timeout: 20000 })
 
   const trigger = page.getByRole('button', { name: 'Practice', exact: true })
   await expect(trigger).toBeVisible({ timeout: 10000 })

--- a/e2e/ux-audit-shots.spec.ts
+++ b/e2e/ux-audit-shots.spec.ts
@@ -2,6 +2,12 @@ import { test, expect, type Page } from '@playwright/test'
 import { createClient } from '@supabase/supabase-js'
 import { readFileSync, mkdirSync } from 'node:fs'
 
+// Matches playwright.config.ts's own PORT/BASE_URL derivation: with PW_PORT unset
+// this is byte-identical to the old hardcoded localhost:4321, but under the
+// documented isolated-port recipe (PW_PORT=4399 ...) it follows the server this
+// spec's own baseURL actually points at.
+const BASE_URL = `http://localhost:${Number(process.env.PW_PORT) || 4321}`
+
 // Dark+light screenshots of the UX-audit surfaces for owner visual review.
 // Saved under .kiro/ (gitignored). Run after a build against the test backend.
 test.use({ reducedMotion: 'reduce' })
@@ -56,7 +62,7 @@ async function signIn(page: Page, email: string): Promise<void> {
   await expect(page.locator('input[name="cf-turnstile-response"]')).toHaveValue(/.+/, { timeout: 25000 })
   await page.waitForTimeout(750)
   await page.locator('form button[type="submit"]').click()
-  await page.waitForURL('http://localhost:4321/', { timeout: 20000 })
+  await page.waitForURL(`${BASE_URL}/`, { timeout: 20000 })
 }
 
 for (const theme of ['light', 'dark'] as const) {

--- a/src/index.css
+++ b/src/index.css
@@ -729,7 +729,7 @@ body {
   color: rgb(var(--color-text-primary));
 }
 .blog-content figure {
-  margin: 0;
+  margin-inline: 0;
   overflow-x: auto;
   text-align: center;
 }

--- a/src/pages/_Account.tsx
+++ b/src/pages/_Account.tsx
@@ -154,11 +154,6 @@ export function Account() {
     setDeleteError(null)
     try {
       const supabase = await getSupabase()
-      // Optional exit-reason signal (GROW M1): anonymous, opt-in only - never
-      // gates deletion, and only sent if the user tapped a chip.
-      if (deleteReason) {
-        trackEvent('account_delete_reason', { reason: deleteReason })
-      }
       // 30s race (note 3): functions.invoke never times out on its own, and
       // the modal is deliberately unclosable mid-delete - a hung request would
       // lock the user on the spinner forever. The deletion itself is
@@ -169,6 +164,12 @@ export function Account() {
           setTimeout(() => reject(new Error('delete-account timed out after 30s')), 30000)),
       ])
       if (error) throw error
+      // Optional exit-reason signal (GROW M1): anonymous, opt-in only - never
+      // gates deletion, and only sent once deletion has actually succeeded, so
+      // a hard failure (thrown above) never logs a churn reason.
+      if (deleteReason) {
+        trackEvent('account_delete_reason', { reason: deleteReason })
+      }
       // The account (and session) no longer exist; clear the local token and
       // leave the app. The home banner acknowledges the deletion. signOut can
       // itself reject at the storage layer, which used to land the user on
@@ -295,7 +296,7 @@ export function Account() {
             <button
               type="button"
               onClick={() => { setShowDeleteModal(false); handleExport() }}
-              disabled={deleting}
+              disabled={deleting || exporting}
               className="text-text-primary underline underline-offset-2 hover:text-text-primary/70 transition-colors"
             >
               Download your data


### PR DESCRIPTION
Follow-up fixes from the 2026-07-05 merged-PR audit. Draft for owner review; do not merge until reviewed.

- #144 (_Account.tsx): account_delete_reason now fires only after a successful delete (was firing even on hard failure); the delete-modal export pointer is disabled on deleting||exporting to prevent a concurrent double-export.
- #153 (.gitignore): ignore supabase/.temp/ local CLI state.
- #146b (index.css): .blog-content figure no longer zeroes its top vertical-rhythm gap (forward fix for wave-1 diagrams; no live figure yet).