### PR TITLE
fix(a11y): announce password criteria status

### DIFF
--- a/src/components/PasswordStrengthMeter.tsx
+++ b/src/components/PasswordStrengthMeter.tsx
@@ -57,13 +57,20 @@ export function PasswordStrengthMeter({ password }: PasswordStrengthMeterProps) 
           return (
             <li key={c.key} className="flex items-center gap-1.5 text-xs">
               {ok ? (
-                <Check className="w-3.5 h-3.5 text-success flex-shrink-0" />
+                <Check
+                  className="w-3.5 h-3.5 text-success flex-shrink-0"
+                  aria-hidden="true"
+                />
               ) : (
-                <X className="w-3.5 h-3.5 text-text-muted flex-shrink-0" />
+                <X
+                  className="w-3.5 h-3.5 text-text-muted flex-shrink-0"
+                  aria-hidden="true"
+                />
               )}
               <span className={ok ? 'text-text-primary' : 'text-text-muted'}>
                 {c.text}
               </span>
+              <span className="sr-only">, {ok ? 'met' : 'not met'}</span>
             </li>
           )
         })}


### PR DESCRIPTION
## What does this PR do?

Hides the password criteria status icons from assistive technology and adds screen-reader-only text that announces whether each criterion is met or not met. The visual layout and password scoring behavior are unchanged.

## Why?

Screen readers currently encounter decorative icons without an explicit textual state for each password requirement.

Closes #101

## How was this tested?

- `npm run check` (Astro check, ESLint, and 300 tests)
- `npm run build` with placeholder public Supabase environment values
- Playwright checks at 390x844 and 1440x1000 confirmed all four criteria expose met/not met text, all criterion icons are hidden, and the status text remains visually clipped

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [x] `npm run validate` is not applicable because no `src/data/**/*.json` files changed
- [x] No new third-party dependencies

## Screenshots (UI changes only)

No visible UI change.