### PR TITLE
Add 2 domain 4 question on SagMaker Clarify and Amazon A2I

### DIFF
--- a/src/data/aif-c01/domain4.json
+++ b/src/data/aif-c01/domain4.json
@@ -968,5 +968,35 @@
       "Amazon Augmented AI (Amazon A2I)",
       "Amazon SageMaker Model Cards"
     ]
-  }
+  },
+  {
+  "id": "aif-q465",
+  "question": "A company's board of directors has no data science background but needs to understand how each input variable influences a demand forecasting model's predictions. Which approach best meets this requirement?",
+  "options": {
+    "A": "Share the raw Python training code and hyperparameter configuration",
+    "B": "Generate Partial Dependence Plots showing how each feature affects the predicted output",
+    "C": "Provide a sample of the raw training dataset",
+    "D": "Share model convergence tables showing loss and accuracy across training epochs"
+  },
+  "answer": "B",
+  "explanation": "Partial Dependence Plots show how a model's prediction changes as one input feature varies while other features are held constant, producing a simple visual curve that non-technical stakeholders can interpret without needing to understand the underlying math. Amazon SageMaker Clarify can generate these plots automatically as part of its explainability reporting.\nRaw training code and convergence tables are development artifacts meant for data scientists, not business audiences, and a sample of training data shows what the model was fed rather than what it learned or how it uses that information to make predictions.",
+  "isMultiAnswer": false,
+  "taskStatement": "4.2",
+  "services": ["Amazon SageMaker Clarify"]
+},
+  {
+  "id": "aif-q466",
+  "question": "A healthcare company deploys an AI diagnostic tool and requires that a clinician always review and approve the model's suggestion before it becomes final. Which AWS service supports this requirement?",
+  "options": {
+    "A": "Amazon SageMaker Model Monitor",
+    "B": "Amazon Augmented AI (A2I)",
+    "C": "Amazon Bedrock Guardrails",
+    "D": "AWS Audit Manager"
+  },
+  "answer": "B",
+  "explanation": "Amazon Augmented AI, also known as A2I, introduces human review into an AI workflow by routing model outputs to a human reviewer before a decision is finalized, which directly supports the requirement for mandatory clinician approval.\nModel Monitor tracks data drift and model quality after deployment rather than inserting a human into each decision, Bedrock Guardrails filters generative model output for safety rather than routing decisions to a person, and Audit Manager collects compliance evidence rather than performing real time human review of individual predictions.",
+  "isMultiAnswer": false,
+  "taskStatement": "4.1",
+  "services": ["Amazon Augmented AI (A2I)"]
+}
 ]


### PR DESCRIPTION
## What does this PR do?

Adds two new questions to Domain 4 of the question bank, covering Amazon SageMaker Clarify (explainability) and Amazon Augmented AI (A2I) (human review workflows).

## Why?

Adds two Domain 4 questions to strengthen coverage on explainability and human-in-the-loop review:
- Amazon SageMaker Clarify (partial dependence plots for model explainability): https://aws.amazon.com/sagemaker/clarify/
- Amazon Augmented AI (A2I) (human review workflows for ML predictions): https://aws.amazon.com/augmented-ai/

Closes #198

## How was this tested?

- CI validation (`npm run validate`) runs automatically on this PR — see the Checks tab
- Manually verified the questions render correctly and answers/explanations are accurate

## Checklist

- [ ] `npm run build` passes locally
- [ ] `npm run lint` passes locally
- [ ] `npm run test` passes locally
- [x] `npm run validate` passes (via CI — see Checks tab)
- [x] No new third-party dependencies

