### PR TITLE
a11y(batch): CertSwitcher aria-hidden + design-token contrast verification

### DIFF
--- a/src/components/CertSwitcher.tsx
+++ b/src/components/CertSwitcher.tsx
@@ -206,7 +206,7 @@ export function CertSwitcher({ variant, onSelect, initialPathname }: CertSwitche
                       Soon
                     </span>
                   )}
-                  {isActive && <Check className="w-4 h-4 text-brand ml-2" />}
+                  {isActive && <Check className="w-4 h-4 text-brand ml-2" aria-hidden="true" />}
                 </button>
               </li>
             )


### PR DESCRIPTION
## What does this PR do?

Closes #95, closes #23.

**#95** - `src/components/CertSwitcher.tsx:209`: adds `aria-hidden="true"` to the active-item `<Check>` icon. The active state is already conveyed by `aria-current="true"` on the parent button, so the icon carried no independent information for screen readers. One line, matches the issue exactly, no visual change.

**#23** - verification only, per the issue's own scope ("do not change token values in this issue"). Independently measured every WCAG contrast claim in `src/index.css`'s light and dark token blocks using the standard WCAG relative-luminance formula (implemented directly, no dependency - validated against the black/white=21:1 and `#767676`-on-white=4.54:1 reference points before trusting it on the real tokens). Full table, codex-cross-checked (independent from-scratch reimplementation, not given my code): `.kiro/cloudcertprep/A11Y-BATCH-2026-08-05.md`.

**Result: every documented claim holds, no token fails AA (4.5:1) in its documented usage.** No token value changed - this PR is code (`#95`) + a verification doc (`#23`), nothing else.

## Testing

- `npm run check`: 0 errors, 0 warnings, 300/300 tests pass.
- No visual change (`#95` is `aria-hidden` only, `#23` changed no CSS).

## Checklist

- [x] `npm run lint` and `npm run test` pass (via `npm run check`)
- [x] No visual/behavioral change
- [x] No token values changed (`#23` is verification-only per its own scope)
- [x] No new dependencies