### PR TITLE
fix(question-bank): correct q326 VPC typo

### DIFF
--- a/src/data/bank-lastmod.json
+++ b/src/data/bank-lastmod.json
@@ -6,8 +6,8 @@
       "lastmod": "2026-07-04"
     },
     "clf-c02": {
-      "contentHash": "e29c822cfe48a94af594f60c157bc5dd846db151cb8b3180e70f91d278b3dc45",
-      "lastmod": "2026-07-05"
+      "contentHash": "932ac1f0ab20fa60fefc6c6c459b8ea51fe7a66c03e4fafa621707009af86eb3",
+      "lastmod": "2026-08-18"
     },
     "saa-c03": {
       "contentHash": "f1d5eb5cad2c83ec61c2e475cc9d888397becb9b017c77c2c86735b52c90d3ea",

--- a/src/data/clf-c02/domain3.json
+++ b/src/data/clf-c02/domain3.json
@@ -1634,7 +1634,7 @@
     "question": "Both AWS and traditional IT distributors provide a wide range of virtual servers to meet their customers' requirements. What is the name of these virtual servers in AWS?",
     "options": {
       "A": "Amazon EBS Snapshots",
-      "B": "Amazon VP",
+      "B": "Amazon VPC",
       "C": "Amazon Lightsail",
       "D": "Amazon EC2 Instances"
     },


### PR DESCRIPTION
## What does this PR do?

Corrects the `q326` answer text from `Amazon VP` to `Amazon VPC` and refreshes the question-bank metadata hash.

## Why?

The truncated service name makes the answer inaccurate and confusing for learners.

Closes #244

## How was this tested?

- `npm run validate`
- `npm run check` (Astro check, ESLint, and 318 Vitest tests)
- `npm run build`
- `npm run e2e` (109 passed, 20 expected credential-gated skips)
- `git diff --check`

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [x] `npm run validate` passes locally (only if you touched `src/data/**/*.json`)
- [x] No new third-party dependencies (or justified above)

## Screenshots (UI changes only)

Not applicable; this is a question-bank text correction.