### PR TITLE
fix(question-bank): clarify q808 answer count

### DIFF
--- a/src/data/bank-lastmod.json
+++ b/src/data/bank-lastmod.json
@@ -6,8 +6,8 @@
       "lastmod": "2026-07-04"
     },
     "clf-c02": {
-      "contentHash": "e29c822cfe48a94af594f60c157bc5dd846db151cb8b3180e70f91d278b3dc45",
-      "lastmod": "2026-07-05"
+      "contentHash": "338b487ea2965b6382382dafe3d4fc0f8f7e2a4298223ff010d8321b85c36e67",
+      "lastmod": "2026-07-18"
     },
     "saa-c03": {
       "contentHash": "f1d5eb5cad2c83ec61c2e475cc9d888397becb9b017c77c2c86735b52c90d3ea",

--- a/src/data/clf-c02/domain2.json
+++ b/src/data/clf-c02/domain2.json
@@ -2652,7 +2652,7 @@
   },
   {
     "id": "q808",
-    "question": "Which AWS service will provide a way to generate encryption keys that can be used to encrypt data?",
+    "question": "Which AWS services provide ways to generate encryption keys that can be used to encrypt data? (Select TWO)",
     "options": {
       "A": "Amazon Macie",
       "B": "AWS Certificate Manager",


### PR DESCRIPTION
## What does this PR do?

Updates q808 to explicitly state that two answers must be selected and refreshes the question-bank freshness ledger.

## Why?

The existing singular wording is ambiguous for a multi-answer question.

Closes #203

## How was this tested?

- `npm run validate`
- `npm run lint`
- `npm run test` (300 passed)
- `npm run build`
- `npm run e2e` (109 passed, 20 expected skips)

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [x] `npm run validate` passes locally
- [x] No new third-party dependencies

## Screenshots (UI changes only)

Not applicable.