### PR TITLE
content(blog): publish wave 1, the CLF openers (P4 + P5)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -173,6 +173,12 @@ Yes. Like all AWS certifications, the AI Practitioner (AIF-C01) is valid for thr
 
 No. We do not provide exam dumps, which are leaked or stolen real exam questions that violate the AWS Certification agreement and can get your certification revoked. Every AIF-C01 question is original, written from the published AWS exam guide and AWS documentation, and aligned to the five current AIF-C01 domains. We help you pass legitimately by teaching the material, not by sharing stolen answers.
 
+## Articles
+
+- [AWS Cloud Practitioner Passing Score (700/1000) and Pass Rate](https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score): The AWS Cloud Practitioner (CLF-C02) passing score is 700/1000. Here is what that means, the pass-rate context, and what happens if you fail.
+- [Is the AWS Cloud Practitioner Exam Hard?](https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard): How hard is the AWS Cloud Practitioner (CLF-C02) exam? An honest difficulty breakdown by domain, with study time, pass-rate context, and prep tips.
+- [AIF-C01 vs CLF-C02: Which AWS Cert to Take First](https://www.cloudcertprep.io/blog/aif-c01-vs-clf-c02): A practical comparison of the AWS Certified AI Practitioner (AIF-C01) and Cloud Practitioner (CLF-C02) exams, and which foundational cert to sit first.
+
 ## Resources
 
 - [GitHub repository](https://github.com/nastaso/cloudcertprep)

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://www.cloudcertprep.io/</loc>
-    <lastmod>2026-06-19</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/about</loc>
-    <lastmod>2026-06-19</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/contribute</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/privacy</loc>
-    <lastmod>2026-06-19</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/terms</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/clf-c02</loc>
-    <lastmod>2026-06-19</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -41,7 +41,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/aif-c01</loc>
-    <lastmod>2026-06-16</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/clf-c02/cloud-concepts</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -59,7 +59,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/clf-c02/security-and-compliance</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -68,7 +68,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/clf-c02/cloud-technology-and-services</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -77,7 +77,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/clf-c02/billing-pricing-and-support</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -86,7 +86,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/aif-c01/fundamentals-of-ai-and-ml</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -95,7 +95,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/aif-c01/fundamentals-of-generative-ai</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -104,7 +104,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/aif-c01/applications-of-foundation-models</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -113,7 +113,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/aif-c01/guidelines-for-responsible-ai</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -122,7 +122,7 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/aws/aif-c01/security-compliance-and-governance</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -131,13 +131,31 @@
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/blog</loc>
-    <lastmod>2026-06-21</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.cloudcertprep.io/blog/aif-c01-vs-clf-c02</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-06-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <image:image>
+      <image:loc>https://www.cloudcertprep.io/og/og-blog.png</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <image:image>
+      <image:loc>https://www.cloudcertprep.io/og/og-blog.png</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>

--- a/scripts/seo-head-baseline.json
+++ b/scripts/seo-head-baseline.json
@@ -389,6 +389,66 @@
       "{\"@context\":\"https://schema.org\",\"@type\":\"FAQPage\",\"@id\":\"https://www.cloudcertprep.io/blog/aif-c01-vs-clf-c02#faq\",\"mainEntity\":[{\"@type\":\"Question\",\"name\":\"What is the difference between AIF-C01 and CLF-C02?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"CLF-C02 (Cloud Practitioner) covers the AWS Cloud broadly: core services, security, pricing, and support. AIF-C01 (AI Practitioner) focuses on AI and machine learning on AWS. Both are foundational, 65 questions, 90 minutes, and pass at 700 out of 1000; the only real difference is the subject matter.\"}},{\"@type\":\"Question\",\"name\":\"Should I take CLF-C02 or AIF-C01 first?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"For most people new to AWS, take CLF-C02 first. It builds the cloud vocabulary (regions, IAM, S3, the shared responsibility model) that makes several AIF-C01 topics easier to follow. Take AIF-C01 first only if your work is squarely in AI or ML and you already know cloud basics.\"}},{\"@type\":\"Question\",\"name\":\"Do I need CLF-C02 before AIF-C01?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"No. AIF-C01 is foundational and has no prerequisites. Knowing basic AWS concepts helps you place some topics in context, but it is not required to sit or pass the exam.\"}},{\"@type\":\"Question\",\"name\":\"Is AIF-C01 harder than CLF-C02?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"They are the same level (foundational), length (65 questions, 90 minutes), and passing score (700 out of 1000). AIF-C01 is narrower and deeper on AI and ML and adds two question formats (ordering and matching) that CLF-C02 does not use, but neither is harder by design; it depends on your background.\"}},{\"@type\":\"Question\",\"name\":\"How much do the CLF-C02 and AIF-C01 exams cost?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"Each exam fee is about USD 100 before any local tax, and each certification is valid for three years.\"}}]}"
     ]
   },
