### PR TITLE
fix(question-bank): correct six user-reported CLF-C02 question defects

### DIFF
--- a/src/data/bank-lastmod.json
+++ b/src/data/bank-lastmod.json
@@ -6,8 +6,8 @@
       "lastmod": "2026-07-04"
     },
     "clf-c02": {
-      "contentHash": "e29c822cfe48a94af594f60c157bc5dd846db151cb8b3180e70f91d278b3dc45",
-      "lastmod": "2026-07-05"
+      "contentHash": "356328eba0875e45a01910bd32ee51bbd45f268c346091a92443d9177495718e",
+      "lastmod": "2026-08-04"
     },
     "saa-c03": {
       "contentHash": "f1d5eb5cad2c83ec61c2e475cc9d888397becb9b017c77c2c86735b52c90d3ea",

--- a/src/data/clf-c02/domain1.json
+++ b/src/data/clf-c02/domain1.json
@@ -1001,7 +1001,7 @@
   },
   {
     "id": "q583",
-    "question": "What costs are included when comparing AWS Total Cost of Ownership (TCO) with on-premises TCO?",
+    "question": "In a Total Cost of Ownership (TCO) comparison, which cost does a company stop paying for directly when it moves a workload out of its own data center and onto AWS?",
     "options": {
       "A": "Project management",
       "B": "Antivirus software licensing",

--- a/src/data/clf-c02/domain2.json
+++ b/src/data/clf-c02/domain2.json
@@ -809,7 +809,7 @@
   },
   {
     "id": "q231",
-    "question": "Which of the following services will help businesses ensure compliance in AWS?",
+    "question": "Which of the following services helps businesses demonstrate compliance by providing an auditable record of account and API activity in AWS?",
     "options": {
       "A": "Amazon CloudFront",
       "B": "AWS Migration Hub",
@@ -1392,7 +1392,7 @@
       "D",
       "E"
     ],
-    "explanation": "If unrecognized resources appear in your AWS account, this may indicate a security compromise where an attacker has gained access and is creating resources, so you should change your root account password and access keys immediately to revoke the attacker's access and protect the account.\nClosing the account immediately would permanently terminate all resources and data without first investigating the extent of the compromise or recovering any workloads, making it a disproportionate response before proper incident response steps have been completed. Removing all IAM users from the account would lock out your legitimate team members and prevent any investigation or remediation work from being performed, making incident response significantly harder without actually addressing the underlying security compromise. Opening a new root account does not address the compromised account, as the original account with its resources and data would still be exposed; incident response requires securing the existing account rather than abandoning it.",
+    "explanation": "Unrecognized resources can mean an attacker has gained access to the account, so the priority is to revoke that access and remove the attacker's foothold. AWS guidance for unauthorized activity is to change the root user password and the passwords of the IAM users you created, rotate their access keys, and deactivate or delete any IAM users you did not create, which is what opening an investigation and removing the compromised IAM users accomplishes.\nStopping all running services does not revoke the attacker's credentials, so the attacker can simply restart or recreate the resources; it also takes down legitimate production workloads before the compromise has been scoped. Giving your root account password to AWS Support is never correct, because AWS Support will never ask for your password and sharing root credentials widens the compromise rather than containing it. Reviewing the CloudTrail logs is genuinely part of incident response and is how you identify which credentials were used, but the same option also deletes every IAM user with access to your resources, which would lock out your legitimate team and block the investigation; AWS advises deactivating the IAM users you did not create, not all of them.",
     "isMultiAnswer": true
   },
   {
@@ -2983,7 +2983,7 @@
       "D": "AWS Certificate Manager"
     },
     "answer": "C",
-    "explanation": "AWS KMS manages encryption keys and integrates natively with CloudTrail to encrypt log files stored in S3, ensuring that CloudTrail log data is protected at rest using KMS-managed keys.\nAWS Certificate Manager provisions and manages SSL/TLS certificates for encrypting data in transit between applications and end users, and is a certificate management service rather than a service for encrypting data received and stored by CloudTrail. Amazon Macie uses machine learning to discover and classify sensitive data stored in S3, and while it can identify sensitive content in CloudTrail logs stored in S3, it does not perform the encryption of that data. AWS Shield provides managed DDoS protection at the network and transport layers, and is a traffic protection service with no capability to encrypt data stored by CloudTrail or any other AWS service.",
+    "explanation": "AWS KMS manages encryption keys and integrates natively with CloudTrail to encrypt log files stored in S3, ensuring that CloudTrail log data is protected at rest using KMS-managed keys. CloudTrail calls this server-side encryption with a KMS key (SSE-KMS), and you choose the KMS key the trail uses.\nAWS Secrets Manager stores, rotates, and manages access to secrets such as database credentials and API keys. It protects those secrets using KMS, but it is not the service that encrypts the log data CloudTrail delivers. AWS Systems Manager provides operational management for EC2 instances and other resources, covering patching, run commands, and parameter storage, and is an operations and configuration service with no role in encrypting CloudTrail logs. AWS Certificate Manager provisions and manages SSL/TLS certificates for encrypting data in transit between applications and end users, and is a certificate management service rather than a service for encrypting data received and stored by CloudTrail.",
     "isMultiAnswer": false
   },
   {

--- a/src/data/clf-c02/domain3.json
+++ b/src/data/clf-c02/domain3.json
@@ -466,7 +466,7 @@
     "options": {
       "A": "Amazon Rekognition provides automatic watermarking of images",
       "B": "Amazon Rekognition provides automatic detection of objects appearing in pictures",
-      "C": "Amazon Recognition provides the ability to resize millions of images automatically",
+      "C": "Amazon Rekognition provides the ability to resize millions of images automatically",
       "D": "Amazon Rekognition uses Amazon Mechanical Turk to allow humans to bid on object detection jobs"
     },
     "answer": "B",
@@ -2534,8 +2534,8 @@
       "C": "There is no charge when your AWS Lambda code is not running",
       "D": "AWS Lambda can be called directly from any mobile app"
     },
