### PR TITLE
test(logger): cover logError DEV/PROD/Sentry branches

### DIFF
--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { logError } from './logger'
+
+// import.meta.env.DEV / .PROD are typed as readonly booleans by Vite's
+// client types. vi.stubEnv only accepts strings and, in this setup, does
+// not reliably coerce 'true'/'false' back into real booleans (a stubbed
+// 'false' string is truthy!). Casting once here lets us assign real
+// booleans directly and avoids that footgun.
+const env = import.meta.env as unknown as { DEV: boolean; PROD: boolean }
+
+function setEnv(dev: boolean, prod: boolean) {
+  env.DEV = dev
+  env.PROD = prod
+}
+
+describe('logError', () => {
+  const originalDev = env.DEV
+  const originalProd = env.PROD
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    // vitest.config.ts runs this suite under environment: 'node', so there
+    // is no global `window` to begin with. Stub a fresh one per test rather
+    // than referencing a bare `window` (which throws ReferenceError).
+    vi.stubGlobal('window', {})
+  })
+
+  afterEach(() => {
+    setEnv(originalDev, originalProd)
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('logs to console in development', () => {
+    // Arrange
+    setEnv(true, false)
+    const err = new Error('dev boom')
+
+    // Act
+    logError('DevContext', err)
+
+    // Assert
+    expect(console.error).toHaveBeenCalledWith('[DevContext]', err)
+    expect(console.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends errors to Sentry in production', () => {
+    // Arrange
+    setEnv(false, true)
+    const captureException = vi.fn()
+    window.Sentry = { captureException }
+    const err = new Error('prod boom')
+
+    // Act
+    logError('ProdContext', err)
+
+    // Assert
+    expect(captureException).toHaveBeenCalledWith(err, { tags: { context: 'ProdContext' } })
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('falls back to console when Sentry throws', () => {
+    // Arrange
+    setEnv(false, true)
+    const sentryErr = new Error('sentry is down')
+    window.Sentry = {
+      captureException: vi.fn(() => {
+        throw sentryErr
+      }),
+    }
+    const err = new Error('prod boom')
+
+    // Act
+    logError('FallbackContext', err)
+
+    // Assert
+    expect(console.error).toHaveBeenNthCalledWith(1, '[Sentry Error]', sentryErr)
+    expect(console.error).toHaveBeenNthCalledWith(2, '[FallbackContext]', err)
+    expect(console.error).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs to console when Sentry is unavailable', () => {
+    // Arrange
+    setEnv(false, true)
+    // window.Sentry left unset on the fresh stubbed window from beforeEach
+    const err = new Error('no sentry boom')
+
+    // Act
+    logError('NoSentryContext', err)
+
+    // Assert
+    expect(console.error).toHaveBeenCalledWith('[NoSentryContext]', err)
+    expect(console.error).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What does this PR do?
Adds `src/lib/logger.test.ts`, unit-testing `logError` across all four DEV/PROD/Sentry code paths.

## Why?
`logError` is the app's single error-logging chokepoint but had zero test coverage, so a regression here could silently swallow errors without anyone noticing.

Closes #51

## How was this tested?
Added four cases in `src/lib/logger.test.ts`, following the style of `src/lib/scoring.test.ts`:
- DEV: logs to `console.error` with the `[context]` prefix.
- PROD + `window.Sentry` present: calls `window.Sentry.captureException(err, { tags: { context } })`.
- PROD + Sentry throws: falls back to `console.error` (catch block), verified call order with `toHaveBeenNthCalledWith`.
- PROD + no Sentry: logs to `console.error`.

`window` is stubbed per-test with `vi.stubGlobal('window', {})` since the suite runs under `environment: 'node'` (per `vitest.config.ts`) with no real DOM global. `import.meta.env.DEV`/`PROD` are set directly as booleans (via a typed cast) rather than `vi.stubEnv`, since stubbing them as strings didn't coerce to real booleans in this setup and caused false-positive branch execution.

Ran locally:
```
Test Files  17 passed (17)
     Tests  225 passed (225)
```
- `npm run test` — 225/225 passing (17 test files, including the new 4 in `logger.test.ts`)
- `npm run lint` — clean, no errors or warnings
- `npm run validate` — all question banks valid (pre-existing warnings in `saa-c03` unrelated to this change)

## Checklist
- [ ] `npm run build` passes locally — could not fully verify; local build fails at static-path generation with `Missing Supabase environment variables`, unrelated to this change (no `.env` credentials configured locally)
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [ ] `npm run validate` passes locally (only if you touched `src/data/**/*.json`) — N/A, no data files touched (ran anyway, passes)
- [x] No new third-party dependencies

## Screenshots (UI changes only)
N/A — test-only change, no UI impact.