+  "blog/aws-cloud-practitioner-passing-score.html": {
+    "title": "AWS Cloud Practitioner Passing Score (700/1000) and Pass Rate",
+    "canonical": "https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score",
+    "meta": {
+      "description": "The AWS Cloud Practitioner (CLF-C02) passing score is 700/1000. Here is what that means, the pass-rate context, and what happens if you fail.",
+      "og:description": "The AWS Cloud Practitioner (CLF-C02) passing score is 700/1000. Here is what that means, the pass-rate context, and what happens if you fail.",
+      "og:image": "https://www.cloudcertprep.io/og/og-blog.png",
+      "og:image:alt": "AWS Cloud Practitioner Passing Score (700/1000) and Pass Rate",
+      "og:image:height": "630",
+      "og:image:type": "image/png",
+      "og:image:width": "1200",
+      "og:locale": "en_US",
+      "og:locale:alternate": "en_GB",
+      "og:site_name": "CloudCertPrep",
+      "og:title": "AWS Cloud Practitioner Passing Score (700/1000) and Pass Rate",
+      "og:type": "article",
+      "og:url": "https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score",
+      "robots": "index, follow, max-image-preview:large",
+      "twitter:card": "summary_large_image",
+      "twitter:description": "The AWS Cloud Practitioner (CLF-C02) passing score is 700/1000. Here is what that means, the pass-rate context, and what happens if you fail.",
+      "twitter:image": "https://www.cloudcertprep.io/og/og-blog.png",
+      "twitter:image:alt": "AWS Cloud Practitioner Passing Score (700/1000) and Pass Rate",
+      "twitter:title": "AWS Cloud Practitioner Passing Score (700/1000) and Pass Rate",
+      "twitter:url": "https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score"
+    },
+    "jsonld": [
+      "{\"@context\":\"https://schema.org\",\"@type\":\"BlogPosting\",\"@id\":\"https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score#article\",\"headline\":\"AWS Cloud Practitioner Passing Score (700/1000) and Pass Rate\",\"description\":\"The AWS Cloud Practitioner (CLF-C02) passing score is 700/1000. Here is what that means, the pass-rate context, and what happens if you fail.\",\"datePublished\":\"<DATETIME>\",\"dateModified\":\"<DATETIME>\",\"url\":\"https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score\",\"mainEntityOfPage\":{\"@type\":\"WebPage\",\"@id\":\"https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score\"},\"inLanguage\":\"en\",\"author\":{\"@type\":\"Person\",\"@id\":\"https://www.cloudcertprep.io/#author\"},\"publisher\":{\"@id\":\"https://www.cloudcertprep.io/#organization\"},\"image\":{\"@type\":\"ImageObject\",\"url\":\"https://www.cloudcertprep.io/og/og-blog.png\",\"width\":1200,\"height\":630},\"keywords\":\"clf-c02, exam-format, study-tips\"}",
+      "{\"@context\":\"https://schema.org\",\"@type\":\"FAQPage\",\"@id\":\"https://www.cloudcertprep.io/blog/aws-cloud-practitioner-passing-score#faq\",\"mainEntity\":[{\"@type\":\"Question\",\"name\":\"What score do you need to pass the AWS Cloud Practitioner exam?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"The passing score is 700 out of 1000. CLF-C02 uses a scaled score from 100 to 1000, so 700 is not 70% of questions correct; it is a scaled threshold AWS sets to keep difficulty consistent across exam versions. You pass or fail against 700, and the result shows as pass or fail.\"}},{\"@type\":\"Question\",\"name\":\"Is 700 the same as 70 percent on the Cloud Practitioner exam?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"No. The 100 to 1000 scale is not a simple percentage. Because questions vary in difficulty and 15 of the 65 are unscored, the number you need correct to reach 700 is not a fixed 70%. Aim well above the threshold in practice rather than targeting an exact percentage.\"}},{\"@type\":\"Question\",\"name\":\"Is there an official AWS Cloud Practitioner pass rate?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"AWS does not publish an official pass rate. CLF-C02 is widely regarded as high-pass because it is foundational and well-resourced, but any specific figure you see is an unofficial estimate. Focus on your own practice scores, which are the only reliable readiness measure.\"}},{\"@type\":\"Question\",\"name\":\"What happens if you fail the AWS Cloud Practitioner exam?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"If you fail, you wait 14 days before retaking and pay the exam fee again each attempt. You can retake as many times as you need; only the 14-day wait applies between attempts. Your score report shows performance by domain, so use it to target weak areas before you rebook.\"}}]}"
+    ]
+  },
+  "blog/is-aws-cloud-practitioner-exam-hard.html": {
+    "title": "Is the AWS Cloud Practitioner Exam Hard?",
+    "canonical": "https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard",
+    "meta": {
+      "description": "How hard is the AWS Cloud Practitioner (CLF-C02) exam? An honest difficulty breakdown by domain, with study time, pass-rate context, and prep tips.",
+      "og:description": "How hard is the AWS Cloud Practitioner (CLF-C02) exam? An honest difficulty breakdown by domain, with study time, pass-rate context, and prep tips.",
+      "og:image": "https://www.cloudcertprep.io/og/og-blog.png",
+      "og:image:alt": "Is the AWS Cloud Practitioner Exam Hard?",
+      "og:image:height": "630",
+      "og:image:type": "image/png",
+      "og:image:width": "1200",
+      "og:locale": "en_US",
+      "og:locale:alternate": "en_GB",
+      "og:site_name": "CloudCertPrep",
+      "og:title": "Is the AWS Cloud Practitioner Exam Hard?",
+      "og:type": "article",
+      "og:url": "https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard",
+      "robots": "index, follow, max-image-preview:large",
+      "twitter:card": "summary_large_image",
+      "twitter:description": "How hard is the AWS Cloud Practitioner (CLF-C02) exam? An honest difficulty breakdown by domain, with study time, pass-rate context, and prep tips.",
+      "twitter:image": "https://www.cloudcertprep.io/og/og-blog.png",
+      "twitter:image:alt": "Is the AWS Cloud Practitioner Exam Hard?",
+      "twitter:title": "Is the AWS Cloud Practitioner Exam Hard?",
+      "twitter:url": "https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard"
+    },
+    "jsonld": [
+      "{\"@context\":\"https://schema.org\",\"@type\":\"BlogPosting\",\"@id\":\"https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard#article\",\"headline\":\"Is the AWS Cloud Practitioner Exam Hard?\",\"description\":\"How hard is the AWS Cloud Practitioner (CLF-C02) exam? An honest difficulty breakdown by domain, with study time, pass-rate context, and prep tips.\",\"datePublished\":\"<DATETIME>\",\"dateModified\":\"<DATETIME>\",\"url\":\"https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard\",\"mainEntityOfPage\":{\"@type\":\"WebPage\",\"@id\":\"https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard\"},\"inLanguage\":\"en\",\"author\":{\"@type\":\"Person\",\"@id\":\"https://www.cloudcertprep.io/#author\"},\"publisher\":{\"@id\":\"https://www.cloudcertprep.io/#organization\"},\"image\":{\"@type\":\"ImageObject\",\"url\":\"https://www.cloudcertprep.io/og/og-blog.png\",\"width\":1200,\"height\":630},\"keywords\":\"clf-c02, study-tips, exam-format\"}",
+      "{\"@context\":\"https://schema.org\",\"@type\":\"FAQPage\",\"@id\":\"https://www.cloudcertprep.io/blog/is-aws-cloud-practitioner-exam-hard#faq\",\"mainEntity\":[{\"@type\":\"Question\",\"name\":\"How hard is the AWS Cloud Practitioner exam?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"It is one of the more approachable IT certifications. CLF-C02 is foundational, multiple choice and multiple response, with no hands-on tasks, and tests breadth of cloud concepts rather than deep technical skill. With one to three weeks of focused study and full-length practice, most beginners pass comfortably on the first attempt.\"}},{\"@type\":\"Question\",\"name\":\"Is AWS Cloud Practitioner hard for beginners?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"Not especially. CLF-C02 is designed for people new to the cloud, including non-technical roles. The main challenge is the breadth of services and terminology, not difficulty. Structured study by domain plus practice questions with explanations makes it very manageable for a complete beginner.\"}},{\"@type\":\"Question\",\"name\":\"Which CLF-C02 domain is the hardest?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"Most people find Cloud Technology and Services the most demanding, because it is the largest domain at 34% and covers the widest range of services. Billing, Pricing, and Support is usually the easiest at 12%. Weighting your study toward the technology domain pays off most.\"}},{\"@type\":\"Question\",\"name\":\"How long should I study for the Cloud Practitioner exam?\",\"acceptedAnswer\":{\"@type\":\"Answer\",\"text\":\"Most candidates need one to three weeks of part-time study. With prior IT or cloud exposure a focused week can be enough; with none, plan three to four weeks. The reliable readiness signal is consistently scoring above 80% on full-length timed practice across all four domains.\"}}]}"
+    ]
+  },
   "contribute.html": {
     "title": "Contribute to CloudCertPrep · Open-Source AWS Practice Exams",
     "canonical": "https://www.cloudcertprep.io/contribute",

--- a/src/content/blog/aws-cloud-practitioner-passing-score.md
+++ b/src/content/blog/aws-cloud-practitioner-passing-score.md
@@ -1,0 +1,93 @@
+---
+title: 'AWS Cloud Practitioner Passing Score (700/1000) and Pass Rate'
+slug: aws-cloud-practitioner-passing-score
+description: 'The AWS Cloud Practitioner (CLF-C02) passing score is 700/1000. Here is what that means, the pass-rate context, and what happens if you fail.'
+date: 2026-07-05
+tags: ['clf-c02', 'exam-format', 'study-tips']
+ogImage: /og/og-blog.png
+draft: false
+faq:
+  - q: "What score do you need to pass the AWS Cloud Practitioner exam?"
+    a: "The passing score is 700 out of 1000. CLF-C02 uses a scaled score from 100 to 1000, so 700 is not 70% of questions correct; it is a scaled threshold AWS sets to keep difficulty consistent across exam versions. You pass or fail against 700, and the result shows as pass or fail."
+  - q: "Is 700 the same as 70 percent on the Cloud Practitioner exam?"
+    a: "No. The 100 to 1000 scale is not a simple percentage. Because questions vary in difficulty and 15 of the 65 are unscored, the number you need correct to reach 700 is not a fixed 70%. Aim well above the threshold in practice rather than targeting an exact percentage."
+  - q: "Is there an official AWS Cloud Practitioner pass rate?"
+    a: "AWS does not publish an official pass rate. CLF-C02 is widely regarded as high-pass because it is foundational and well-resourced, but any specific figure you see is an unofficial estimate. Focus on your own practice scores, which are the only reliable readiness measure."
+  - q: "What happens if you fail the AWS Cloud Practitioner exam?"
+    a: "If you fail, you wait 14 days before retaking and pay the exam fee again each attempt. You can retake as many times as you need; only the 14-day wait applies between attempts. Your score report shows performance by domain, so use it to target weak areas before you rebook."
+---
+
+The AWS Certified Cloud Practitioner (CLF-C02) passing score is **700 out of 1000**. That is a scaled score, not a percentage: the exam reports a result from 100 to 1000, and 700 is the fixed threshold AWS uses to keep difficulty consistent across versions. You get a pass or fail, measured against 700.
+
+This guide explains what the passing score means, how scaled scoring works, what the pass-rate figures online are really worth, and what happens if you do not pass.
+
+_Last reviewed: July 2026._
+
+## What is the AWS Cloud Practitioner passing score?
+
+The AWS Cloud Practitioner passing score is **700 out of 1000**. CLF-C02 reports a scaled score from 100 to 1000, and 700 is the fixed pass threshold AWS sets to keep difficulty consistent across exam versions. You see a pass or fail result measured against 700, not a raw percentage of questions answered correctly.
+
+You also pass on your overall score alone: you do not need to pass each domain separately, so a weak domain can be offset by a strong one. The biggest domains still deserve the most study. All of this comes straight from the official [CLF-C02 exam guide](https://docs.aws.amazon.com/aws-certification/latest/cloud-practitioner-02/cloud-practitioner-02.html), not from third-party write-ups. Here is the quick-reference scorecard.
+
+| Item | Value |
+| --- | --- |
+| Scoring scale | 100 to 1000 (scaled) |
+| Passing score | 700 |
+| Questions | 65 (50 scored, 15 unscored) |
+| Time | 90 minutes |
+| Retake wait | 14 days |
+| Result | Pass or fail |
+
+Scoring facts are from the [exam guide](https://docs.aws.amazon.com/aws-certification/latest/cloud-practitioner-02/cloud-practitioner-02.html); exam length and logistics are on the [official certification page](https://aws.amazon.com/certification/certified-cloud-practitioner/).
+
+## How the 100 to 1000 scaled score works
+
+The 100 to 1000 score is not a percentage of questions you got right. The questions are not all equally hard, and 15 of the 65 do not count at all, so the number of correct answers you need to reach 700 is not a fixed 70%. Scaling lets AWS compare results fairly, which is why you target a score, not a percentage, and why the pass mark stays at 700 across exam versions while the questions change.
+
+The practical takeaway: stop trying to back-calculate "how many can I get wrong." Aim to be comfortably above the threshold on [full-length practice](/aws/clf-c02/practice-exam), and the scaled-score mechanics take care of themselves.
+
+One more scoring rule straight from the guide: unanswered questions count as wrong and there is no penalty for guessing. Never leave a question blank.
+
+## What is the Cloud Practitioner pass rate?
+
+AWS does not publish an official Cloud Practitioner pass rate, so any figure is an estimate. CLF-C02 is widely considered high-pass because it is foundational and well-resourced, but treat quoted pass rates as rough context only and rely on your own full-length practice scores as the real readiness signal.
+
+This is worth stressing because pass-rate numbers get repeated as fact across the web with no source. They are not AWS data. Our own numbers are different in one way: the [live community stats page](/stats) shows pass rates and average scores from signed-in users taking the practice exams on this site, so you can see exactly where the data comes from. It is practice data, not the real exam, but it is honest data. If the exam feels approachable, that is consistent with it being [a foundational, broad-but-not-deep exam](/blog/is-aws-cloud-practitioner-exam-hard); your practice scores are the measure that actually predicts your result.
+
+## What happens if you fail the exam?
+
+If you fail CLF-C02 you wait 14 calendar days before you can retake, and you pay the exam fee again each attempt. [AWS's own retake policy](https://aws.amazon.com/certification/policies/after-testing/) sets no limit on attempts: you can retake as many times as you need. Your score report breaks performance down by domain, so use it to target your weakest areas before you rebook the exam.
+
+A fail is recoverable and common enough not to dwell on. Use the domain breakdown, drill the weak areas on the [CLF-C02 domain practice](/aws/clf-c02), and rebook once your timed mock scores hold.
+
+## How to know you are ready to pass
+
+You are ready when your full-length timed mocks keep landing above 80% in every one of the four domains, comfortably clear of the 700 threshold. One good score is not enough; look for repeatable results and steady domain coverage. Timed mocks also build the pacing and stamina the real exam needs. To see what those questions feel like first, try a [full-length timed mock](/aws/clf-c02/practice-exam).
+
+For what it's worth, I passed with a scaled score around 850, comfortably above the 700 line. The pass result popped up on screen the moment I hit submit at the test center, and the official score and Credly badge landed a day or two later.
+
+## Bottom line
+
+- The pass mark is a scaled **700 out of 1000**. It is a threshold, not a 70% mark.
+- AWS publishes no official pass rate, so trust your own mock scores over internet figures.
+- A fail costs a 14-day wait and a domain-by-domain plan, nothing more.
+
+Aim for a steady 80%-plus on full mocks before you book, using the free [CLF-C02 practice exams](/aws/clf-c02).
+
+## Frequently asked questions
+
+### What score do you need to pass the AWS Cloud Practitioner exam?
+
+The passing score is 700 out of 1000. CLF-C02 uses a scaled score from 100 to 1000, so 700 is not 70% of questions correct; it is a scaled threshold AWS sets to keep difficulty consistent across exam versions. You pass or fail against 700, and the result shows as pass or fail.
+
+### Is 700 the same as 70 percent on the Cloud Practitioner exam?
+
+No. The 100 to 1000 scale is not a simple percentage. Because questions vary in difficulty and 15 of the 65 are unscored, the number you need correct to reach 700 is not a fixed 70%. Aim well above the threshold in practice rather than targeting an exact percentage.
+
+### Is there an official AWS Cloud Practitioner pass rate?
+
+AWS does not publish an official pass rate. CLF-C02 is widely regarded as high-pass because it is foundational and well-resourced, but any specific figure you see is an unofficial estimate. Focus on your own practice scores, which are the only reliable readiness measure.
+
+### What happens if you fail the AWS Cloud Practitioner exam?
+
+If you fail, you wait 14 days before retaking and pay the exam fee again each attempt. You can retake as many times as you need; only the 14-day wait applies between attempts. Your score report shows performance by domain, so use it to target weak areas before you rebook.

--- a/src/content/blog/is-aws-cloud-practitioner-exam-hard.md
+++ b/src/content/blog/is-aws-cloud-practitioner-exam-hard.md
@@ -1,0 +1,98 @@
+---
+title: 'Is the AWS Cloud Practitioner Exam Hard?'
+slug: is-aws-cloud-practitioner-exam-hard
+description: 'How hard is the AWS Cloud Practitioner (CLF-C02) exam? An honest difficulty breakdown by domain, with study time, pass-rate context, and prep tips.'
+date: 2026-07-05
+tags: ['clf-c02', 'study-tips', 'exam-format']
+ogImage: /og/og-blog.png
+draft: false
+faq:
+  - q: "How hard is the AWS Cloud Practitioner exam?"
+    a: "It is one of the more approachable IT certifications. CLF-C02 is foundational, multiple choice and multiple response, with no hands-on tasks, and tests breadth of cloud concepts rather than deep technical skill. With one to three weeks of focused study and full-length practice, most beginners pass comfortably on the first attempt."
+  - q: "Is AWS Cloud Practitioner hard for beginners?"
+    a: "Not especially. CLF-C02 is designed for people new to the cloud, including non-technical roles. The main challenge is the breadth of services and terminology, not difficulty. Structured study by domain plus practice questions with explanations makes it very manageable for a complete beginner."
+  - q: "Which CLF-C02 domain is the hardest?"
+    a: "Most people find Cloud Technology and Services the most demanding, because it is the largest domain at 34% and covers the widest range of services. Billing, Pricing, and Support is usually the easiest at 12%. Weighting your study toward the technology domain pays off most."
+  - q: "How long should I study for the Cloud Practitioner exam?"
+    a: "Most candidates need one to three weeks of part-time study. With prior IT or cloud exposure a focused week can be enough; with none, plan three to four weeks. The reliable readiness signal is consistently scoring above 80% on full-length timed practice across all four domains."
+---
+
+The AWS Certified Cloud Practitioner (CLF-C02) is one of the more approachable IT certifications. It is foundational, multiple choice and multiple response, with no hands-on tasks, and it tests breadth of cloud knowledge rather than deep technical skill. The real challenge is not difficulty but coverage: a lot of services and terminology, each at a shallow level.
+
+This is an honest breakdown of how hard CLF-C02 actually is, where the difficulty sits by domain, how long it takes to be ready, and how to make it easier on yourself.
+
+_Last reviewed: July 2026._
+
+## How hard is the AWS Cloud Practitioner exam, really?
+
+The AWS Cloud Practitioner exam is one of the more approachable IT certifications. CLF-C02 is foundational, multiple choice and multiple response, with no hands-on tasks, and it tests breadth of cloud concepts rather than deep technical skill. With one to three weeks of focused study and full-length practice, most beginners pass comfortably on their first attempt.
+
+AWS even lists coding, architecture design, and troubleshooting as [out of scope for the exam](https://docs.aws.amazon.com/aws-certification/latest/cloud-practitioner-02/cloud-practitioner-02.html). That does not make it free, though. The exam is broad: 65 questions across four domains, and you need to recognize a wide range of services and concepts. The difficulty is in the breadth, not the depth, which is good news, because breadth is exactly what structured study handles well.
+
+## What makes CLF-C02 easier or harder than people expect
+
+CLF-C02 is easier than people fear on difficulty but harder than they expect on breadth. There is a lot of terminology and many services to recognize, even though each concept is shallow. The trap is underestimating coverage, not depth, so broad, structured study beats deep study of any one area.
+
+### Difficulty by domain
+
+The four domains are not equal in size or in how much ground they cover. The table maps the official weightings to where most people feel the difficulty.
+
+| Domain | Weight | Relative difficulty | Drill page |
+| --- | --- | --- | --- |
+| Cloud Concepts | 24% | Moderate, lots of definitions | [Practice](/aws/clf-c02/cloud-concepts) |
+| Security and Compliance | 30% | Moderate, the shared responsibility model trips people | [Practice](/aws/clf-c02/security-and-compliance) |
+| Cloud Technology and Services | 34% | Hardest, the widest range of services | [Practice](/aws/clf-c02/cloud-technology-and-services) |
+| Billing, Pricing, and Support | 12% | Easiest, smallest and most concrete | [Practice](/aws/clf-c02/billing-pricing-and-support) |
+
+Cloud Technology and Services is the largest domain at 34% and the one most people find demanding, because it spans compute, storage, networking, and databases. Billing, Pricing, and Support is the smallest at 12% and usually the easiest. Weighting your study toward the technology domain is the single highest-return move.
+
+## How long does it take to study and pass?
+
+Most candidates need one to three weeks of part-time study. With prior IT or cloud exposure a focused week can be enough; with none, plan three to four weeks. The reliable readiness signal is scoring consistently above 80% on full-length timed practice across all four domains, not just finishing a course.
+
+Background drives the timeline more than anything else. If cloud terms are new, give yourself the upper end and lean on practice questions rather than passive reading, which is slower and sticks less.
+
+One number worth clearing up: AWS's official [exam guide](https://docs.aws.amazon.com/aws-certification/latest/cloud-practitioner-02/cloud-practitioner-02.html) describes its target candidate as someone with up to six months of exposure to the AWS Cloud. That is background experience, not a study plan. The one-to-three-week window above is focused exam prep, and the less exposure you start with, the closer you will sit to its upper end.
+
+## What the pass-rate context tells you
+
+AWS does not publish official pass rates, so any figure you see is an estimate. CLF-C02 is widely considered high-pass among AWS exams because it is foundational and well-resourced, but treat reported pass rates as rough context, not official numbers. Your own practice scores are the only reliable readiness measure (we publish our own live practice pass data from signed-in users on the [community stats page](/stats)). For how the score itself works, see the [CLF-C02 passing score and pass rate](/blog/aws-cloud-practitioner-passing-score) guide.
+
+## How to make CLF-C02 easier on yourself
+
+Make CLF-C02 easier by studying with the exam's own structure instead of against it:
+
+- Study along the four domain weightings, heaviest domain first.
+- Drill questions domain by domain to find your gaps.
+- Sit timed, full-length mocks to build pacing.
+- Read every explanation, so you learn the reasoning and not just the answer.
+- Learn services by what they do rather than memorizing names.
+- Stay away from dumps, which teach answers rather than understanding.
+
+If you want a structured course first, AWS runs free digital training linked from the [official Cloud Practitioner page](https://aws.amazon.com/certification/certified-cloud-practitioner/); just do not mistake finishing a course for being ready. This site focuses on the practice side, because scores on full-length mocks are the readiness signal a course cannot give you.
+
+The recognize-by-function habit is the one that scales: there are too many services to memorize as a list, but each has a clear job, and the exam asks which one fits a situation. Drill that on the free [CLF-C02 domain practice](/aws/clf-c02) and rehearse with a full-length mock before you book.
+
+I took CLF-C02 myself about three months ago. I was honestly pretty anxious going in, and then the real thing felt so close to the practice exams here that I finished all 65 questions in about 20 minutes. I still didn't quite believe it had been that easy, so I spent another 10 or 15 minutes re-checking every single answer before submitting.
+
+## Bottom line
+
+CLF-C02 is not a hard exam; it is a broad one. It is foundational, multiple choice and multiple response, no hands-on, and most beginners pass within one to three weeks of structured study. Put the most time into Cloud Technology and Services (34%), learn services by function, and rehearse with timed mocks until you clear 80% across all four domains. Start with the free [CLF-C02 practice questions](/aws/clf-c02).
+
+## Frequently asked questions
+
+### How hard is the AWS Cloud Practitioner exam?
+
+It is one of the more approachable IT certifications. CLF-C02 is foundational, multiple choice and multiple response, with no hands-on tasks, and tests breadth of cloud concepts rather than deep technical skill. With one to three weeks of focused study and full-length practice, most beginners pass comfortably on the first attempt.
+
+### Is AWS Cloud Practitioner hard for beginners?
+
+Not especially. CLF-C02 is designed for people new to the cloud, including non-technical roles. The main challenge is the breadth of services and terminology, not difficulty. Structured study by domain plus practice questions with explanations makes it very manageable for a complete beginner.
+
+### Which CLF-C02 domain is the hardest?
+
+Most people find Cloud Technology and Services the most demanding, because it is the largest domain at 34% and covers the widest range of services. Billing, Pricing, and Support is usually the easiest at 12%. Weighting your study toward the technology domain pays off most.
+
+### How long should I study for the Cloud Practitioner exam?
+
+Most candidates need one to three weeks of part-time study. With prior IT or cloud exposure a focused week can be enough; with none, plan three to four weeks. The reliable readiness signal is consistently scoring above 80% on full-length timed practice across all four domains.


### PR DESCRIPTION
## What

Publishes the first two blog posts of the content wave, together in one commit (they mutually cross-link; the internal-link guard fails if either publishes alone):

- **is-aws-cloud-practitioner-exam-hard** (P4) - difficulty breakdown by domain
- **aws-cloud-practitioner-passing-score** (P5) - the 700/1000 scoring explainer

## Owner finalization applied (2026-07-05)

- First-person CLF-C02 exam-experience lines (owner-approved wording)
- De-formalization voice pass per owner feedback (compensatory, pretest items, etc. rewritten in plain words)
- 2-3 outbound authority citations per post, each fetched and quote-verified today: CLF-C02 exam guide, official certification page, AWS retake policy
- Live /stats link as honest first-party pass-rate context (no number hardcoded; the page carries the live figure)
- 6-months-exposure vs study-time reconciliation sourced to the exam guide
- Multiple choice AND multiple response stated consistently; no-penalty-for-guessing rule added
- P5 title carries (700/1000); answer bolded; comma-run enumerations converted to real lists
- date: and Last-reviewed bumped to the publish date
- P5's link to the unpublished practice-exam post deliberately held (returns in wave 4)

## Verification

- npm run build fully green: citation guard 9/9, internal link graph 0 violations, person-graph byte-identical (31 pages), **seo-head baseline re-blessed 18 -> 20 indexable pages** and byte-identical, N1 citation validator passed, CSP hashes regenerated (script-src unchanged at 16)
- npm run lint clean; npm run test 300/300
- sitemap.xml + llms.txt regenerated and committed intentionally (2 new URLs; llms.txt Articles section activates with its first entries)
- e2e runs in CI on this PR (static content change; no app-flow surface touched)

## After merge (owner)

1. GSC request-indexing for both URLs (I will provide them on merge)
2. Syndication step follows per blog-syndication.md

Prepared by the admin session; owner merges. Merging this PR is the publish consent for exactly these two posts.