-    "answer": "D",
-    "explanation": "AWS Lambda functions cannot be invoked directly from a mobile app without using an intermediary API layer such as Amazon API Gateway or AWS AppSync; direct invocation from arbitrary external code is not supported, making this statement false rather than a genuine benefit.\nLambda running code without provisioning or managing servers is a genuine benefit; it eliminates the need to select, patch, or maintain underlying compute infrastructure. Lambda does provide resizable compute capacity, automatically scaling from a few requests per day to thousands per second based on the incoming trigger volume. There is genuinely no charge when Lambda code is not running; billing is based on the number of requests and the duration of execution, making it cost-free during idle periods.",
+    "answer": "B",
+    "explanation": "Resizable compute capacity in the cloud is how AWS describes Amazon EC2, not AWS Lambda. With EC2 you choose an instance type and resize it as your needs change, which is the capacity model the phrase refers to. Lambda works the other way round: you never provision or resize a pool of compute capacity, and Lambda simply runs as many concurrent execution environments as the incoming request volume requires. This statement borrows the EC2 description, so it is the one that is not a benefit of Lambda.\nRunning code without provisioning or managing servers is AWS's headline description of Lambda and a genuine benefit, since Lambda manages the underlying infrastructure including capacity provisioning, patching, and scaling. There is genuinely no charge when your Lambda code is not running, because billing is based on the number of requests and the duration of execution, so an idle function costs nothing. Lambda can be called directly from a mobile app; AWS documents that you can set up your code to trigger automatically from other AWS services or call it directly from any web or mobile app, using the AWS SDK with credentials from a service such as Amazon Cognito.",
     "isMultiAnswer": false
   },
   {


### PR DESCRIPTION
## What does this PR do?

Works through the seven open user-reported question-error issues as one change, since they touch the same banks and `validate-questions` gates them together.

**Every report was verified against AWS documentation before anything was edited, and independently cross-checked by a second model (Codex/GPT-5.6). Two reports turned out to be wrong about the answer key; those questions were not changed to match the report.**

Closes #216, #214, #213, #212, #207, #206.

| Issue | Q | Report | Verdict | Change |
|---|---|---|---|---|
| #207 | q478 | Wrong answer marked correct | **CORRECT** | Answer flipped `D` -> `B`, explanation rewritten |
| #212 | q889 | Explanation discusses services that are not options | **CORRECT** | Explanation rewritten, answer unchanged |
| #206 | q093 | "Amazon Recognition" typo | **CORRECT** | Spelling fixed |
| #216 | q583 | Stem ambiguous | **CORRECT** | Stem reworded, answer unchanged |
| #213 | q231 | Stem ambiguous | **PARTLY CORRECT** | Stem tightened, answer unchanged (reporter's alternatives are not options) |
| #214 | q387 | Wrong answer marked correct | **WRONG on the answer** | Answer unchanged; a separate real defect in the explanation was fixed |
| #204 | q280 | Correct answer graded incorrect | **WRONG about the question** | No bank change. Root-caused to a UI bug, see below |

### The one real answer-key error: q478 (#207)

> Which of the following is NOT a benefit of using AWS Lambda?

The bank marked **D** ("AWS Lambda can be called directly from any mobile app") as the non-benefit. That is wrong on both halves:

- AWS's own Lambda description says you can "set up your code to automatically trigger from other AWS services **or call it directly from any web or mobile app**". D is a documented benefit.
- "Secure and resizable compute capacity" is AWS's branding for **Amazon EC2**. Option B borrows the EC2 description, so B is the statement that is not a Lambda benefit.

The previous explanation asserted the opposite of the AWS docs ("Lambda functions cannot be invoked directly from a mobile app"), so it has been rewritten too.

Source: [AWS Well-Architected, Lambda concept](https://wa.aws.amazon.com/wellarchitected/2020-07-02T19-33-23/wat.concept.lambda.en.html) (the source the reporter cited) and [aws.amazon.com/ec2](https://aws.amazon.com/ec2/).

### Two explanations described options that do not exist

q889 (#212) and q387 (#214) both had distractor paragraphs written against a different option set: q889 discussed Macie and Shield, q387 discussed "closing the account" and "opening a new root account". Neither appears in its question. Both rewritten against the real options. Neither answer key changed.

q387's reporter argued CloudTrail should be the answer. It should not: that option also deletes *every* IAM user with access to your resources, and [AWS guidance](https://repost.aws/knowledge-center/potential-account-compromise) is to deactivate the IAM users you did **not** create, not all of them. The rewritten explanation now says this explicitly, so the next reader gets the reasoning.

### #204 (q280) is not a content bug

The reporter selected the correct answers and was still graded incorrect. The question content is right (NACLs + security groups). The cause is in the review UI: `QuestionReviewCard.tsx:96-98` paints **every** correct option green whether or not the user selected it, and there is no "you picked this" state. An unanswered or half-answered multi-answer question therefore renders identically to a fully correct one while still being badged INCORRECT.

That is a real user-facing bug, but it is a UI/design change needing screenshot verification, so it is deliberately **not** bundled into a question-bank PR. #204 should stay open and be re-scoped. Details in the handoff.

## How was this tested?

- `npm run validate` - all questions valid, warning count unchanged from baseline (19, all pre-existing `saa-c03` ones)
- `npm run check` - `astro check` 0 errors, eslint clean, 300 tests / 26 suites passed
- `npm run bank:lastmod` - freshness ledger regenerated (unit-test gated by `bankFreshness.test.ts`)

## Checklist

- [x] `npm run validate` passes locally
- [x] `npm run check` passes locally
- [x] No new third-party dependencies
- [x] No changes to scoring, the question schema, or the auth flow

## Note on #205

PR #205 (q808 answer count) is correct and was deliberately **not** absorbed here, so the external contributor keeps authorship. It touches `src/data/clf-c02/domain2.json` and `bank-lastmod.json`, so whichever of the two merges second needs a `npm run bank:lastmod` re-run to settle the ledger hash. No semantic conflict: different questions.

## Screenshots (UI changes only)

Not applicable, content-only change.