### PR TITLE
test(keyword-clusters): cover SEO keyword helpers

### DIFF
--- a/src/data/keyword-clusters.test.ts
+++ b/src/data/keyword-clusters.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fixKeywordInitialisms,
+  getSampleKeywordTerms,
+  titleCaseKeyword,
+} from './keyword-clusters'
+
+describe('titleCaseKeyword', () => {
+  it('keeps known initialisms and hyphenated certification codes uppercase', () => {
+    expect(titleCaseKeyword('aws practice for aif-c01 and clf-c02')).toBe(
+      'AWS Practice for AIF-C01 and CLF-C02',
+    )
+  })
+
+  it('lowercases function words in the middle of a title', () => {
+    expect(titleCaseKeyword('security and compliance for the cloud')).toBe(
+      'Security and Compliance for the Cloud',
+    )
+  })
+
+  it('capitalizes a function word when it is the first word', () => {
+    expect(titleCaseKeyword('for aws and the cloud')).toBe('For AWS and the Cloud')
+  })
+})
+
+describe('fixKeywordInitialisms', () => {
+  it('uppercases official certification codes without title-casing other words', () => {
+    expect(fixKeywordInitialisms('aif-c01 and clf-c02 practice questions')).toBe(
+      'AIF-C01 and CLF-C02 practice questions',
+    )
+  })
+})
+
+describe('getSampleKeywordTerms', () => {
+  it('removes generic exam-prep tokens', () => {
+    expect(getSampleKeywordTerms('clf-c02', 1)).toEqual(['cloud', 'concepts'])
+  })
+
+  it('removes tokens shorter than three characters', () => {
+    expect(getSampleKeywordTerms('aif-c01', 1)).toEqual(['fundamentals'])
+  })
+
+  it('preserves first-seen order while removing duplicate tokens', () => {
+    expect(getSampleKeywordTerms('aif-c01', 3)).toEqual([
+      'foundation',
+      'models',
+      'applications',
+    ])
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds co-located Vitest coverage for `titleCaseKeyword`, `fixKeywordInitialisms`, and `getSampleKeywordTerms`.

The tests cover initialism and certification-code casing, function-word title casing, generic-token filtering, minimum token length, duplicate removal, and stable ordering.

## Why?

These helpers generate locked SEO text across domain landing pages but previously had no direct unit coverage.

Closes #72

## How was this tested?

- `npm run check` - passed, 307 tests
- `npm run build` - passed with all post-build guards
- `npm run lint` - passed
- `npm run validate` - passed with existing SAA-C03 warnings
- Focused test - 7 passed
- Isolated E2E run - 103 passed, 20 skipped, 6 unrelated existing failures in analytics, auth-banner, dashboard, and contrast flows

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [x] `npm run validate` passes locally
- [x] No new third-party dependencies

## Screenshots (UI changes only)

Not applicable. This is a tests-only change.

Implementation and verification assisted by OpenAI Codex.