### PR TITLE
feat(growth): star-on-GitHub CTA on the exam results screen

### DIFF
--- a/e2e/mock-exam-hardening.spec.ts
+++ b/e2e/mock-exam-hardening.spec.ts
@@ -54,6 +54,16 @@ test('retake does not re-open the "Ready to submit?" modal over question 1', asy
   await expect(page.getByText('Question 1 of', { exact: false })).toBeVisible()
 })
 
+test('results screen shows the star-on-GitHub CTA linking to the repo', async ({ page }) => {
+  await page.goto(EXAM_URL)
+  await startExam(page)
+  await submitExam(page) // guest, 0 answers -> fail results (CTA shows on pass AND fail)
+
+  const starCta = page.getByRole('link', { name: /star the repo on GitHub/i })
+  await expect(starCta).toBeVisible()
+  await expect(starCta).toHaveAttribute('href', 'https://github.com/nastaso/cloudcertprep')
+})
+
 test('signed-in sub-60s submit shows an explicit "not saved" notice', async ({ page }) => {
   await seedSession(page)
   await page.goto(EXAM_URL)

--- a/src/pages/_MockExam.tsx
+++ b/src/pages/_MockExam.tsx
@@ -1,6 +1,6 @@
 ﻿import { useState, useEffect, useRef, Fragment } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { Flag, AlertCircle, LayoutGrid, Heart, ArrowLeft } from 'lucide-react'
+import { Flag, AlertCircle, LayoutGrid, Heart, ArrowLeft, Star } from 'lucide-react'
 import { Button } from '../components/Button'
 import { Card } from '../components/Card'
 import { Alert } from '../components/Alert'
@@ -29,7 +29,7 @@ import type { Question, OptionKey } from '../types'
 import { loadAllQuestions } from '../data/questions'
 import { shuffleAndMapQuestions, toggleMultiAnswer, getQuestionType, encodeAnswerForDb, type OptionKeyMap } from '../lib/utils'
 import { trackEvent } from '../lib/analytics'
-import { KOFI_URL } from '../lib/constants'
+import { KOFI_URL, GITHUB_REPO_URL } from '../lib/constants'
 import { MAX_MULTI_ANSWER, TIMER_PULSE_THRESHOLD } from '../lib/constants'
 import { registerExamLeaveHandler, confirmExamLeave, isIntentionalLeave, SIGN_OUT_SENTINEL, markIntentionalLeave } from '../lib/examGuard'
 import { useSignOut } from '../hooks/useSignOut'
@@ -995,6 +995,26 @@ export function MockExam() {
               <span className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-text-primary">
                 <Heart className="w-4 h-4 text-danger" fill="currentColor" aria-hidden="true" />
                 Buy me a coffee
+              </span>
+            </a>
+
+            {/* Quiet star-on-GitHub ask at the highest-intent moment (just
+                finished an exam) - growth lever A7, the site-to-repo funnel is
+                near-invisible. Recessed (no fill, hairline border only) so it
+                sits below both the primary result actions and the Ko-fi ask and
+                never competes with them. Shown on pass AND fail. Reuses the
+                existing `github_click` event with its own `location: 'results'`.
+                Real anchor to the repo with honest link text; min 44px tall. */}
+            <a
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackEvent('github_click', { location: 'results' })}
+              className="flex min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-border-hairline p-4 text-center text-sm text-text-muted transition-colors duration-200 hover:border-text-muted/40"
+            >
+              <Star className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+              <span>
+                CloudCertPrep is free and open source. If it helped, <span className="font-medium text-text-primary">star the repo on GitHub</span> so others can find it.
               </span>
             </a>
           </div>


### PR DESCRIPTION
## Problem

Growth lever A7. The site-to-repo funnel is nearly invisible: ~32 `github_click`/30d against ~49k question events, and the repo sits around 41 stars, short of its 50-star gate. There is no star ask at the highest-intent moment (a just-finished exam).

## What changed

Added a quiet, recessed star-on-GitHub CTA to the mock-exam **results** screen, placed BELOW the primary result actions (Review / Back / Retake) and below the existing Ko-fi support ask, so it never competes with them.

- Self-contained block in the `screen === 'results'` branch of `src/pages/_MockExam.tsx`, following the existing quiet-panel pattern (`rounded-2xl border border-border-hairline`, muted copy, design tokens only). It is the most recessed element on the screen: no fill, hairline border only, so it sits a rung below the (filled) Ko-fi card.
- Real `<a>` to the repo via the existing `GITHUB_REPO_URL` constant (= `https://github.com/nastaso/cloudcertprep`), honest link text, a lucide-react `Star` icon (already a dependency), and a `min-h-[44px]` touch target.
- Analytics: reuses the existing `github_click` event with a new `{ location: 'results' }` param (joins the existing `header` / `mobile_drawer` locations). No new `KNOWN_EVENTS` entry.
- Shown on **both** pass and fail results (it lives in the shared bottom action stack, so no branching was needed).
- No changes to scoring, timers, or the dup-submit guard.

Copy (no dashes): "CloudCertPrep is free and open source. If it helped, **star the repo on GitHub** so others can find it."

## Files touched

- `src/pages/_MockExam.tsx` - import `Star` + `GITHUB_REPO_URL`; new CTA block in the results branch.
- `e2e/mock-exam-hardening.spec.ts` - one new assertion.

## Overlap with #178

Open PR #178 also edits `_MockExam.tsx` (a cross-cert nudge in the pass branch). This insertion is small and self-contained (an appended sibling in the shared bottom action stack, plus two import additions), so whichever merges second should rebase trivially. No overlap with the pass-branch region #178 touches.

## Verification

All run against a fresh `npm ci` in an isolated worktree branched from `origin/main`.

- `npm run lint` - clean (no output).
- `npm run test` - `Test Files 25 passed (25)`, `Tests 296 passed (296)`.
- `npm run build` - full prebuild + postbuild guard chain green: citation guard PASSED (9/9), internal-graph 0 violations, person-graph byte-identical, SEO `<head>` snapshot byte-identical across all 18 indexable pages, CSP hash + cf:headers regenerated.
- Pre-push hook (`npm run check`: astro check + lint + unit tests) ran on push - green.
- e2e (new assertion, isolated port): `PW_PORT=4411 PW_REUSE_SERVER=0 npx playwright test mock-exam-hardening -g "star-on-GitHub"` -> `1 passed`. It drives the guest start -> submit path to the results screen and asserts the CTA link is visible with `href="https://github.com/nastaso/cloudcertprep"`.

### Build-drift note

`npm run build` also regenerated `public/sitemap.xml` (lastmod churn) and `functions/_csp.generated.js` (a single `style-src` hash shifted from the stats-snapshot/OG prebuild, script-src byte-identical). The island is mounted `client:only="react"` and the results JSX never appears in prerendered HTML, so my change adds no inline script/style to built output. Both drift files were reverted (not committed), per the repo rules.

## Screenshots (results screen, reduced motion)

Recessed hairline CTA, light and dark:

Light: quiet panel, muted copy, `star the repo on GitHub` bolded.
Dark: same, on the dark surface.

Context (dark): the CTA renders at the very bottom of the results stack, below Review/Back/Retake and below the filled Ko-fi card, confirming it does not compete with the primary actions.

(Element + context shots captured via a throwaway spec using the guest start -> submit path with the matchMedia reduced-motion patch; the spec was not committed.)

---
Model: Claude Opus 4.8 (claude-opus-4-8[1m])